### PR TITLE
fix(udf): restore CI under -D warnings

### DIFF
--- a/crates/hadris-cd/src/layout.rs
+++ b/crates/hadris-cd/src/layout.rs
@@ -258,7 +258,7 @@ mod tests {
         let options = CdOptions::default();
         let mut layout = LayoutManager::new(2048);
 
-        let info = layout.layout_files(&mut tree, &options).unwrap();
+        layout.layout_files(&mut tree, &options).unwrap();
 
         // First file should have a valid extent
         let file1 = tree.root.files.get(0).unwrap();

--- a/crates/hadris-udf/src/descriptor/logical.rs
+++ b/crates/hadris-udf/src/descriptor/logical.rs
@@ -64,6 +64,36 @@ impl LogicalVolumeDescriptor {
     pub fn is_udf_domain(&self) -> bool {
         self.domain_identifier.is(b"*OSTA UDF Compliant")
     }
+
+    /// Yield Type 1 partition maps from the embedded map table (ECMA-167 3/10.7.2).
+    ///
+    /// Skips unknown / Type 2 maps and stops if the table is truncated or malformed.
+    pub fn type1_partition_maps(&self) -> impl Iterator<Item = Type1PartitionMap> + '_ {
+        let maps = &self.partition_maps;
+        let mut offset = 0usize;
+        let mut remaining = self.num_partition_maps as usize;
+        core::iter::from_fn(move || {
+            while remaining > 0 {
+                remaining -= 1;
+                if offset + 2 > maps.len() {
+                    return None;
+                }
+                let map_type = maps[offset];
+                let map_len = maps[offset + 1] as usize;
+                if map_len < 2 || offset + map_len > maps.len() {
+                    return None;
+                }
+                let entry = &maps[offset..offset + map_len];
+                offset += map_len;
+                if map_type == 1 && map_len >= core::mem::size_of::<Type1PartitionMap>() {
+                    return Some(*bytemuck::from_bytes(
+                        &entry[..core::mem::size_of::<Type1PartitionMap>()],
+                    ));
+                }
+            }
+            None
+        })
+    }
 }
 
 /// Type 1 Partition Map (ECMA-167 3/10.7.2)
@@ -86,4 +116,38 @@ mod tests {
 
     static_assertions::const_assert_eq!(size_of::<LogicalVolumeDescriptor>(), 512);
     static_assertions::const_assert_eq!(size_of::<Type1PartitionMap>(), 6);
+
+    #[test]
+    fn type1_partition_maps_parses_embedded_table() {
+        let mut lvd = LogicalVolumeDescriptor {
+            tag: bytemuck::Zeroable::zeroed(),
+            vds_number: 0,
+            descriptor_char_set: CharSpec::default(),
+            logical_volume_identifier: [0; 128],
+            logical_block_size: 2048,
+            domain_identifier: EntityIdentifier::EMPTY,
+            logical_volume_contents_use: [0; 16],
+            map_table_length: 6,
+            num_partition_maps: 1,
+            implementation_identifier: EntityIdentifier::EMPTY,
+            implementation_use: [0; 128],
+            integrity_sequence_extent: ExtentDescriptor::default(),
+            partition_maps: [0; 72],
+        };
+        let map = Type1PartitionMap {
+            partition_map_type: 1,
+            partition_map_length: 6,
+            volume_sequence_number: 1,
+            partition_number: 0,
+        };
+        lvd.partition_maps[..6].copy_from_slice(bytemuck::bytes_of(&map));
+
+        let mut parsed = lvd.type1_partition_maps();
+        let first = parsed.next().expect("type 1 map");
+        assert!(parsed.next().is_none());
+        assert_eq!(first.partition_map_type, 1);
+        assert_eq!(first.partition_map_length, 6);
+        assert_eq!(first.volume_sequence_number, 1);
+        assert_eq!(first.partition_number, 0);
+    }
 }

--- a/crates/hadris-udf/src/descriptor/mod.rs
+++ b/crates/hadris-udf/src/descriptor/mod.rs
@@ -12,7 +12,7 @@ mod tag;
 
 pub use anchor::AnchorVolumeDescriptorPointer;
 pub use fileset::FileSetDescriptor;
-pub use logical::LogicalVolumeDescriptor;
+pub use logical::{LogicalVolumeDescriptor, Type1PartitionMap};
 pub use partition::{PartitionContents, PartitionDescriptor};
 pub use primary::PrimaryVolumeDescriptor;
 pub use tag::{DescriptorTag, TagIdentifier};

--- a/crates/hadris-udf/src/lib.rs
+++ b/crates/hadris-udf/src/lib.rs
@@ -32,12 +32,13 @@
 //! println!("Volume: {}", info.volume_id);
 //!
 //! // List root directory
-//! for entry in udf.root_dir().unwrap().entries() {
+//! let root = udf.root_dir().unwrap();
+//! for entry in root.entries() {
 //!     println!("{} ({})", entry.name(), entry.size);
 //! }
 //!
 //! // Read a file's contents
-//! # let entry = udf.root_dir().unwrap().entries().next().unwrap();
+//! # let entry = root.entries().next().unwrap();
 //! let bytes = udf.read_file(&entry).unwrap();
 //! # let _ = bytes;
 //! ```


### PR DESCRIPTION
## Summary
- Wire `Type1PartitionMap` through `LogicalVolumeDescriptor::type1_partition_maps()` so `-D warnings` no longer fails on dead code
- Fix Quick Start doctest temporary borrow (`E0716`)
- Drop unused `info` binding in `hadris-cd` layout test

## Test plan
- [x] `RUSTFLAGS='-D warnings' cargo check -p hadris-udf` (default + `read,sync`)
- [x] `RUSTFLAGS='-D warnings' cargo test -p hadris-udf --lib descriptor::logical`
- [x] `RUSTFLAGS='-D warnings' cargo test -p hadris-udf --doc`
- [x] `RUSTFLAGS='-D warnings' cargo check --workspace`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)