### PR TITLE
refactor(hadris-fat): unify FileReader reads around internal read_to_buf

### DIFF
--- a/crates/hadris-fat/src/read.rs
+++ b/crates/hadris-fat/src/read.rs
@@ -126,10 +126,116 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
 
     /// Read data from the file.
     ///
-    /// This method follows the FAT cluster chain to read file contents.
-    /// If buffering is enabled, reads are served from the buffer when possible.
+    /// Reads up to `buf.len()` bytes, or fewer at end-of-file. Use a small `buf` to
+    /// stream incrementally; a larger `buf` allows more bytes per call (including
+    /// contiguous-cluster bulk I/O when the chain is cached). The underlying
+    /// [`Read`](crate::io::Read) / [`Seek`](crate::io::Seek) implementation can enforce
+    /// alignment or transfer sizes as needed. Optional per-cluster buffering applies when
+    /// enabled.
     pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        // Check if we've reached the end of the file
+        // Cap by caller buffer and bytes left in the file; actual I/O may be one or many
+        // steps inside read_to_buf (cached contiguous runs vs. read_one_chunk loop).
+        let max = buf.len().min(self.remaining());
+        if max == 0 {
+            return Ok(0);
+        }
+        self.read_to_buf(&mut buf[..max]).await
+    }
+
+    /// Read into `buf` until the buffer is full or the end of the file is reached.
+    ///
+    /// At most `buf.len().min(self.remaining())` bytes are read. Returns the number of
+    /// bytes written to the start of `buf`.
+    ///
+    /// When the cluster chain is cached (`with_cached_chain`), contiguous runs of
+    /// clusters are read in one seek+read per run (one I/O per fragment) instead of
+    /// one per cluster.
+    async fn read_to_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let max = buf.len().min(self.remaining());
+        if max == 0 {
+            return Ok(0);
+        }
+        let buf = &mut buf[..max];
+
+        #[cfg(feature = "alloc")]
+        {
+            let mut data = self.fs.data.lock();
+            let cluster_size = data.cluster_size;
+            let data_start = self.fs.info.data_start;
+
+            // Cached chain: coalesce physically consecutive clusters into one seek+read per run.
+            if let Some(ref chain) = self.cached_chain {
+                let buf_len = buf.len();
+                // Fast path: one seek + one read per contiguous run of clusters
+                let mut total = 0usize;
+                let mut chain_index = self.chain_index;
+                let mut offset_in_cluster = self.offset_in_cluster;
+
+                while total < buf_len && chain_index < chain.len() {
+                    let first_cluster = chain[chain_index] as usize;
+                    // Count contiguous run: chain[chain_index], chain[chain_index+1], ... while consecutive
+                    let mut run_len = 1usize;
+                    while chain_index + run_len < chain.len()
+                        && chain[chain_index + run_len] == chain[chain_index + run_len - 1] + 1
+                    {
+                        run_len += 1;
+                    }
+
+                    // Bytes we can read from this run (from current offset to end of run)
+                    let bytes_from_first = cluster_size.saturating_sub(offset_in_cluster);
+                    let bytes_from_run = bytes_from_first
+                        .saturating_add(run_len.saturating_sub(1).saturating_mul(cluster_size));
+                    let to_read = bytes_from_run.min(buf_len - total);
+
+                    if to_read == 0 {
+                        break;
+                    }
+
+                    let seek_pos = Cluster(first_cluster)
+                        .to_bytes(data_start, cluster_size)
+                        .saturating_add(offset_in_cluster);
+                    data.seek(SeekFrom::Start(seek_pos as u64)).await?;
+                    data.read_exact(&mut buf[total..total + to_read]).await?;
+
+                    total += to_read;
+                    self.total_read += to_read;
+
+                    // Advance by clusters we consumed
+                    let new_offset = offset_in_cluster + to_read;
+                    chain_index += new_offset / cluster_size;
+                    offset_in_cluster = new_offset % cluster_size;
+                }
+
+                self.chain_index = chain_index;
+                self.offset_in_cluster = offset_in_cluster;
+                if chain_index < chain.len() {
+                    self.cluster.0 = chain[chain_index] as usize;
+                }
+                drop(data);
+                return Ok(total);
+            }
+
+            drop(data);
+        }
+
+        // No cached chain (or alloc off): walk the FAT one cluster-sized step at a time.
+        let buf_len = buf.len();
+        let mut total = 0usize;
+        while total < buf_len {
+            let n = self.read_one_chunk(&mut buf[total..]).await?;
+            if n == 0 {
+                break;
+            }
+            total += n;
+        }
+        Ok(total)
+    }
+
+    /// Read at most one contiguous span within the current cluster (or less if `buf` or the
+    /// file ends sooner). Used by [`read_to_buf`](Self::read_to_buf) when the chain is not
+    /// cached; advances to the next FAT cluster when the current one is exhausted.
+    async fn read_one_chunk(&mut self, buf: &mut [u8]) -> Result<usize> {
+        // End of logical file
         if self.total_read >= self.size {
             return Ok(0);
         }
@@ -137,30 +243,29 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
         let mut data = self.fs.data.lock();
         let cluster_size = data.cluster_size;
 
-        // Check if we need to move to the next cluster
+        // Consumed the whole cluster: follow the chain to the next data cluster.
         if self.offset_in_cluster >= cluster_size {
             #[cfg(feature = "alloc")]
             {
                 if let Some(ref chain) = self.cached_chain {
-                    // Use cached chain
+                    // Next cluster from the pre-read chain (no FAT table walk).
                     self.chain_index += 1;
                     if self.chain_index >= chain.len() {
                         return Ok(0); // End of file
                     }
                     self.cluster.0 = chain[self.chain_index] as usize;
                     self.offset_in_cluster = 0;
-                    // Invalidate buffer for new cluster
+                    // Cluster buffer holds one cluster; must reload after moving.
                     if let Some(ref mut buffer) = self.cluster_buffer {
                         buffer.clear();
                     }
                 } else {
-                    // Fall back to FAT lookup
+                    // Resolve next cluster from the FAT on disk.
                     let next = self.fs.fat.next_cluster(data.deref_mut(), self.cluster.0).await?;
                     match next {
                         Some(cluster) => {
                             self.cluster.0 = cluster as usize;
                             self.offset_in_cluster = 0;
-                            // Invalidate buffer for new cluster
                             if let Some(ref mut buffer) = self.cluster_buffer {
                                 buffer.clear();
                             }
@@ -183,7 +288,7 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
             }
         }
 
-        // Calculate how much we can read
+        // How much we can copy from the current cluster in this step.
         let bytes_left_in_cluster = cluster_size - self.offset_in_cluster;
         let bytes_left_in_file = self.size - self.total_read;
         let read_max = buf.len().min(bytes_left_in_cluster).min(bytes_left_in_file);
@@ -192,10 +297,9 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
             return Ok(0);
         }
 
-        // Read with buffering if enabled
         #[cfg(feature = "alloc")]
         let bytes_read = if let Some(ref mut buffer) = self.cluster_buffer {
-            // Fill buffer if empty
+            // Load whole cluster once, then serve reads from RAM.
             if buffer.is_empty() {
                 let cluster_start = self.cluster.to_bytes(self.fs.info.data_start, cluster_size);
                 data.seek(SeekFrom::Start(cluster_start as u64)).await?;
@@ -204,12 +308,11 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
                 data.read_exact(buffer).await?;
             }
 
-            // Read from buffer
             let src = &buffer[self.offset_in_cluster..self.offset_in_cluster + read_max];
             buf[..read_max].copy_from_slice(src);
             read_max
         } else {
-            // Direct read (no buffering)
+            // Direct read at file offset within this cluster.
             let seek_pos = self.cluster.to_bytes(self.fs.info.data_start, cluster_size)
                 + self.offset_in_cluster;
             data.seek(SeekFrom::Start(seek_pos as u64)).await?;
@@ -230,85 +333,19 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
         Ok(bytes_read)
     }
 
-    /// Read the entire file contents into a vector.
+    /// Read all bytes from the current read position through the end of the file.
     ///
-    /// When the cluster chain is cached, reads contiguous runs of clusters in a single
-    /// seek+read per run (one I/O per fragment) instead of one per cluster.
+    /// Data is read starting at this reader's current offset in the file (the same
+    /// position the next [`read`](Self::read) would use—not necessarily offset 0). Bytes
+    /// already consumed by earlier [`read`](Self::read) or `read_to_vec` calls are not read
+    /// again. The allocation size is [`remaining`](Self::remaining); bytes are read using the
+    /// same internal bulk-read path as [`read`](Self::read).
     #[cfg(feature = "alloc")]
     pub async fn read_to_vec(&mut self) -> Result<Vec<u8>> {
+        // One allocation sized to what's left from the current read cursor.
         let mut buf = alloc::vec![0u8; self.remaining()];
-        let buf_len = buf.len();
-        if buf_len == 0 {
-            return Ok(buf);
-        }
-
-        let mut data = self.fs.data.lock();
-        let cluster_size = data.cluster_size;
-        let data_start = self.fs.info.data_start;
-
-        if let Some(ref chain) = self.cached_chain {
-            // Fast path: one seek + one read per contiguous run of clusters
-            let mut total = 0usize;
-            let mut chain_index = self.chain_index;
-            let mut offset_in_cluster = self.offset_in_cluster;
-
-            while total < buf_len && chain_index < chain.len() {
-                let first_cluster = chain[chain_index] as usize;
-                // Count contiguous run: chain[chain_index], chain[chain_index+1], ... while consecutive
-                let mut run_len = 1usize;
-                while chain_index + run_len < chain.len()
-                    && chain[chain_index + run_len] == chain[chain_index + run_len - 1] + 1
-                {
-                    run_len += 1;
-                }
-
-                // Bytes we can read from this run (from current offset to end of run)
-                let bytes_from_first = cluster_size.saturating_sub(offset_in_cluster);
-                let bytes_from_run = bytes_from_first
-                    .saturating_add(run_len.saturating_sub(1).saturating_mul(cluster_size));
-                let to_read = bytes_from_run.min(buf_len - total);
-
-                if to_read == 0 {
-                    break;
-                }
-
-                let seek_pos = Cluster(first_cluster)
-                    .to_bytes(data_start, cluster_size)
-                    .saturating_add(offset_in_cluster);
-                data.seek(SeekFrom::Start(seek_pos as u64)).await?;
-                data.read_exact(&mut buf[total..total + to_read]).await?;
-
-                total += to_read;
-                self.total_read += to_read;
-
-                // Advance by clusters we consumed
-                let new_offset = offset_in_cluster + to_read;
-                chain_index += new_offset / cluster_size;
-                offset_in_cluster = new_offset % cluster_size;
-            }
-
-            self.chain_index = chain_index;
-            self.offset_in_cluster = offset_in_cluster;
-            if chain_index < chain.len() {
-                self.cluster.0 = chain[chain_index] as usize;
-            }
-            drop(data);
-            buf.truncate(total);
-            return Ok(buf);
-        }
-
-        drop(data);
-
-        // No cached chain: fall back to read() loop
-        let mut total = 0;
-        while total < buf_len {
-            let n = self.read(&mut buf[total..]).await?;
-            if n == 0 {
-                break;
-            }
-            total += n;
-        }
-        buf.truncate(total);
+        let n = self.read_to_buf(&mut buf).await?;
+        buf.truncate(n);
         Ok(buf)
     }
 }


### PR DESCRIPTION
- Add private read_to_buf to fill a slice up to EOF or buffer capacity; use cached-chain fast path when with_cached_chain is enabled.
- read_to_vec allocates for remaining() and delegates to read_to_buf.
- read forwards to read_to_buf with min(buf.len(), remaining()) so callers control chunk size; read_one_chunk handles uncached cluster steps.
- Document read_to_vec from current cursor; restore inline comments for I/O paths.