### PR TITLE
wip/endian num

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endian-num"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4a54dfedecb1dc004776a597db0c858cf6c31579296734511309291b8399ce"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +512,7 @@ version = "1.1.0"
 dependencies = [
  "bytemuck",
  "crc",
+ "endian-num",
  "hadris-io",
  "hadris-macros",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ repository = "https://github.com/hxyulin/hadris"
 log = "0.4.26"
 bytemuck = { version = "1.22.0", default-features = false }
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+endian-num = { version = "0.2", default-features = false, features = ["bytemuck"] }
 bitflags = "2.9.0"
 static_assertions = "1.1.0"
 criterion = "0.5.1"

--- a/crates/hadris-iso/src/write/mod.rs
+++ b/crates/hadris-iso/src/write/mod.rs
@@ -29,6 +29,7 @@ use hadris_part::{
     gpt::{GptPartitionEntry, Guid},
     hybrid::HybridMbrBuilder,
     mbr::{Chs, MasterBootRecord, MbrPartition, MbrPartitionType},
+    Le,
 };
 use options::PartitionScheme;
 use writer::{PathTableWriter, WrittenDirectory, WrittenFile, WrittenFiles};
@@ -876,8 +877,8 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                 start_chs: Chs::new(start_block),
                 part_type: MbrPartitionType::Iso9660.to_u8(),
                 end_chs: Chs::new(end_block),
-                start_lba: start_block,
-                sector_count: end_block - start_block,
+                start_lba: Le::<u32>::from_ne(start_block),
+                sector_count: Le::<u32>::from_ne(end_block - start_block),
             };
         });
 
@@ -911,8 +912,8 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                 start_chs: Chs::new(0),
                 part_type: MbrPartitionType::Iso9660.to_u8(),
                 end_chs: Chs::new(end_block.saturating_sub(1)),
-                start_lba: 0,
-                sector_count: end_block,
+                start_lba: Le::<u32>::from_ne(0),
+                sector_count: Le::<u32>::from_ne(end_block),
             };
         });
 

--- a/crates/hadris-part/Cargo.toml
+++ b/crates/hadris-part/Cargo.toml
@@ -23,5 +23,6 @@ write = ["alloc", "read"]
 hadris-io = { workspace = true, default-features = false }
 hadris-macros = { workspace = true }
 bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
+endian-num.workspace = true
 crc = { version = "3", default-features = false, optional = true }
 rand = { version = "0.9", default-features = false, optional = true, features = ["thread_rng"] }

--- a/crates/hadris-part/src/gpt.rs
+++ b/crates/hadris-part/src/gpt.rs
@@ -8,6 +8,8 @@
 
 use core::fmt::{Debug, Display};
 
+use endian_num::Le;
+
 /// A 128-bit GUID (Globally Unique Identifier).
 ///
 /// GUIDs are stored in mixed-endian format:
@@ -548,10 +550,10 @@ impl Guid {
     }
 }
 
-/// GPT partition entry attributes.
+/// GPT partition entry attributes (64-bit flags, little-endian on disk).
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Default, bytemuck::Pod, bytemuck::Zeroable)]
-pub struct GptAttributes(u64);
+pub struct GptAttributes(Le<u64>);
 
 impl GptAttributes {
     /// Platform required (required for system to function).
@@ -563,39 +565,39 @@ impl GptAttributes {
 
     /// Creates new attributes from a raw value.
     pub const fn new(value: u64) -> Self {
-        Self(value)
+        Self(Le::<u64>::from_ne(value))
     }
 
     /// Returns the raw attribute value.
     pub const fn get(&self) -> u64 {
-        self.0
+        self.0.to_ne()
     }
 
     /// Sets the raw attribute value.
     pub fn set(&mut self, value: u64) {
-        self.0 = value;
+        self.0 = Le::<u64>::from_ne(value);
     }
 
     /// Returns whether the platform required flag is set.
     pub const fn is_platform_required(&self) -> bool {
-        (self.0 & Self::PLATFORM_REQUIRED) != 0
+        (self.0.to_ne() & Self::PLATFORM_REQUIRED) != 0
     }
 
     /// Returns whether the EFI ignore flag is set.
     pub const fn is_efi_ignore(&self) -> bool {
-        (self.0 & Self::EFI_IGNORE) != 0
+        (self.0.to_ne() & Self::EFI_IGNORE) != 0
     }
 
     /// Returns whether the legacy BIOS bootable flag is set.
     pub const fn is_legacy_bios_bootable(&self) -> bool {
-        (self.0 & Self::LEGACY_BIOS_BOOTABLE) != 0
+        (self.0.to_ne() & Self::LEGACY_BIOS_BOOTABLE) != 0
     }
 }
 
 impl Debug for GptAttributes {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("GptAttributes")
-            .field("raw", &format_args!("0x{:016X}", self.0))
+            .field("raw", &format_args!("0x{:016X}", self.get()))
             .field("platform_required", &self.is_platform_required())
             .field("efi_ignore", &self.is_efi_ignore())
             .field("legacy_bios_bootable", &self.is_legacy_bios_bootable())
@@ -661,58 +663,58 @@ impl GptPartitionName {
 
 /// GPT partition table header (92 bytes, padded to sector size).
 ///
-/// Note: This struct uses native alignment for ease of use. When reading/writing
-/// to disk, use the serialization methods rather than direct memory casting.
+/// Numeric fields use [`Le`] so their on-disk little-endian layout is explicit.
+/// Use `to_raw` / `from_raw` or the I/O extension traits for serialization.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct GptHeader {
     /// Signature: must be "EFI PART" (0x5452415020494645).
     pub signature: [u8; 8],
-    /// Revision: currently 0x00010000 (1.0).
-    pub revision: u32,
-    /// Header size in bytes (usually 92).
-    pub header_size: u32,
-    /// CRC32 of header (with this field set to 0 during calculation).
-    pub header_crc32: u32,
-    /// Reserved, must be 0.
-    pub reserved: u32,
-    /// LBA of this header.
-    pub my_lba: u64,
-    /// LBA of alternate header (backup).
-    pub alternate_lba: u64,
-    /// First usable LBA for partitions.
-    pub first_usable_lba: u64,
-    /// Last usable LBA for partitions.
-    pub last_usable_lba: u64,
+    /// Revision: currently 0x00010000 (1.0), little-endian on disk.
+    pub revision: Le<u32>,
+    /// Header size in bytes (usually 92), little-endian on disk.
+    pub header_size: Le<u32>,
+    /// CRC32 of header (with this field set to 0 during calculation), little-endian on disk.
+    pub header_crc32: Le<u32>,
+    /// Reserved, must be 0, little-endian on disk.
+    pub reserved: Le<u32>,
+    /// LBA of this header, little-endian on disk.
+    pub my_lba: Le<u64>,
+    /// LBA of alternate header (backup), little-endian on disk.
+    pub alternate_lba: Le<u64>,
+    /// First usable LBA for partitions, little-endian on disk.
+    pub first_usable_lba: Le<u64>,
+    /// Last usable LBA for partitions, little-endian on disk.
+    pub last_usable_lba: Le<u64>,
     /// Disk GUID.
     pub disk_guid: Guid,
-    /// Starting LBA of partition entry array.
-    pub partition_entry_lba: u64,
-    /// Number of partition entries.
-    pub num_partition_entries: u32,
-    /// Size of each partition entry (usually 128).
-    pub size_of_partition_entry: u32,
-    /// CRC32 of partition entry array.
-    pub partition_entry_array_crc32: u32,
+    /// Starting LBA of partition entry array, little-endian on disk.
+    pub partition_entry_lba: Le<u64>,
+    /// Number of partition entries, little-endian on disk.
+    pub num_partition_entries: Le<u32>,
+    /// Size of each partition entry (usually 128), little-endian on disk.
+    pub size_of_partition_entry: Le<u32>,
+    /// CRC32 of partition entry array, little-endian on disk.
+    pub partition_entry_array_crc32: Le<u32>,
 }
 
 impl Default for GptHeader {
     fn default() -> Self {
         Self {
             signature: *b"EFI PART",
-            revision: 0x00010000,
-            header_size: 92,
-            header_crc32: 0,
-            reserved: 0,
-            my_lba: 0,
-            alternate_lba: 0,
-            first_usable_lba: 0,
-            last_usable_lba: 0,
+            revision: Le::<u32>::from_ne(0x00010000),
+            header_size: Le::<u32>::from_ne(92),
+            header_crc32: Le::<u32>::from_ne(0),
+            reserved: Le::<u32>::from_ne(0),
+            my_lba: Le::<u64>::from_ne(0),
+            alternate_lba: Le::<u64>::from_ne(0),
+            first_usable_lba: Le::<u64>::from_ne(0),
+            last_usable_lba: Le::<u64>::from_ne(0),
             disk_guid: Guid::default(),
-            partition_entry_lba: 0,
-            num_partition_entries: 0,
-            size_of_partition_entry: 128,
-            partition_entry_array_crc32: 0,
+            partition_entry_lba: Le::<u64>::from_ne(0),
+            num_partition_entries: Le::<u32>::from_ne(0),
+            size_of_partition_entry: Le::<u32>::from_ne(128),
+            partition_entry_array_crc32: Le::<u32>::from_ne(0),
         }
     }
 }
@@ -748,7 +750,7 @@ impl GptHeader {
         const HASHER: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
         let mut header = *self;
-        header.header_crc32 = 0;
+        header.header_crc32 = Le::<u32>::from_ne(0);
         let raw = header.to_raw();
         HASHER.checksum(bytemuck::bytes_of(&raw))
     }
@@ -756,42 +758,42 @@ impl GptHeader {
     /// Verifies the header CRC32.
     #[cfg(feature = "crc")]
     pub fn verify_crc32(&self) -> bool {
-        self.header_crc32 == self.calculate_crc32()
+        self.header_crc32.to_ne() == self.calculate_crc32()
     }
 
     /// Updates the header CRC32 field.
     #[cfg(feature = "crc")]
     pub fn update_crc32(&mut self) {
-        self.header_crc32 = 0;
-        self.header_crc32 = self.calculate_crc32();
+        self.header_crc32 = Le::<u32>::from_ne(0);
+        self.header_crc32 = Le::<u32>::from_ne(self.calculate_crc32());
     }
 }
 
 /// On-disk GPT header representation (92 bytes, packed).
 ///
 /// This struct matches the exact on-disk layout of the GPT header.
-/// The `GptHeader` struct uses native alignment for convenience but may
-/// have padding, so this packed representation is used for serialization.
+/// The [`GptHeader`] struct uses native alignment and may include padding;
+/// this packed representation is used for serialization and CRC.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub(crate) struct GptHeaderRaw {
     signature: [u8; 8],
-    revision: [u8; 4],
-    header_size: [u8; 4],
-    header_crc32: [u8; 4],
-    reserved: [u8; 4],
-    my_lba: [u8; 8],
-    alternate_lba: [u8; 8],
-    first_usable_lba: [u8; 8],
-    last_usable_lba: [u8; 8],
+    revision: Le<u32>,
+    header_size: Le<u32>,
+    header_crc32: Le<u32>,
+    reserved: Le<u32>,
+    my_lba: Le<u64>,
+    alternate_lba: Le<u64>,
+    first_usable_lba: Le<u64>,
+    last_usable_lba: Le<u64>,
     disk_guid: [u8; 16],
-    partition_entry_lba: [u8; 8],
-    num_partition_entries: [u8; 4],
-    size_of_partition_entry: [u8; 4],
-    partition_entry_array_crc32: [u8; 4],
+    partition_entry_lba: Le<u64>,
+    num_partition_entries: Le<u32>,
+    size_of_partition_entry: Le<u32>,
+    partition_entry_array_crc32: Le<u32>,
 }
 
-// SAFETY: GptHeaderRaw is repr(C, packed) with only byte arrays.
+// SAFETY: GptHeaderRaw is repr(C, packed) with Pod field types (`Le`, byte arrays).
 // All bit patterns are valid.
 unsafe impl bytemuck::Pod for GptHeaderRaw {}
 unsafe impl bytemuck::Zeroable for GptHeaderRaw {}
@@ -806,19 +808,19 @@ impl GptHeader {
     pub(crate) fn to_raw(self) -> GptHeaderRaw {
         GptHeaderRaw {
             signature: self.signature,
-            revision: self.revision.to_le_bytes(),
-            header_size: self.header_size.to_le_bytes(),
-            header_crc32: self.header_crc32.to_le_bytes(),
-            reserved: self.reserved.to_le_bytes(),
-            my_lba: self.my_lba.to_le_bytes(),
-            alternate_lba: self.alternate_lba.to_le_bytes(),
-            first_usable_lba: self.first_usable_lba.to_le_bytes(),
-            last_usable_lba: self.last_usable_lba.to_le_bytes(),
+            revision: self.revision,
+            header_size: self.header_size,
+            header_crc32: self.header_crc32,
+            reserved: self.reserved,
+            my_lba: self.my_lba,
+            alternate_lba: self.alternate_lba,
+            first_usable_lba: self.first_usable_lba,
+            last_usable_lba: self.last_usable_lba,
             disk_guid: self.disk_guid.to_bytes(),
-            partition_entry_lba: self.partition_entry_lba.to_le_bytes(),
-            num_partition_entries: self.num_partition_entries.to_le_bytes(),
-            size_of_partition_entry: self.size_of_partition_entry.to_le_bytes(),
-            partition_entry_array_crc32: self.partition_entry_array_crc32.to_le_bytes(),
+            partition_entry_lba: self.partition_entry_lba,
+            num_partition_entries: self.num_partition_entries,
+            size_of_partition_entry: self.size_of_partition_entry,
+            partition_entry_array_crc32: self.partition_entry_array_crc32,
         }
     }
 
@@ -826,19 +828,19 @@ impl GptHeader {
     pub(crate) fn from_raw(raw: &GptHeaderRaw) -> Self {
         Self {
             signature: raw.signature,
-            revision: u32::from_le_bytes(raw.revision),
-            header_size: u32::from_le_bytes(raw.header_size),
-            header_crc32: u32::from_le_bytes(raw.header_crc32),
-            reserved: u32::from_le_bytes(raw.reserved),
-            my_lba: u64::from_le_bytes(raw.my_lba),
-            alternate_lba: u64::from_le_bytes(raw.alternate_lba),
-            first_usable_lba: u64::from_le_bytes(raw.first_usable_lba),
-            last_usable_lba: u64::from_le_bytes(raw.last_usable_lba),
+            revision: raw.revision,
+            header_size: raw.header_size,
+            header_crc32: raw.header_crc32,
+            reserved: raw.reserved,
+            my_lba: raw.my_lba,
+            alternate_lba: raw.alternate_lba,
+            first_usable_lba: raw.first_usable_lba,
+            last_usable_lba: raw.last_usable_lba,
             disk_guid: Guid::from_bytes(raw.disk_guid),
-            partition_entry_lba: u64::from_le_bytes(raw.partition_entry_lba),
-            num_partition_entries: u32::from_le_bytes(raw.num_partition_entries),
-            size_of_partition_entry: u32::from_le_bytes(raw.size_of_partition_entry),
-            partition_entry_array_crc32: u32::from_le_bytes(raw.partition_entry_array_crc32),
+            partition_entry_lba: raw.partition_entry_lba,
+            num_partition_entries: raw.num_partition_entries,
+            size_of_partition_entry: raw.size_of_partition_entry,
+            partition_entry_array_crc32: raw.partition_entry_array_crc32,
         }
     }
 }
@@ -851,10 +853,10 @@ pub struct GptPartitionEntry {
     pub type_guid: Guid,
     /// Unique partition GUID.
     pub unique_guid: Guid,
-    /// First LBA (little-endian).
-    pub first_lba: u64,
-    /// Last LBA (inclusive, little-endian).
-    pub last_lba: u64,
+    /// First LBA, little-endian on disk.
+    pub first_lba: Le<u64>,
+    /// Last LBA (inclusive), little-endian on disk.
+    pub last_lba: Le<u64>,
     /// Attribute flags.
     pub attributes: GptAttributes,
     /// Partition name (UTF-16LE).
@@ -866,8 +868,8 @@ impl Default for GptPartitionEntry {
         Self {
             type_guid: Guid::UNUSED,
             unique_guid: Guid::UNUSED,
-            first_lba: 0,
-            last_lba: 0,
+            first_lba: Le::<u64>::from_ne(0),
+            last_lba: Le::<u64>::from_ne(0),
             attributes: GptAttributes::default(),
             name: GptPartitionName::default(),
         }
@@ -879,8 +881,8 @@ impl Debug for GptPartitionEntry {
         f.debug_struct("GptPartitionEntry")
             .field("type_guid", &self.type_guid)
             .field("unique_guid", &self.unique_guid)
-            .field("first_lba", &self.first_lba)
-            .field("last_lba", &self.last_lba)
+            .field("first_lba", &self.first_lba.to_ne())
+            .field("last_lba", &self.last_lba.to_ne())
             .field("attributes", &self.attributes)
             .field("name", &self.name)
             .finish()
@@ -893,8 +895,8 @@ impl GptPartitionEntry {
         Self {
             type_guid,
             unique_guid,
-            first_lba,
-            last_lba,
+            first_lba: Le::<u64>::from_ne(first_lba),
+            last_lba: Le::<u64>::from_ne(last_lba),
             attributes: GptAttributes::new(0),
             name: GptPartitionName([0; 36]),
         }
@@ -907,10 +909,12 @@ impl GptPartitionEntry {
 
     /// Returns the partition size in sectors.
     pub const fn size_sectors(&self) -> u64 {
-        if self.is_unused() || self.last_lba < self.first_lba {
+        let first = self.first_lba.to_ne();
+        let last = self.last_lba.to_ne();
+        if self.is_unused() || last < first {
             0
         } else {
-            self.last_lba - self.first_lba + 1
+            last - first + 1
         }
     }
 

--- a/crates/hadris-part/src/hybrid.rs
+++ b/crates/hadris-part/src/hybrid.rs
@@ -236,15 +236,18 @@ impl HybridMbrBuilder {
             }
 
             // Check if partition fits in 32-bit MBR addressing
-            if gpt_entry.last_lba > u32::MAX as u64 {
+            let first_native = gpt_entry.first_lba.to_ne();
+            let last_native = gpt_entry.last_lba.to_ne();
+
+            if last_native > u32::MAX as u64 {
                 return Err(PartitionError::InvalidHybridMbr {
                     reason: "GPT partition extends beyond MBR 32-bit limit",
                 });
             }
 
             let slot = self.config.calculate_slot(i);
-            let start_lba = gpt_entry.first_lba as u32;
-            let sector_count = (gpt_entry.last_lba - gpt_entry.first_lba + 1) as u32;
+            let start_lba = first_native as u32;
+            let sector_count = (last_native - first_native + 1) as u32;
 
             partition_table[slot] = MbrPartition {
                 boot_indicator: if mirrored.bootable { 0x80 } else { 0x00 },
@@ -255,7 +258,7 @@ impl HybridMbrBuilder {
                 sector_count: Le::<u32>::from_ne(sector_count),
             };
 
-            mirrored_ranges[mirror_count] = (gpt_entry.first_lba, gpt_entry.last_lba);
+            mirrored_ranges[mirror_count] = (first_native, last_native);
             mirror_count += 1;
         }
 

--- a/crates/hadris-part/src/hybrid.rs
+++ b/crates/hadris-part/src/hybrid.rs
@@ -18,6 +18,7 @@ use alloc::vec::Vec;
 use crate::error::{PartitionError, Result};
 use crate::gpt::GptPartitionEntry;
 use crate::mbr::{Chs, MasterBootRecord, MbrPartition, MbrPartitionTable, MbrPartitionType};
+use endian_num::Le;
 
 /// A partition to be mirrored from GPT to MBR in a hybrid configuration.
 #[derive(Debug, Clone, Copy)]
@@ -250,8 +251,8 @@ impl HybridMbrBuilder {
                 start_chs: Chs::new(start_lba),
                 part_type: mirrored.mbr_type.to_u8(),
                 end_chs: Chs::new(start_lba + sector_count - 1),
-                start_lba,
-                sector_count,
+                start_lba: Le::<u32>::from_ne(start_lba),
+                sector_count: Le::<u32>::from_ne(sector_count),
             };
 
             mirrored_ranges[mirror_count] = (gpt_entry.first_lba, gpt_entry.last_lba);
@@ -291,8 +292,8 @@ impl HybridMbrBuilder {
             start_chs: Chs::new(1),
             part_type: MbrPartitionType::ProtectiveMbr.to_u8(),
             end_chs: Chs::new(protective_end),
-            start_lba: 1,
-            sector_count: protective_size,
+            start_lba: Le::<u32>::from_ne(1),
+            sector_count: Le::<u32>::from_ne(protective_size),
         };
 
         mbr.partition_table = partition_table;

--- a/crates/hadris-part/src/lib.rs
+++ b/crates/hadris-part/src/lib.rs
@@ -211,19 +211,21 @@ impl PartitionInfoTrait for MbrPartition {
 
 impl PartitionInfoTrait for GptPartitionEntry {
     fn start_lba(&self) -> u64 {
-        self.first_lba
+        self.first_lba.to_ne()
     }
 
     fn size_sectors(&self) -> u64 {
-        if self.is_unused() || self.last_lba < self.first_lba {
+        let first = self.first_lba.to_ne();
+        let last = self.last_lba.to_ne();
+        if self.is_unused() || last < first {
             0
         } else {
-            self.last_lba - self.first_lba + 1
+            last - first + 1
         }
     }
 
     fn end_lba(&self) -> u64 {
-        self.last_lba
+        self.last_lba.to_ne()
     }
 }
 

--- a/crates/hadris-part/src/lib.rs
+++ b/crates/hadris-part/src/lib.rs
@@ -157,6 +157,7 @@ pub mod r#async {
 pub use sync::*;
 
 // Re-export commonly used types at the crate root
+pub use endian_num::Le;
 pub use error::{PartitionError, Result};
 pub use geometry::{DiskGeometry, validate_partition_alignment};
 pub use gpt::{GptHeader, GptPartitionEntry, Guid};
@@ -200,11 +201,11 @@ pub trait PartitionInfoTrait {
 
 impl PartitionInfoTrait for MbrPartition {
     fn start_lba(&self) -> u64 {
-        self.start_lba as u64
+        self.start_lba.to_ne() as u64
     }
 
     fn size_sectors(&self) -> u64 {
-        self.sector_count as u64
+        self.sector_count.to_ne() as u64
     }
 }
 

--- a/crates/hadris-part/src/mbr.rs
+++ b/crates/hadris-part/src/mbr.rs
@@ -9,6 +9,8 @@
 use core::fmt::Debug;
 use core::ops::{Index, IndexMut};
 
+use endian_num::Le;
+
 /// A simplified enum for common MBR partition types.
 ///
 /// For a complete list of partition types, see [`MbrPartitionTypeFull`].
@@ -216,10 +218,10 @@ pub struct MbrPartition {
     pub part_type: u8,
     /// Ending CHS address.
     pub end_chs: Chs,
-    /// Starting LBA (sector number).
-    pub start_lba: u32,
-    /// Number of sectors in this partition.
-    pub sector_count: u32,
+    /// Starting LBA (sector number), little-endian on disk.
+    pub start_lba: Le<u32>,
+    /// Number of sectors in this partition, little-endian on disk.
+    pub sector_count: Le<u32>,
 }
 
 impl Default for MbrPartition {
@@ -229,8 +231,8 @@ impl Default for MbrPartition {
             start_chs: Chs::new(0),
             part_type: 0x00,
             end_chs: Chs::new(0),
-            start_lba: 0,
-            sector_count: 0,
+            start_lba: Le::<u32>::from_ne(0),
+            sector_count: Le::<u32>::from_ne(0),
         }
     }
 }
@@ -248,8 +250,8 @@ impl MbrPartition {
             start_chs: Chs::new(start_lba),
             part_type: part_type.to_u8(),
             end_chs: Chs::new(end_lba),
-            start_lba,
-            sector_count,
+            start_lba: Le::<u32>::from_ne(start_lba),
+            sector_count: Le::<u32>::from_ne(sector_count),
         }
     }
 
@@ -291,10 +293,12 @@ impl MbrPartition {
 
     /// Returns the ending LBA (inclusive).
     pub const fn end_lba(&self) -> u32 {
-        if self.sector_count == 0 {
-            self.start_lba
+        let start = self.start_lba.to_ne();
+        let count = self.sector_count.to_ne();
+        if count == 0 {
+            start
         } else {
-            self.start_lba + self.sector_count - 1
+            start + count - 1
         }
     }
 }
@@ -329,8 +333,8 @@ impl MbrPartitionTable {
         start_chs: Chs([0, 0, 0]),
         part_type: 0,
         end_chs: Chs([0, 0, 0]),
-        start_lba: 0,
-        sector_count: 0,
+        start_lba: Le::<u32>::from_ne(0),
+        sector_count: Le::<u32>::from_ne(0),
     };
 
     /// Creates a new empty MBR partition table.
@@ -849,8 +853,8 @@ mod tests {
         assert!(mbr.has_valid_signature());
         let pt = mbr.get_partition_table();
         assert!(pt.is_protective());
-        assert_eq!(pt[0].start_lba, 1);
-        assert_eq!(pt[0].sector_count, 999);
+        assert_eq!(pt[0].start_lba.to_ne(), 1);
+        assert_eq!(pt[0].sector_count.to_ne(), 999);
     }
 
     #[test]

--- a/crates/hadris-part/src/scheme.rs
+++ b/crates/hadris-part/src/scheme.rs
@@ -16,6 +16,8 @@ use crate::error::{PartitionError, Result};
 use crate::gpt::Guid;
 #[cfg(feature = "alloc")]
 use crate::gpt::{GptHeader, GptPartitionEntry};
+#[cfg(feature = "alloc")]
+use endian_num::Le;
 use crate::hybrid::is_hybrid_mbr;
 use crate::mbr::MasterBootRecord;
 
@@ -123,26 +125,26 @@ impl GptDisk {
         #[cfg_attr(not(feature = "crc"), allow(unused_mut))]
         let mut primary_header = GptHeader {
             signature: GptHeader::SIGNATURE,
-            revision: GptHeader::REVISION_1_0,
-            header_size: GptHeader::STANDARD_HEADER_SIZE,
-            header_crc32: 0,
-            reserved: 0,
-            my_lba: 1,
-            alternate_lba: disk_sectors - 1,
-            first_usable_lba: first_usable,
-            last_usable_lba: last_usable,
+            revision: Le::<u32>::from_ne(GptHeader::REVISION_1_0),
+            header_size: Le::<u32>::from_ne(GptHeader::STANDARD_HEADER_SIZE),
+            header_crc32: Le::<u32>::from_ne(0),
+            reserved: Le::<u32>::from_ne(0),
+            my_lba: Le::<u64>::from_ne(1),
+            alternate_lba: Le::<u64>::from_ne(disk_sectors - 1),
+            first_usable_lba: Le::<u64>::from_ne(first_usable),
+            last_usable_lba: Le::<u64>::from_ne(last_usable),
             disk_guid,
-            partition_entry_lba: 2,
-            num_partition_entries: entry_count,
-            size_of_partition_entry: entry_size,
-            partition_entry_array_crc32: 0,
+            partition_entry_lba: Le::<u64>::from_ne(2),
+            num_partition_entries: Le::<u32>::from_ne(entry_count),
+            size_of_partition_entry: Le::<u32>::from_ne(entry_size),
+            partition_entry_array_crc32: Le::<u32>::from_ne(0),
         };
 
         #[cfg_attr(not(feature = "crc"), allow(unused_mut))]
         let mut backup_header = GptHeader {
-            my_lba: disk_sectors - 1,
-            alternate_lba: 1,
-            partition_entry_lba: disk_sectors - 1 - entry_sectors as u64,
+            my_lba: Le::<u64>::from_ne(disk_sectors - 1),
+            alternate_lba: Le::<u64>::from_ne(1),
+            partition_entry_lba: Le::<u64>::from_ne(disk_sectors - 1 - entry_sectors as u64),
             ..primary_header
         };
 
@@ -152,8 +154,8 @@ impl GptDisk {
         #[cfg(feature = "crc")]
         {
             let entries_crc = crate::gpt::calculate_partition_array_crc32(&entries);
-            primary_header.partition_entry_array_crc32 = entries_crc;
-            backup_header.partition_entry_array_crc32 = entries_crc;
+            primary_header.partition_entry_array_crc32 = Le::<u32>::from_ne(entries_crc);
+            backup_header.partition_entry_array_crc32 = Le::<u32>::from_ne(entries_crc);
             primary_header.update_crc32();
             backup_header.update_crc32();
         }
@@ -210,15 +212,15 @@ impl GptDisk {
         {
             if !self.primary_header.verify_crc32() {
                 return Err(PartitionError::GptHeaderCrcMismatch {
-                    expected: self.primary_header.header_crc32,
+                    expected: self.primary_header.header_crc32.to_ne(),
                     actual: self.primary_header.calculate_crc32(),
                 });
             }
 
             let entries_crc = crate::gpt::calculate_partition_array_crc32(&self.entries);
-            if self.primary_header.partition_entry_array_crc32 != entries_crc {
+            if self.primary_header.partition_entry_array_crc32.to_ne() != entries_crc {
                 return Err(PartitionError::GptEntriesCrcMismatch {
-                    expected: self.primary_header.partition_entry_array_crc32,
+                    expected: self.primary_header.partition_entry_array_crc32.to_ne(),
                     actual: entries_crc,
                 });
             }
@@ -230,9 +232,11 @@ impl GptDisk {
             for j in (i + 1)..used.len() {
                 let (idx1, p1) = used[i];
                 let (idx2, p2) = used[j];
-                if p1.first_lba <= p2.last_lba && p2.first_lba <= p1.last_lba {
-                    let overlap_start = p1.first_lba.max(p2.first_lba);
-                    let overlap_end = p1.last_lba.min(p2.last_lba);
+                if p1.first_lba.to_ne() <= p2.last_lba.to_ne()
+                    && p2.first_lba.to_ne() <= p1.last_lba.to_ne()
+                {
+                    let overlap_start = p1.first_lba.to_ne().max(p2.first_lba.to_ne());
+                    let overlap_end = p1.last_lba.to_ne().min(p2.last_lba.to_ne());
                     return Err(PartitionError::PartitionOverlap {
                         index1: idx1,
                         index2: idx2,
@@ -245,13 +249,13 @@ impl GptDisk {
 
         // Check partitions are within usable area
         for (idx, entry) in self.partitions() {
-            if entry.first_lba < self.primary_header.first_usable_lba
-                || entry.last_lba > self.primary_header.last_usable_lba
+            if entry.first_lba.to_ne() < self.primary_header.first_usable_lba.to_ne()
+                || entry.last_lba.to_ne() > self.primary_header.last_usable_lba.to_ne()
             {
                 return Err(PartitionError::PartitionOutOfBounds {
                     index: idx,
-                    partition_end: entry.last_lba,
-                    disk_end: self.primary_header.last_usable_lba,
+                    partition_end: entry.last_lba.to_ne(),
+                    disk_end: self.primary_header.last_usable_lba.to_ne(),
                 });
             }
         }
@@ -263,8 +267,8 @@ impl GptDisk {
     #[cfg(feature = "crc")]
     pub fn update_crcs(&mut self) {
         let entries_crc = crate::gpt::calculate_partition_array_crc32(&self.entries);
-        self.primary_header.partition_entry_array_crc32 = entries_crc;
-        self.backup_header.partition_entry_array_crc32 = entries_crc;
+        self.primary_header.partition_entry_array_crc32 = Le::<u32>::from_ne(entries_crc);
+        self.backup_header.partition_entry_array_crc32 = Le::<u32>::from_ne(entries_crc);
         self.primary_header.update_crc32();
         self.backup_header.update_crc32();
     }
@@ -276,7 +280,7 @@ impl GptDisk {
 
     /// Creates a protective MBR for this GPT disk.
     pub fn create_protective_mbr(&self) -> MasterBootRecord {
-        let disk_sectors = self.backup_header.my_lba + 1;
+        let disk_sectors = self.backup_header.my_lba.to_ne().saturating_add(1);
         MasterBootRecord::protective(disk_sectors)
     }
 }
@@ -352,8 +356,8 @@ impl DiskPartitionScheme {
                 .partitions()
                 .map(|(i, e)| PartitionInfo {
                     index: i,
-                    start_lba: e.first_lba,
-                    end_lba: e.last_lba,
+                    start_lba: e.first_lba.to_ne(),
+                    end_lba: e.last_lba.to_ne(),
                     size_sectors: e.size_sectors(),
                     bootable: e.attributes.is_legacy_bios_bootable(),
                     partition_type: PartitionType::Gpt(e.type_guid),

--- a/crates/hadris-part/src/scheme.rs
+++ b/crates/hadris-part/src/scheme.rs
@@ -340,9 +340,9 @@ impl DiskPartitionScheme {
                     .filter(|(_, p)| !p.is_empty())
                     .map(|(i, p)| PartitionInfo {
                         index: i,
-                        start_lba: p.start_lba as u64,
+                        start_lba: p.start_lba.to_ne() as u64,
                         end_lba: p.end_lba() as u64,
-                        size_sectors: p.sector_count as u64,
+                        size_sectors: p.sector_count.to_ne() as u64,
                         bootable: p.is_bootable(),
                         partition_type: PartitionType::Mbr(p.part_type),
                     })

--- a/crates/hadris-part/src/scheme_io.rs
+++ b/crates/hadris-part/src/scheme_io.rs
@@ -61,24 +61,24 @@ impl GptDiskReadExt for GptDisk {
         #[cfg(feature = "crc")]
         if !primary_header.verify_crc32() {
             return Err(PartitionError::GptHeaderCrcMismatch {
-                expected: primary_header.header_crc32,
+                expected: primary_header.header_crc32.to_ne(),
                 actual: primary_header.calculate_crc32(),
             });
         }
 
         // Validate partition entry size
-        let entry_size = primary_header.size_of_partition_entry;
+        let entry_size = primary_header.size_of_partition_entry.to_ne();
         if entry_size != core::mem::size_of::<GptPartitionEntry>() as u32 {
             return Err(PartitionError::InvalidPartitionEntrySize { size: entry_size });
         }
 
         // Read partition entries
-        let num_entries = primary_header.num_partition_entries as usize;
+        let num_entries = primary_header.num_partition_entries.to_ne() as usize;
         let mut entries = alloc::vec![GptPartitionEntry::default(); num_entries];
 
         reader
             .seek(SeekFrom::Start(
-                primary_header.partition_entry_lba * block_size as u64,
+                primary_header.partition_entry_lba.to_ne() * block_size as u64,
             ))
             .await
             .map_err(|_| PartitionError::Io)?;
@@ -96,9 +96,9 @@ impl GptDiskReadExt for GptDisk {
         #[cfg(feature = "crc")]
         {
             let entries_crc = crate::gpt::calculate_partition_array_crc32(&entries);
-            if primary_header.partition_entry_array_crc32 != entries_crc {
+            if primary_header.partition_entry_array_crc32.to_ne() != entries_crc {
                 return Err(PartitionError::GptEntriesCrcMismatch {
-                    expected: primary_header.partition_entry_array_crc32,
+                    expected: primary_header.partition_entry_array_crc32.to_ne(),
                     actual: entries_crc,
                 });
             }
@@ -106,7 +106,9 @@ impl GptDiskReadExt for GptDisk {
 
         // Try to read backup header
         let backup_header =
-            match GptHeader::read_from_lba(reader, primary_header.alternate_lba, block_size).await {
+            match GptHeader::read_from_lba(reader, primary_header.alternate_lba.to_ne(), block_size)
+                .await
+            {
                 Ok(header) => header,
                 Err(_) => GptHeader {
                     // If backup header read fails, construct it from primary
@@ -184,7 +186,7 @@ impl GptDiskWriteExt for GptDisk {
         // Write primary partition entries starting at partition_entry_lba
         writer
             .seek(SeekFrom::Start(
-                self.primary_header.partition_entry_lba * self.block_size as u64,
+                self.primary_header.partition_entry_lba.to_ne() * self.block_size as u64,
             ))
             .await
             .map_err(|_| PartitionError::Io)?;
@@ -199,7 +201,7 @@ impl GptDiskWriteExt for GptDisk {
         // Write backup partition entries
         writer
             .seek(SeekFrom::Start(
-                self.backup_header.partition_entry_lba * self.block_size as u64,
+                self.backup_header.partition_entry_lba.to_ne() * self.block_size as u64,
             ))
             .await
             .map_err(|_| PartitionError::Io)?;
@@ -213,7 +215,7 @@ impl GptDiskWriteExt for GptDisk {
 
         // Write backup header at last LBA
         self.backup_header
-            .write_to_lba(writer, self.backup_header.my_lba, self.block_size)
+            .write_to_lba(writer, self.backup_header.my_lba.to_ne(), self.block_size)
             .await?;
 
         Ok(())
@@ -239,7 +241,7 @@ impl GptDiskWriteExt for GptDisk {
         // Write primary partition entries
         writer
             .seek(SeekFrom::Start(
-                self.primary_header.partition_entry_lba * self.block_size as u64,
+                self.primary_header.partition_entry_lba.to_ne() * self.block_size as u64,
             ))
             .await
             .map_err(|_| PartitionError::Io)?;
@@ -254,7 +256,7 @@ impl GptDiskWriteExt for GptDisk {
         // Write backup partition entries
         writer
             .seek(SeekFrom::Start(
-                self.backup_header.partition_entry_lba * self.block_size as u64,
+                self.backup_header.partition_entry_lba.to_ne() * self.block_size as u64,
             ))
             .await
             .map_err(|_| PartitionError::Io)?;
@@ -268,7 +270,7 @@ impl GptDiskWriteExt for GptDisk {
 
         // Write backup header at last LBA
         self.backup_header
-            .write_to_lba(writer, self.backup_header.my_lba, self.block_size)
+            .write_to_lba(writer, self.backup_header.my_lba.to_ne(), self.block_size)
             .await?;
 
         Ok(())

--- a/crates/hadris-part/tests/roundtrip.rs
+++ b/crates/hadris-part/tests/roundtrip.rs
@@ -28,9 +28,9 @@ fn mbr_write_read_roundtrip() {
     assert!(mbr2.has_valid_signature());
     let t2 = mbr2.get_partition_table();
     assert_eq!(t2.count(), 2);
-    assert_eq!(t2[0].start_lba as u64, 2048);
-    assert_eq!(t2[0].sector_count as u64, 204800);
-    assert_eq!(t2[1].start_lba as u64, 206848);
+    assert_eq!(t2[0].start_lba.to_ne() as u64, 2048);
+    assert_eq!(t2[0].sector_count.to_ne() as u64, 204800);
+    assert_eq!(t2[1].start_lba.to_ne() as u64, 206848);
 }
 
 #[test]

--- a/crates/hadris-part/tests/roundtrip.rs
+++ b/crates/hadris-part/tests/roundtrip.rs
@@ -63,8 +63,8 @@ fn gpt_partition_entry_roundtrip() {
 
     let entry2: &GptPartitionEntry = bytemuck::from_bytes(bytes);
     assert_eq!(entry2.type_guid, Guid::EFI_SYSTEM);
-    assert_eq!(entry2.first_lba, 2048);
-    assert_eq!(entry2.last_lba, 206847);
+    assert_eq!(entry2.first_lba.to_ne(), 2048);
+    assert_eq!(entry2.last_lba.to_ne(), 206847);
     assert_eq!(entry2.size_sectors(), 204800);
 }
 


### PR DESCRIPTION
Use rust-dev endian-num to ensure there are no endian errors when reading or writing partition entires.

Eventually the same should be done in FS metadata.