### PR TITLE
docs: spec compliance documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ See [CLAUDE.md](CLAUDE.md) for the full per-crate feature matrix used in CI.
   Replay corpora with `cargo +nightly fuzz run <target> -- -runs=0` after
   parser fixes; prefer a normal unit/integration test for PR-gating regressions.
 
+## Spec annotations
+
+When changing on-disk layouts or public parse/format entry points for a
+standard section, add or update `@hadris-spec` tags (see
+[`docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`](docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md))
+and sync [`docs/spec-coverage.md`](docs/spec-coverage.md).
+
+- `full` needs `@hadris-tests` and/or `@hadris-fuzz`.
+- `partial` needs `@hadris-note` describing the gap.
+- Fuzz targets are local discovery tools, not CI gates.
+
 ## Docs
 
 ```bash

--- a/crates/hadris-fat/src/raw.rs
+++ b/crates/hadris-fat/src/raw.rs
@@ -8,6 +8,11 @@ use hadris_common::types::{
 /// This only contains the common fields of the boot sector, and is not meant to be used directly
 /// for reading or writing to the boot sector, for that, see `RawBootSector`, which contains
 /// the boot sector and the extended boot sector
+///
+/// @hadris-spec FAT:BPB
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_fat::test_valid_sector_sizes
+/// @hadris-fuzz fat_read
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RawBpb {
@@ -276,6 +281,12 @@ unsafe impl bytemuck::AnyBitPattern for RawFileEntry {}
 /// Embedded paces are also allowed
 /// The name is stored in UTF-16 encoding (UNICODE)
 /// When the unicode character cannot be translated to ANSI, an underscore is used
+///
+/// @hadris-spec FAT:LFN
+/// @hadris-compliance partial
+/// @hadris-tests comprehensive_fat::test_lfn_builder_sequence
+/// @hadris-fuzz fat_read
+/// @hadris-note cross-cluster LFN directory entry runs unsupported on write
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub struct RawLfnEntry {

--- a/crates/hadris-iso/spec/Specification.md
+++ b/crates/hadris-iso/spec/Specification.md
@@ -1,5 +1,8 @@
 # ISO-9660 Specification
 
+> Maintainer machine-index for implemented sections:
+> [`docs/spec-coverage.md`](../../../docs/spec-coverage.md).
+
 This is an unofficial specification for the ISO-9660 filesystem.
 
 ## Table of Contents

--- a/crates/hadris-iso/src/boot.rs
+++ b/crates/hadris-iso/src/boot.rs
@@ -220,6 +220,12 @@ impl PlatformId {
     }
 }
 
+/// El Torito boot catalog validation entry.
+///
+/// @hadris-spec El-Torito:validation
+/// @hadris-compliance full
+/// @hadris-tests xorriso_boot::test_eltorito_boot_catalog_comparison
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct BootValidationEntry {

--- a/crates/hadris-iso/src/directory.rs
+++ b/crates/hadris-iso/src/directory.rs
@@ -4,7 +4,13 @@ use bytemuck::Zeroable;
 use super::io::LogicalSector;
 use crate::types::{U16LsbMsb, U32LsbMsb};
 
-/// The header of a directory record, because the identifier is variable length,
+/// The header of a directory record, because the identifier is variable length
+/// (ECMA-119 9.1 fixed fields).
+///
+/// @hadris-spec ECMA-119:9.1
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_iso::test_directory_record_structure
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct DirectoryRecordHeader {
@@ -53,6 +59,13 @@ impl DirectoryRecordHeader {
     }
 }
 
+/// Directory Record (ECMA-119 9.1) — header plus variable identifier / system use.
+///
+/// @hadris-spec ECMA-119:9.1
+/// @hadris-compliance partial
+/// @hadris-tests comprehensive_iso::test_directory_record_structure
+/// @hadris-fuzz iso_read
+/// @hadris-note Joliet+RRIP coexistence on read may hide one namespace; see crate Known Limitations
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct DirectoryRecord {

--- a/crates/hadris-iso/src/volume.rs
+++ b/crates/hadris-iso/src/volume.rs
@@ -324,6 +324,12 @@ impl Debug for UnknownVolumeDescriptor {
 unsafe impl bytemuck::Zeroable for UnknownVolumeDescriptor {}
 unsafe impl bytemuck::Pod for UnknownVolumeDescriptor {}
 
+/// Primary Volume Descriptor (ECMA-119 8.4)
+///
+/// @hadris-spec ECMA-119:8.4
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_iso::test_pvd_standard_identifier
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PrimaryVolumeDescriptor {

--- a/crates/hadris-udf/src/descriptor/anchor.rs
+++ b/crates/hadris-udf/src/descriptor/anchor.rs
@@ -7,6 +7,11 @@ use crate::error::{UdfError, UdfResult};
 /// Anchor Volume Descriptor Pointer (AVDP)
 ///
 /// Located at sector 256 (and optionally at N-256 and N where N is last sector)
+///
+/// @hadris-spec ECMA-167:3/10.2
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_avdp_structure
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct AnchorVolumeDescriptorPointer {

--- a/crates/hadris-udf/src/descriptor/fileset.rs
+++ b/crates/hadris-udf/src/descriptor/fileset.rs
@@ -5,6 +5,11 @@ use crate::error::UdfResult;
 use crate::time::UdfTimestamp;
 
 /// File Set Descriptor (ECMA-167 4/14.1)
+///
+/// @hadris-spec ECMA-167:4/14.1
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_allocation_descriptor_sizes
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct FileSetDescriptor {

--- a/crates/hadris-udf/src/descriptor/logical.rs
+++ b/crates/hadris-udf/src/descriptor/logical.rs
@@ -7,6 +7,11 @@ use super::{
 use crate::error::UdfResult;
 
 /// Logical Volume Descriptor (ECMA-167 3/10.6)
+///
+/// @hadris-spec ECMA-167:3/10.6
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_allocation_descriptor_sizes
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct LogicalVolumeDescriptor {
@@ -97,6 +102,11 @@ impl LogicalVolumeDescriptor {
 }
 
 /// Type 1 Partition Map (ECMA-167 3/10.7.2)
+///
+/// @hadris-spec ECMA-167:3/10.7.2
+/// @hadris-compliance full
+/// @hadris-tests descriptor::logical::tests::type1_partition_maps_parses_embedded_table
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct Type1PartitionMap {

--- a/crates/hadris-udf/src/descriptor/mod.rs
+++ b/crates/hadris-udf/src/descriptor/mod.rs
@@ -21,6 +21,11 @@ use super::super::{Read, Seek, SeekFrom};
 use crate::error::{UdfError, UdfResult};
 
 /// Extent descriptor (ECMA-167 3/7.1)
+///
+/// @hadris-spec ECMA-167:3/7.1
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_extent_descriptor
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct ExtentDescriptor {
@@ -40,6 +45,11 @@ impl ExtentDescriptor {
 /// Long allocation descriptor (ECMA-167 4/14.14.2)
 ///
 /// Used to reference data that may span multiple partitions
+///
+/// @hadris-spec ECMA-167:4/14.14.2
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_allocation_descriptor_sizes
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LongAllocationDescriptor {
@@ -82,6 +92,11 @@ impl LongAllocationDescriptor {
 }
 
 /// Short allocation descriptor (ECMA-167 4/14.14.1)
+///
+/// @hadris-spec ECMA-167:4/14.14.1
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_allocation_descriptor_sizes
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct ShortAllocationDescriptor {
@@ -139,6 +154,11 @@ pub struct LbAddr {
 }
 
 /// Entity identifier (ECMA-167 1/7.4)
+///
+/// @hadris-spec ECMA-167:1/7.4
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_partition_contents
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct EntityIdentifier {
@@ -182,6 +202,10 @@ unsafe impl bytemuck::Zeroable for EntityIdentifier {}
 unsafe impl bytemuck::Pod for EntityIdentifier {}
 
 /// Character set specification (ECMA-167 1/7.2.1)
+///
+/// @hadris-spec ECMA-167:1/7.2.1
+/// @hadris-compliance full
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct CharSpec {

--- a/crates/hadris-udf/src/descriptor/partition.rs
+++ b/crates/hadris-udf/src/descriptor/partition.rs
@@ -4,6 +4,11 @@ use super::{DescriptorTag, EntityIdentifier, TagIdentifier};
 use crate::error::UdfResult;
 
 /// Partition Descriptor (ECMA-167 3/10.5)
+///
+/// @hadris-spec ECMA-167:3/10.5
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_partition_contents
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct PartitionDescriptor {

--- a/crates/hadris-udf/src/descriptor/primary.rs
+++ b/crates/hadris-udf/src/descriptor/primary.rs
@@ -5,6 +5,10 @@ use crate::error::UdfResult;
 use crate::time::UdfTimestamp;
 
 /// Primary Volume Descriptor (ECMA-167 3/10.1)
+///
+/// @hadris-spec ECMA-167:3/10.1
+/// @hadris-compliance full
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct PrimaryVolumeDescriptor {

--- a/crates/hadris-udf/src/descriptor/tag.rs
+++ b/crates/hadris-udf/src/descriptor/tag.rs
@@ -5,6 +5,11 @@ use crate::error::{UdfError, UdfResult};
 /// Descriptor tag (ECMA-167 3/7.2)
 ///
 /// Every UDF descriptor starts with this 16-byte tag
+///
+/// @hadris-spec ECMA-167:3/7.2
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_tag_structure
+/// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct DescriptorTag {
@@ -82,6 +87,11 @@ impl DescriptorTag {
 }
 
 /// Tag identifier values (ECMA-167 3/7.2.1)
+///
+/// @hadris-spec ECMA-167:3/7.2.1
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_descriptor_tag_ids
+/// @hadris-fuzz udf_read
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum TagIdentifier {

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -17,7 +17,19 @@ Fuzz columns name targets under `fuzz/` (local only — not PR CI).
 
 | Spec | Item | Compliance | Tests | Fuzz | Notes |
 |------|------|------------|-------|------|-------|
-| *(pilot rows added in Task 2)* | | | | | |
+| ECMA-167:3/7.2 | `DescriptorTag` | full | `comprehensive_udf::test_tag_structure` | `udf_read` | |
+| ECMA-167:3/7.2.1 | `TagIdentifier` | full | `comprehensive_udf::test_descriptor_tag_ids` | `udf_read` | |
+| ECMA-167:3/7.1 | `ExtentDescriptor` | full | `comprehensive_udf::test_extent_descriptor` | `udf_read` | |
+| ECMA-167:1/7.4 | `EntityIdentifier` | full | `comprehensive_udf::test_partition_contents` | `udf_read` | |
+| ECMA-167:1/7.2.1 | `CharSpec` | full | | `udf_read` | |
+| ECMA-167:4/14.14.2 | `LongAllocationDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
+| ECMA-167:4/14.14.1 | `ShortAllocationDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
+| ECMA-167:3/10.2 | `AnchorVolumeDescriptorPointer` | full | `comprehensive_udf::test_avdp_structure` | `udf_read` | |
+| ECMA-167:3/10.1 | `PrimaryVolumeDescriptor` | full | | `udf_read` | |
+| ECMA-167:3/10.5 | `PartitionDescriptor` | full | `comprehensive_udf::test_partition_contents` | `udf_read` | |
+| ECMA-167:3/10.6 | `LogicalVolumeDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
+| ECMA-167:3/10.7.2 | `Type1PartitionMap` | full | `descriptor::logical::tests::type1_partition_maps_parses_embedded_table` | `udf_read` | |
+| ECMA-167:4/14.1 | `FileSetDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
 
 ## hadris-iso
 

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -35,7 +35,9 @@ Fuzz columns name targets under `fuzz/` (local only — not PR CI).
 
 | Spec | Item | Compliance | Tests | Fuzz | Notes |
 |------|------|------------|-------|------|-------|
-| *(pilot rows added in Task 3–4)* | | | | | |
+| ECMA-119:8.4 | `PrimaryVolumeDescriptor` | full | `comprehensive_iso::test_pvd_standard_identifier` | `iso_read` | |
+| ECMA-119:9.1 | `DirectoryRecordHeader` | full | `comprehensive_iso::test_directory_record_structure` | `iso_read` | Fixed fields of the directory record |
+| ECMA-119:9.1 | `DirectoryRecord` | partial | `comprehensive_iso::test_directory_record_structure` | `iso_read` | Joliet+RRIP coexistence on read may hide one namespace |
 
 ## hadris-fat
 

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -38,9 +38,11 @@ Fuzz columns name targets under `fuzz/` (local only — not PR CI).
 | ECMA-119:8.4 | `PrimaryVolumeDescriptor` | full | `comprehensive_iso::test_pvd_standard_identifier` | `iso_read` | |
 | ECMA-119:9.1 | `DirectoryRecordHeader` | full | `comprehensive_iso::test_directory_record_structure` | `iso_read` | Fixed fields of the directory record |
 | ECMA-119:9.1 | `DirectoryRecord` | partial | `comprehensive_iso::test_directory_record_structure` | `iso_read` | Joliet+RRIP coexistence on read may hide one namespace |
+| El-Torito:validation | `BootValidationEntry` | full | `xorriso_boot::test_eltorito_boot_catalog_comparison` | `iso_read` | |
 
 ## hadris-fat
 
 | Spec | Item | Compliance | Tests | Fuzz | Notes |
 |------|------|------------|-------|------|-------|
-| *(pilot rows added in Task 5)* | | | | | |
+| FAT:BPB | `RawBpb` | full | `comprehensive_fat::test_valid_sector_sizes` | `fat_read` | |
+| FAT:LFN | `RawLfnEntry` | partial | `comprehensive_fat::test_lfn_builder_sequence` | `fat_read` | Cross-cluster LFN directory entry runs unsupported on write |

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -1,0 +1,32 @@
+# Spec coverage
+
+Maintainer audit index for standards-facing types in Hadris.
+Not a public marketing matrix (v0).
+
+**Design:** [`docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`](superpowers/specs/2026-07-09-spec-compliance-program-design.md)
+
+**How to update**
+
+1. `rg '@hadris-spec' crates/`
+2. Sync rows below (one primary row per annotated item).
+3. Prefer `partial` + Notes over claiming `full`.
+
+Fuzz columns name targets under `fuzz/` (local only — not PR CI).
+
+## hadris-udf
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| *(pilot rows added in Task 2)* | | | | | |
+
+## hadris-iso
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| *(pilot rows added in Task 3–4)* | | | | | |
+
+## hadris-fat
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| *(pilot rows added in Task 5)* | | | | | |

--- a/docs/superpowers/plans/2026-07-09-spec-compliance-v0-pilot.md
+++ b/docs/superpowers/plans/2026-07-09-spec-compliance-v0-pilot.md
@@ -1,0 +1,437 @@
+# Spec Compliance Program v0 Pilot — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the Phase E v0 pilot — grepable `@hadris-spec` tags on UDF/ISO/FAT hot paths, a hand-maintained `docs/spec-coverage.md`, and a CONTRIBUTING blurb — with no CI fuzz job and no proc-macros.
+
+**Architecture:** Comment-only annotations on spec-facing types (design: [`docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`](../specs/2026-07-09-spec-compliance-program-design.md)). One workspace markdown index; tags link existing tests/fuzz targets. Maintainer audit first; public matrix later.
+
+**Tech Stack:** Rust rustdoc/`//` comments, `rg`, Markdown, existing `cargo test` / local `cargo fuzz` targets (`udf_read`, `iso_read`, `fat_read`).
+
+## Global Constraints
+
+- Follow annotation grammar in the design doc §4 exactly (`@hadris-spec`, `@hadris-compliance`, `@hadris-tests` / `@hadris-fuzz`, `@hadris-note` for `partial`).
+- `full` requires at least one of `@hadris-tests` or `@hadris-fuzz`; prefer naming real existing tests.
+- Prefer `partial` + honest `@hadris-note` over claiming `full` when write paths or options are incomplete.
+- Annotate **spec-facing** structs / parse entry points only — not every helper.
+- Do **not** add a fuzz CI job, proc-macro, or table generator in v0.
+- Do **not** rewrite `crates/hadris-iso/spec/` beyond a one-line pointer.
+- Out of pilot: exFAT depth, full RRIP write matrix, GPT/MBR, CPIO, golden vectors, v1 CI checker.
+- Keep `RUSTFLAGS="-D warnings"` green; comment-only changes should not alter behavior.
+- Design docs under `docs/superpowers/specs/` may still be untracked — include them in the first commit of this plan if not already on `main`.
+
+---
+
+## File structure (v0)
+
+| Path | Role |
+|------|------|
+| `docs/spec-coverage.md` | **Create** — workspace audit table (UDF / ISO / FAT sections) |
+| `CONTRIBUTING.md` | **Modify** — short “Spec annotations” subsection |
+| `docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md` | Ensure committed (source of truth) |
+| `docs/superpowers/specs/2026-07-09-professionalization-review.md` | Ensure Phase E pointer committed |
+| `crates/hadris-udf/src/descriptor/{tag,anchor,primary,partition,logical,fileset,mod}.rs` | Add tags on ECMA-167 types |
+| `crates/hadris-iso/src/volume.rs` | Tag `PrimaryVolumeDescriptor` |
+| `crates/hadris-iso/src/directory.rs` | Tag `DirectoryRecord` / header |
+| `crates/hadris-iso/src/boot.rs` | Tag El-Torito validation entry **only if cheap** (see Task 4) |
+| `crates/hadris-iso/spec/Specification.md` | One-line pointer to coverage doc |
+| `crates/hadris-fat/src/raw.rs` | Tag `RawBpb` (`FAT:BPB`) and `RawLfnEntry` (`FAT:LFN`) |
+
+No new Rust modules, no CI workflow changes in v0.
+
+---
+
+### Task 1: Scaffold coverage doc + CONTRIBUTING + commit design specs
+
+**Files:**
+- Create: `docs/spec-coverage.md`
+- Modify: `CONTRIBUTING.md`
+- Add (if untracked): `docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`, `docs/superpowers/specs/2026-07-09-professionalization-review.md`, this plan file
+
+**Interfaces:**
+- Produces: Empty-but-structured coverage table and contributor instructions that later tasks fill in.
+
+- [ ] **Step 1: Create `docs/spec-coverage.md` stub**
+
+```markdown
+# Spec coverage
+
+Maintainer audit index for standards-facing types in Hadris.
+Not a public marketing matrix (v0).
+
+**Design:** [`docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`](superpowers/specs/2026-07-09-spec-compliance-program-design.md)
+
+**How to update**
+
+1. `rg '@hadris-spec' crates/`
+2. Sync rows below (one primary row per annotated item).
+3. Prefer `partial` + Notes over claiming `full`.
+
+Fuzz columns name targets under `fuzz/` (local only — not PR CI).
+
+## hadris-udf
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| *(pilot rows added in Task 2)* | | | | | |
+
+## hadris-iso
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| *(pilot rows added in Task 3–4)* | | | | | |
+
+## hadris-fat
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| *(pilot rows added in Task 5)* | | | | | |
+```
+
+- [ ] **Step 2: Add CONTRIBUTING subsection** (after “Safety and fuzzing”)
+
+```markdown
+## Spec annotations
+
+When changing on-disk layouts or public parse/format entry points for a
+standard section, add or update `@hadris-spec` tags (see
+[`docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`](docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md))
+and sync [`docs/spec-coverage.md`](docs/spec-coverage.md).
+
+- `full` needs `@hadris-tests` and/or `@hadris-fuzz`.
+- `partial` needs `@hadris-note` describing the gap.
+- Fuzz targets are local discovery tools, not CI gates.
+```
+
+- [ ] **Step 3: Verify design docs exist and review pointer is present**
+
+Run: `test -f docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md && rg -n 'spec-compliance-program-design' docs/superpowers/specs/2026-07-09-professionalization-review.md`
+Expected: file exists; review mentions the design.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/spec-coverage.md CONTRIBUTING.md \
+  docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md \
+  docs/superpowers/specs/2026-07-09-professionalization-review.md \
+  docs/superpowers/plans/2026-07-09-spec-compliance-v0-pilot.md
+git commit -m "$(cat <<'EOF'
+docs: scaffold Phase E v0 spec coverage and contributor guide
+
+Add hand-maintained coverage table stub, CONTRIBUTING annotation
+blurb, and commit the approved design/plan for the compliance pilot.
+EOF
+)"
+```
+
+---
+
+### Task 2: Tag hadris-udf descriptors (pilot core)
+
+**Files:**
+- Modify: `crates/hadris-udf/src/descriptor/tag.rs`
+- Modify: `crates/hadris-udf/src/descriptor/anchor.rs`
+- Modify: `crates/hadris-udf/src/descriptor/primary.rs`
+- Modify: `crates/hadris-udf/src/descriptor/partition.rs`
+- Modify: `crates/hadris-udf/src/descriptor/logical.rs` (`LogicalVolumeDescriptor`, `Type1PartitionMap`)
+- Modify: `crates/hadris-udf/src/descriptor/fileset.rs`
+- Modify: `crates/hadris-udf/src/descriptor/mod.rs` (shared building blocks: `ExtentDescriptor`, `LongAllocationDescriptor`, `ShortAllocationDescriptor`, `EntityIdentifier`, `CharSpec` — tag only if they are clearly spec-facing and already titled; skip `LbAddr` / tiny helpers if noisy)
+- Modify: `docs/spec-coverage.md` (UDF section rows)
+
+**Interfaces:**
+- Consumes: Existing ECMA-167 titles already on these modules.
+- Produces: Grepable tags + UDF table rows. Suggested test ids (integration crate `comprehensive_udf`):
+  - Tag / checksum: `comprehensive_udf::constants_tests` / `test_tag_structure`, `test_tag_checksum`, `test_descriptor_tag_ids`
+  - AVDP: `comprehensive_udf::…::test_avdp_structure` (use the actual module path from the file — today nested under `mod` blocks; prefer the **runnable** filter string, e.g. document as `comprehensive_udf` + test name, or `cargo test -p hadris-udf --test comprehensive_udf test_avdp_structure`)
+  - Prefer stable form in tags: `comprehensive_udf::test_avdp_structure` (test name unique in that file)
+  - Fuzz: `udf_read` for all UDF parse-facing rows
+
+**Compliance guidance (default honesty):**
+- Layout + `validate` / checksum paths that are exercised → `full` with tests + `udf_read`.
+- If write path invents or stubs fields → `partial` + note (check write module briefly; do not expand write work in this task).
+
+- [ ] **Step 1: Add tags to `DescriptorTag` and `TagIdentifier` in `tag.rs`**
+
+Example shape (adapt to existing rustdoc):
+
+```rust
+/// Descriptor tag (ECMA-167 3/7.2)
+///
+/// @hadris-spec ECMA-167:3/7.2
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::test_tag_structure
+/// @hadris-fuzz udf_read
+pub struct DescriptorTag { ... }
+```
+
+- [ ] **Step 2: Tag `AnchorVolumeDescriptorPointer`, `PrimaryVolumeDescriptor`, `PartitionDescriptor`, `LogicalVolumeDescriptor`, `Type1PartitionMap`, `FileSetDescriptor`**
+
+Use section ids already in module titles:
+- AVDP → `ECMA-167:3/10.2`
+- PVD → `ECMA-167:3/10.1`
+- Partition → `ECMA-167:3/10.5`
+- LVD → `ECMA-167:3/10.6`
+- Type 1 map → `ECMA-167:3/10.7.2`
+- File Set → `ECMA-167:4/14.1`
+
+- [ ] **Step 3: Optionally tag shared types in `mod.rs`** (`ExtentDescriptor` `ECMA-167:3/7.1`, long/short AD, `EntityIdentifier`, `CharSpec`) — only if a clear test or fuzz link exists; otherwise leave for a later pass to avoid empty `full` claims.
+
+- [ ] **Step 4: Fill UDF rows in `docs/spec-coverage.md`**
+
+- [ ] **Step 5: Verify tags are grepable**
+
+Run: `rg -n '@hadris-spec ECMA-167' crates/hadris-udf/src/descriptor`
+Expected: one hit per tagged item (≥6).
+
+Run: `RUSTFLAGS='-D warnings' cargo check -p hadris-udf --no-default-features --features 'read,sync'`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hadris-udf/src/descriptor docs/spec-coverage.md
+git commit -m "$(cat <<'EOF'
+docs(udf): add @hadris-spec tags for ECMA-167 descriptor pilot
+
+Annotate volume/file-set descriptor types and sync the UDF section of
+docs/spec-coverage.md for maintainer traceability.
+EOF
+)"
+```
+
+---
+
+### Task 3: Tag hadris-iso PVD + directory record
+
+**Files:**
+- Modify: `crates/hadris-iso/src/volume.rs` (`PrimaryVolumeDescriptor` ~line 329)
+- Modify: `crates/hadris-iso/src/directory.rs` (`DirectoryRecordHeader` / `DirectoryRecord`)
+- Modify: `docs/spec-coverage.md` (ISO section)
+
+**Interfaces:**
+- Tests (integration `comprehensive_iso`):
+  - PVD: `comprehensive_iso::test_pvd_standard_identifier`, `test_volume_id_extraction`
+  - Directory: `comprehensive_iso::test_directory_record_structure`, `test_root_directory_access`
+- Fuzz: `iso_read`
+
+**Compliance guidance:**
+- PVD read layout → likely `full` if tests cover identifier/volume id.
+- Directory record → `full` for basic ECMA-119 9.1 layout **or** `partial` if RRIP/Joliet coexistence caveats belong on this type (prefer a short note rather than overclaiming).
+
+- [ ] **Step 1: Tag `PrimaryVolumeDescriptor`**
+
+```rust
+/// @hadris-spec ECMA-119:8.4
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_iso::test_pvd_standard_identifier
+/// @hadris-fuzz iso_read
+```
+
+(Confirm section number against existing comments / ECMA-119 PVD clause; if the codebase already cites a different section, use that id consistently.)
+
+- [ ] **Step 2: Tag `DirectoryRecord` (and header if it is the layout carrier)**
+
+```rust
+/// @hadris-spec ECMA-119:9.1
+/// @hadris-compliance full   # or partial + note
+/// @hadris-tests comprehensive_iso::test_directory_record_structure
+/// @hadris-fuzz iso_read
+```
+
+- [ ] **Step 3: Update ISO rows in `docs/spec-coverage.md`**
+
+- [ ] **Step 4: Verify**
+
+Run: `rg -n '@hadris-spec ECMA-119' crates/hadris-iso/src`
+Expected: ≥2 hits.
+
+Run: `RUSTFLAGS='-D warnings' cargo check -p hadris-iso --no-default-features --features 'read,sync'`
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hadris-iso/src/volume.rs crates/hadris-iso/src/directory.rs docs/spec-coverage.md
+git commit -m "$(cat <<'EOF'
+docs(iso): tag PVD and directory record for spec coverage pilot
+
+Link ECMA-119 sections to comprehensive_iso tests and iso_read fuzz.
+EOF
+)"
+```
+
+---
+
+### Task 4: El-Torito — include only if cheap
+
+**Files:**
+- Modify (conditional): `crates/hadris-iso/src/boot.rs` (`BootValidationEntry` and/or `BaseBootCatalog`)
+- Modify (conditional): `docs/spec-coverage.md`
+- Modify: `crates/hadris-iso/spec/Specification.md` (pointer — always do this step even if El-Torito is skipped)
+
+**Decision gate:** If `BootValidationEntry` already has a clear struct + parse path and a nearby test (`xorriso_boot` or unit tests), tag with `@hadris-spec El-Torito:validation` (or the id used in `Booting.md`) as `partial`/`full` with note. If tagging requires inventing tests or large docs, **skip El-Torito** and record “skipped — not cheap” in the PR description.
+
+- [ ] **Step 1: Decide include/skip** after 2-minute skim of `boot.rs` + `tests/xorriso_boot.rs`
+
+- [ ] **Step 2a (include):** Add tags + coverage row; fuzz `iso_read` if applicable
+
+- [ ] **Step 2b (skip):** No code change in `boot.rs`
+
+- [ ] **Step 3: Add pointer at top of `crates/hadris-iso/spec/Specification.md`**
+
+```markdown
+> Maintainer machine-index for implemented sections:
+> [`docs/spec-coverage.md`](../../../docs/spec-coverage.md).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/hadris-iso/spec/Specification.md docs/spec-coverage.md
+# plus boot.rs if tagged
+git commit -m "$(cat <<'EOF'
+docs(iso): link in-repo spec notes to workspace coverage table
+
+Optional El-Torito tags only when the validation entry path is cheap.
+EOF
+)"
+```
+
+---
+
+### Task 5: Tag hadris-fat BPB + LFN
+
+**Files:**
+- Modify: `crates/hadris-fat/src/raw.rs` (`RawBpb` ~line 13, `RawLfnEntry` ~line 281)
+- Modify: `docs/spec-coverage.md` (FAT section)
+
+**Interfaces:**
+- Spec ids: `FAT:BPB`, `FAT:LFN` (stable; Microsoft FAT names already appear as `BPB_*` / `LFN_*` field comments)
+- Tests: `comprehensive_fat::test_valid_sector_sizes`, `test_detect_fat32` (BPB); `comprehensive_fat::test_lfn_builder_sequence`, `test_unicode_filename` (LFN)
+- Fuzz: `fat_read`
+- LFN is feature-gated (`lfn`); note that in compliance/`@hadris-note` if claiming depends on the feature.
+
+**Compliance guidance:**
+- `RawBpb` read validation heavily tested → `full` + `fat_read`.
+- `RawLfnEntry` + builder: if cross-cluster LFN write still unsupported (Known Limitations), use `partial` with note e.g. `cross-cluster LFN runs unsupported on write`.
+
+- [ ] **Step 1: Tag `RawBpb`**
+
+```rust
+/// @hadris-spec FAT:BPB
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_fat::test_valid_sector_sizes
+/// @hadris-fuzz fat_read
+```
+
+- [ ] **Step 2: Tag `RawLfnEntry`**
+
+```rust
+/// @hadris-spec FAT:LFN
+/// @hadris-compliance partial
+/// @hadris-tests comprehensive_fat::test_lfn_builder_sequence
+/// @hadris-fuzz fat_read
+/// @hadris-note cross-cluster LFN directory runs unsupported on write
+```
+
+(Adjust note to match current Known Limitations wording.)
+
+- [ ] **Step 3: Fill FAT rows in `docs/spec-coverage.md`**
+
+- [ ] **Step 4: Verify**
+
+Run: `rg -n '@hadris-spec FAT:' crates/hadris-fat/src/raw.rs`
+Expected: 2 hits.
+
+Run: `RUSTFLAGS='-D warnings' cargo check -p hadris-fat --no-default-features --features 'read,sync,lfn'`
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hadris-fat/src/raw.rs docs/spec-coverage.md
+git commit -m "$(cat <<'EOF'
+docs(fat): tag BPB and LFN entries for spec coverage pilot
+
+Use stable FAT:BPB / FAT:LFN ids and link comprehensive_fat + fat_read.
+EOF
+)"
+```
+
+---
+
+### Task 6: Final sync + v0 acceptance check
+
+**Files:**
+- Modify: `docs/spec-coverage.md` (ensure no stub placeholders remain)
+- Optionally: one-line mention in root `README.md` under contributing — **skip unless** you already touch README; design says internal-first.
+
+- [ ] **Step 1: Inventory tags vs table**
+
+Run:
+
+```bash
+rg -n '@hadris-spec' crates/hadris-udf crates/hadris-iso crates/hadris-fat
+rg -n '^\| ECMA-|^\| FAT:|^\| El-' docs/spec-coverage.md
+```
+
+Expected: every `@hadris-spec` value appears as a table row; every `full` row has Tests or Fuzz; every `partial` row has Notes.
+
+- [ ] **Step 2: Spot-check `full` rule manually**
+
+Run: `rg -n '@hadris-compliance full' -A2 crates/hadris-udf crates/hadris-iso crates/hadris-fat`
+Expected: each block shows `@hadris-tests` and/or `@hadris-fuzz` within the next few lines.
+
+- [ ] **Step 3: Workspace warning check (touched crates)**
+
+Run:
+
+```bash
+RUSTFLAGS='-D warnings' cargo check -p hadris-udf -p hadris-iso -p hadris-fat
+```
+
+Expected: success.
+
+- [ ] **Step 4: Confirm no fuzz CI / no proc-macro**
+
+Run: `rg -n 'cargo fuzz|hadris_spec|spec-coverage' .github/workflows || true`
+Expected: no fuzz job; no new macro.
+
+- [ ] **Step 5: Final commit if table polish needed**
+
+```bash
+git add docs/spec-coverage.md
+git commit -m "$(cat <<'EOF'
+docs: finish Phase E v0 spec-coverage table sync
+
+EOF
+)"
+```
+
+(Skip empty commit if already clean.)
+
+- [ ] **Step 6: Open PR (feature branch → main)** summarizing pilot scope and explicit outs (exFAT, part, cpio, v1 CI).
+
+---
+
+## v0 done checklist (from design §9)
+
+- [ ] Design doc is on the branch / `main`
+- [ ] UDF descriptors tagged
+- [ ] ISO PVD + directory record tagged
+- [ ] FAT BPB + LFN tagged
+- [ ] `docs/spec-coverage.md` filled for those rows
+- [ ] `CONTRIBUTING.md` mentions the convention + fuzz not CI
+- [ ] No fuzz CI job; no proc-macro
+
+**Stop.** Do not start v1 CI checker in this plan.
+
+---
+
+## Self-review (plan author)
+
+1. **Spec coverage:** Maps design §6 pilot (UDF → ISO → FAT → docs) and §9 success criteria; excludes §6.4 outs and v1 tooling.
+2. **Placeholder scan:** Test path strings use real `comprehensive_*` names; implementer must confirm nested `mod` paths when writing tags (filter by test function name if module path is awkward).
+3. **Type consistency:** Spec ids use `ECMA-167:…`, `ECMA-119:…`, `FAT:BPB` / `FAT:LFN` as decided in design §10.
+4. **Ambiguity:** El-Torito is explicitly a cheapness gate (Task 4), not required for v0 done.
+5. **Scope:** Comment + markdown only; no behavior changes expected.

--- a/docs/superpowers/specs/2026-07-09-professionalization-review.md
+++ b/docs/superpowers/specs/2026-07-09-professionalization-review.md
@@ -1,0 +1,374 @@
+# Hadris Whole-Workspace Professionalization Review
+
+**Date:** 2026-07-09
+**Scope:** Entire workspace (libraries, CLIs, meta-crate, CI, fuzz, specs, docs)
+**Method:** Parallel domain deep-dives (FS libs, shared/part core, surface crates, infra/docs), then merge
+**Out of scope this session:** Code/doc fixes, SPEC tooling implementation, GitHub issues
+
+Related prior plan (shared crates only): [`plans/2026-07-09-shared-crates-professionalization.md`](../../../plans/2026-07-09-shared-crates-professionalization.md)
+
+---
+
+## 1. Executive summary (top 10)
+
+| Rank | Sev | Finding | Why it matters |
+|------|-----|---------|----------------|
+| 1 | P0 | Multiple READMEs document **non-existent APIs** (`Fat::open`, `Mbr::read`, `SectorCursor` in `hadris-io`) | First-touch trust failure for crates.io / GitHub visitors |
+| 2 | P0 | Root README version pins `0.2`/`0.3` while workspace is **`1.2.1`**; CHANGELOG `[Unreleased]` empty | Release surface looks abandoned or wrong |
+| 3 | P0 | `hadris-cli` is installable but a **panic-prone stub** (unwrap + debug dump) | Competes with real CLIs; WIP honesty incomplete |
+| 4 | ~~P0~~ | ~~`fuzz/README.md` claims a fuzz CI job~~ — **resolved:** fuzz is documented as local-only (not CI) | — |
+| 5 | P1 | ISO README overclaims **Rock Ridge write** (symlinks / POSIX); `RripOptions` unwired | Spec/marketing mismatch |
+| 6 | P1 | UDF has **no public file-content read**; `UdfDirEntry.size` is placeholder `0`; CLI `cat`/`extract` blocked | Incomplete product surface for a “supported” format |
+| 7 | P1 | CLI naming/UX inconsistent (`fatutil`/`cpioutil` vs `hadris-*-cli`; `ls` vs `list`); **zero CLI tests** | Surface polish lag behind libraries |
+| 8 | P1 | `PartitionError::Io` **discards** underlying I/O error; GPT backup header **silently synthesized** on read failure | Debuggability / correctness honesty |
+| 9 | P1 | Meta-crate / root README claim **“all formats”** but omit UDF (default), `hadris-cd`, `hadris-part` | Umbrella crate oversells |
+| 10 | P1 | In-repo ISO specs WIP; no formal **spec↔test** traceability; async features largely **compile-only** in CI/tests | Hard to claim standards compliance professionally |
+
+**Overall verdict:** Implementation and CI for libraries are strong (feature matrix, Miri, external-tool interop, fuzz harnesses). The main professionalization gap is **surface-layer consistency** — READMEs, version pins, CLI honesty, and process docs that claim jobs/APIs that do not exist.
+
+---
+
+## 2. Cross-cutting themes
+
+### 2.1 Stale and incorrect documentation
+
+Wrong or outdated Quick Starts appear in:
+
+- Root [`README.md`](../../../README.md) — version pins, incomplete crate inventory
+- [`crates/hadris-fat/README.md`](../../../crates/hadris-fat/README.md) — `Fat` vs `FatFs`
+- [`crates/hadris-part/README.md`](../../../crates/hadris-part/README.md) — phantom `Mbr`/`Gpt`
+- [`crates/hadris-io/README.md`](../../../crates/hadris-io/README.md) — phantom `SectorCursor`
+- [`crates/hadris-common/README.md`](../../../crates/hadris-common/README.md) — wrong import paths
+- [`crates/hadris-fat-cli/README.md`](../../../crates/hadris-fat-cli/README.md) — phantom `extract`/`stats`
+- [`crates/hadris-iso-cli/README.md`](../../../crates/hadris-iso-cli/README.md) — incomplete command set / wrong flags
+- [`crates/hadris-udf-cli/README.md`](../../../crates/hadris-udf-cli/README.md) — binary name `hadris-udf` vs `hadris-udf-cli`
+
+Crate-level `//!` rustdoc is often better than READMEs (especially fat/iso/cpio). Prefer regenerating README Quick Starts from working doctests.
+
+### 2.2 API consistency across crates
+
+| Pattern | Mature example | Lagging |
+|---------|----------------|---------|
+| Default features include `read`/`write` | `hadris-fat` | `hadris-part` (`default = ["std"]` only) |
+| Preserve I/O error context | `FatError::Io(...)` | `PartitionError::Io` unit variant |
+| Dual sync/async via macros | FS crates | exFAT outside sync/async; some ISO introspection sync-only |
+| docs.rs feature metadata | `hadris-fat` | part, iso, udf, cpio largely missing |
+| Extension-trait I/O | part (`*ReadExt`) | Discoverability weaker than `open()`-style FS APIs |
+
+### 2.3 Spec traceability
+
+- UDF already tags many structs with `ECMA-167 x/y.z` in module/item docs — best existing pattern.
+- ISO cites `ECMA-119` in places; in-repo [`crates/hadris-iso/spec/`](../../../crates/hadris-iso/spec/) is incomplete and **excluded from crates.io** (`exclude = ["/spec"]`).
+- FAT/CPIO/part rely on informal comments + external references.
+- Tests almost never cite section numbers; compliance is proven via roundtrip / external tools, not a coverage matrix.
+
+### 2.4 Testing maturity skew
+
+| Layer | Strength | Gap |
+|-------|----------|-----|
+| Library unit/integration | Strong (fat/iso/cpio especially) | UDF write→read roundtrip incomplete |
+| External tools | xorriso, fsck.fat, mkudffs (when present) | Not all wired as dedicated CI jobs |
+| Fuzz | Four targets + corpus | Local-only by design (not PR CI) |
+| Miri | Targeted unsafe paths | Scoped by design |
+| Async | Feature flags exist | ~zero async integration tests; CI async tiers thin |
+| CLIs | — | No tests at all |
+
+---
+
+## 3. Finding catalog
+
+Severity: **P0** = blocking trust / wrong public docs; **P1** = API or compliance gap; **P2** = polish.
+Categories: `docs` | `api-ergonomics` | `missing-api` | `spec` | `code-quality` | `tests` | `ci`
+
+### 3.1 Documentation (P0–P2)
+
+| ID | Sev | Cat | Location | Evidence | Suggested follow-up |
+|----|-----|-----|----------|----------|---------------------|
+| D1 | P0 | docs | `crates/hadris-fat/README.md` | Documents `Fat::open`, `root_dir().iter()`, `FatAnalyzer`; real API is `FatFs::open` / `builder`, `entries()` / `next_entry()`, `FatAnalysisExt` | Rewrite Quick Start; add doctests that compile |
+| D2 | P0 | docs | `crates/hadris-part/README.md` | Documents `Mbr::read` / `Gpt::read` and accessors that do not exist | Rewrite against `*ReadExt` / `DiskPartitionScheme` (see shared-crates plan Task 1) |
+| D3 | P0 | docs | `crates/hadris-io/README.md` | Documents `hadris_io::SectorCursor`; type lives in `hadris-fat` | Remove or relocate; sync feature table with `Cargo.toml` |
+| D4 | P0 | docs | Root `README.md` | `hadris-iso = "0.2"`, `hadris-fat = "0.3"`; omits udf/cpio/cd and several CLIs | Bump pins to workspace version; expand inventory |
+| D5 | ~~P0~~ | docs | `fuzz/README.md` | ~~Claims CI fuzz job~~ — **resolved:** local-only workflow documented | — |
+| D6 | P1 | docs | `CHANGELOG.md` | Workspace `1.2.1` but `[Unreleased]` empty; last dated release `1.2.0` | Document 1.2.1 delta or retag |
+| D7 | P1 | docs | `crates/hadris-iso/README.md` + `src/lib.rs` | RRIP write claimed as full POSIX/symlinks; limitations only in `//` comments | Public Limitations section; downgrade claims |
+| D8 | P1 | docs | `crates/hadris-iso/README.md` | `features = ["read"]` as no-alloc bootloader path; high-level `IsoImage` needs `alloc` | Fix feature docs |
+| D9 | P1 | docs | `crates/hadris-common/README.md` | Wrong paths for `U16`/`U32` / endian imports | Match `tests/types_integration.rs` |
+| D10 | P1 | docs | `crates/hadris-common/src/lib.rs` | Claims sync/async “forwarded to hadris-io” but no public re-export | Re-export or fix wording |
+| D11 | P1 | docs | `crates/hadris-part/src/lib.rs` | Calls `read` a “marker feature”; it gates all `*ReadExt` traits | Correct crate docs |
+| D12 | P1 | docs | `crates/hadris-macros/README.md` | One-line README; no `io_transform!` cookbook | Expand from CLAUDE.md + fat/part patterns |
+| D13 | P1 | docs | `crates/hadris` + root README | “All formats” / “all filesystem implementations” overclaim | Feature table: defaults vs optional; mention cd/part |
+| D14 | P1 | docs | `crates/hadris-fat-cli/README.md` | Documents `extract`/`stats`; code has `stat`, no extract | Regenerate from `--help` |
+| D15 | P1 | docs | `crates/hadris-iso-cli/README.md` | Lists 4 commands; code has 8; wrong flag names | Regenerate from `--help` |
+| D16 | P1 | docs | `crates/hadris-udf-cli/README.md` | Examples use `hadris-udf`; binary is `hadris-udf-cli` | Rename bin or fix docs |
+| D17 | P1 | docs | `crates/hadris-udf/README.md` | UDF 2.x “Planned” while writer emits NSR03 for ≥2.00 | Align support matrix with tested write paths |
+| D18 | P2 | docs | Multiple crate READMEs | Stale version pins (`1.0`, `0.2`, …) | Workspace-wide pin sync |
+| D19 | P2 | docs | No `CONTRIBUTING.md` / `CODE_OF_CONDUCT.md` | Contributor workflow lives only in `CLAUDE.md` | Extract public CONTRIBUTING |
+| D20 | P2 | docs | `tests/README.md` | Stub top-level tests dir | Delete or explain purpose |
+| D21 | P2 | docs | No `#![deny(missing_docs)]` | Item docs uneven | Gradual enable per crate |
+
+### 3.2 API ergonomics and missing APIs
+
+| ID | Sev | Cat | Location | Evidence | Suggested follow-up |
+|----|-----|-----|----------|----------|---------------------|
+| A1 | P0 | api-ergonomics | `crates/hadris-cli` | Installable stub with `unwrap()`; no real subcommands | `publish = false` and/or explicit experimental gate; remove install advice until ready |
+| A2 | P1 | missing-api | `hadris-udf` `fs.rs` / `file.rs` | `size = 0; // Placeholder`; `UdfFile` has only `size()`, no read | Populate size from ICB; add `read_file` / `open_file` |
+| A3 | P1 | missing-api | `hadris-iso` write `File` enum | Only file/dir; no symlink/device despite RRIP write claims | Extend input model + wire RRIP |
+| A4 | P1 | api-ergonomics | `hadris-iso` read | Joliet+RRIP written together; reader `best_choice()` picks one root | Document; expose per-namespace roots |
+| A5 | P1 | api-ergonomics | `hadris-iso` | Some introspection APIs sync-only (`read_pvd`, boot sections) | Async parity or document |
+| A6 | P1 | api-ergonomics | `hadris-part` | Default features omit `read`; desktop examples imply read works | Add `read` to default or always show features |
+| A7 | P1 | api-ergonomics | `hadris-part` `error.rs` | `PartitionError::Io` unit; `.map_err(|_| …)` | `Io(hadris_io::Error)` + `source()` |
+| A8 | P1 | api-ergonomics | `hadris-io` | No-std `Error` not full `std::io::Error` parity; under-documented | Document parity matrix in lib.rs/README |
+| A9 | P1 | api-ergonomics | `hadris-fat` exFAT | Public at crate root, not under sync/async codegen | Document intentional split or migrate |
+| A10 | P1 | missing-api | `hadris-fat-cli` | Library has `read_file`, format, exFAT; CLI lacks cat/extract/format | Phase cat/extract then mkfs |
+| A11 | P1 | api-ergonomics | CLI binaries | Mixed names: `fatutil`, `cpioutil`, `hadris-*-cli`; `ls` vs `list` | Workspace CLI convention doc |
+| A12 | P1 | code-quality | `hadris-cd` `writer.rs` | `fs::read(p).unwrap_or_default()` → empty file on failure | Propagate error |
+| A13 | P1 | api-ergonomics | `hadris-cd` | Write-only; no reader/verifier/CLI; weak roundtrip tests | Write→iso+udf reopen tests; optional CLI |
+| A14 | P2 | missing-api | Workspace | No `hadris-cd-cli` | Thin `create` wrapper when CD matures |
+| A15 | P2 | code-quality | iso-cli / udf-cli | Unused `tracing` deps | Remove or wire `--verbose` |
+
+### 3.3 Spec compliance
+
+| ID | Sev | Cat | Location | Evidence | Suggested follow-up |
+|----|-----|-----|----------|----------|---------------------|
+| S1 | P0 | spec | `crates/hadris-iso/spec/Specification.md` | Stops at PVD with `(WIP)`; Booting.md unfinished | Finish or mark planned sections; link from rustdoc |
+| S2 | P1 | spec | ISO RRIP write | Hardcoded modes/uid/gid; `RripOptions` ignored | Wire options or document non-compliance |
+| S3 | P1 | spec | ISO El-Torito write | `// TODO: Create Virtual FAT` for section entries | Implement or document multi-platform limits |
+| S4 | P1 | spec | FAT LFN write | Cross-cluster LFN runs rejected (`DirEntryRunTooLong`) | Implement or document max name vs cluster size |
+| S5 | P1 | spec | exFAT | Fragmented bitmap/upcase → `UnsupportedFatType` | Document hard limits; add fixtures |
+| S6 | P1 | spec | `hadris-part` `scheme_io.rs` | Backup GPT header synthesized on failure without error/flag | Dedicated error or documented fallback |
+| S7 | P2 | spec | UDF | `UnsupportedRevision` never constructed; NSR mapping coarse | Use variant or remove |
+
+### 3.4 Tests and CI
+
+| ID | Sev | Cat | Location | Evidence | Suggested follow-up |
+|----|-----|-----|----------|----------|---------------------|
+| T1 | ~~P0~~ | ci | fuzz vs CI | ~~Missing fuzz CI~~ — **wontfix:** fuzz stays local; PR gate uses unit/integration tests | — |
+| T2 | P1 | tests | `hadris-udf` | No hadris write→`UdfFs::open` roundtrip; write tests admit incomplete read | Add V1_02 / V2_01 roundtrips |
+| T3 | P1 | tests | All `*-cli` crates | Zero `#[test]` | `--help` + one happy path per CLI; `assert_cmd`/`trycmd` |
+| T4 | P1 | tests | `hadris-cd` | `test_basic_writer` only checks `Ok`; no mount/verify | Roundtrip with iso+udf readers |
+| T5 | P1 | ci | Feature matrix | Thin/missing `async` tiers for io/part; clippy may not use `-D warnings` uniformly | Align with CLAUDE.md quality checks |
+| T6 | P2 | tests | FS crates | No async smoke tests despite `async` features | Minimal open/iterate per crate |
+| T7 | P2 | tests | `hadris-part` | No `*ReadExt` I/O tests via `Cursor` | Sync (+ async) Cursor roundtrips |
+| T8 | P2 | ci | Toolchain | No root `rust-toolchain.toml`; no `rust-version` in workspace; CLAUDE claims 1.85+ | Pin MSRV in manifest + toolchain file |
+| T9 | P2 | ci | Governance | No Dependabot; no docs.rs CI job | Weekly cargo/actions; `cargo doc --workspace` |
+| T10 | P2 | docs | docs.rs | Only fat has rich `[package.metadata.docs.rs]` | Mirror for iso/udf/cpio/part |
+
+---
+
+## 4. Per-area summaries
+
+### 4.1 Filesystem libraries
+
+**hadris-iso** — Richest tests and rustdoc; RRIP/Joliet/El-Torito depth. Gaps: overclaimed RRIP write, Joliet+RRIP read selection, sync-only introspection, WIP in-repo spec excluded from crates.io.
+
+**hadris-fat** — Strongest library professionalism (builder, cache/tool, fsck roundtrips, docs.rs). Gaps: **broken README**, LFN cross-cluster limit, exFAT fragmentation limits, exFAT outside dual-async pattern.
+
+**hadris-udf** — Clean descriptor layer and ECMA-167 tags. Gaps: **no file read API**, size placeholder, write→read roundtrip hole, support-matrix messaging lag, dead `UnsupportedRevision`.
+
+**hadris-cpio** — Most honest, focused crate; solid roundtrips and alloc-bomb tests. Gaps: stale version pin, no async tests, no in-repo format notes beyond man-page refs.
+
+### 4.2 Shared / partition core
+
+**hadris-io** — Good lib.rs doctests; README wrong (`SectorCursor`, features). No-std error parity under-documented; async untested in CI.
+
+**hadris-common** — Solid types + Miri coverage; README import paths wrong; “I/O forwarded” overstated.
+
+**hadris-macros** — Critical infrastructure, near-empty README; no edge-case tests for `strip_async!`.
+
+**hadris-part** — Mature on-disk types; P0 README; error context loss; silent backup GPT synthesis; default features omit `read`. Optional `crc`/`rand` deps work as implicit features but are undocumented in `[features]` / README.
+
+### 4.3 Surface crates
+
+| Crate | Verdict |
+|-------|---------|
+| `hadris-iso-cli` | Strongest CLI; docs lag implementation |
+| `hadris-cpio-cli` (`cpioutil`) | Best docs↔code match |
+| `hadris-fat-cli` (`fatutil`) | Good analysis commands; README wrong; missing cat/extract/format |
+| `hadris-udf-cli` | Honest limitations; blocked on library read; binary name mismatch |
+| `hadris-cli` | Not ready; gate or gut |
+| `hadris-cd` | Promising writer; silent empty-file bug; no CLI; weak verification |
+| `hadris` | Convenient umbrella; overclaims “all formats” |
+
+**CLI command parity (abbreviated):**
+
+| Capability | ISO | FAT | CPIO | UDF | CD |
+|------------|-----|-----|------|-----|-----|
+| info | yes | yes | yes | yes | — |
+| ls/list | ls | ls | list | ls | — |
+| tree | yes | yes | — | yes | — |
+| cat | yes | — | yes | lib gap | — |
+| extract | yes | lib ok | yes | lib gap | — |
+| create | yes | lib ok | yes | yes | lib only |
+| verify | yes | yes | — | yes | — |
+
+### 4.4 Infra
+
+**Strengths:** Multi-OS tests, feature-tier `-D warnings` checks, Miri job, pre-commit (fmt/clippy), Keep a Changelog, workspace versioning.
+
+**Gaps (remaining):** ISO in-repo spec incomplete; top-level `tests/` stub; optional CoC.
+**Addressed in Phase D:** MSRV pin, CONTRIBUTING, Dependabot, docs.rs metadata, CLI smoke + doc CI jobs; fuzz explicitly local-only.
+
+---
+
+## 5. Spec-compliance notes
+
+### What “compliant” means today
+
+Compliance is **behavioral**: roundtrip tests and external tools (xorriso, fsck.fat, mkudffs). There is no section-level coverage matrix tying ECMA/Microsoft/cpio(5) clauses to tests.
+
+### Known mismatches / incompleteness
+
+1. **ISO RRIP write** — not a faithful RRIP writer for permissions/symlinks/devices.
+2. **ISO Joliet + RRIP coexistence on read** — single-root selection loses one namespace’s strengths.
+3. **ISO El-Torito** — virtual FAT for non-default section entries unfinished.
+4. **FAT LFN** — cross-cluster directory entry runs unsupported on write.
+5. **exFAT** — fragmented critical metadata unsupported.
+6. **UDF file content** — directory walk without content read; sizes stubbed.
+7. **GPT backup** — failure path invents a header instead of failing closed.
+8. **In-repo ISO spec** — not a usable compliance oracle yet.
+
+### Existing good practice to build on
+
+UDF module docs already look like:
+
+```text
+//! Partition Descriptor (ECMA-167 3/10.5)
+```
+
+ISO has scattered `ECMA-119 9.1`-style comments. Standardizing and linking these to tests is the natural next step (Section 6).
+
+---
+
+## 6. Future: automated compliance suite (design notes only)
+
+**Goal (later session):** Make “we implement §X” auditable — not a full formal verification suite on day one.
+
+### Proposed annotation convention
+
+Build on existing ECMA tags; prefer a machine-grepable prefix:
+
+```rust
+/// @hadris-spec ECMA-167:3/10.5
+/// @hadris-compliance full   // or partial | none | n/a
+/// @hadris-tests comprehensive_udf::partition_descriptor
+/// @hadris-fuzz udf_read
+```
+
+For ISO:
+
+```rust
+// @hadris-spec ECMA-119:9.1
+// @hadris-compliance full
+// @hadris-fuzz iso_read
+```
+
+**Rules of thumb:**
+
+- One primary `@hadris-spec` per on-disk struct or parser entry point.
+- `full` requires at least one `@hadris-tests` **or** `@hadris-fuzz` entry.
+- `partial` requires a one-line note of what is missing (e.g. “symlinks not written”).
+- Do not annotate every helper; annotate **spec-facing** types and public parse/format paths.
+
+### Phased tooling
+
+| Phase | Deliverable | Effort |
+|-------|-------------|--------|
+| v0 | Convention + `rg '@hadris-spec'` → hand-maintained `spec-coverage.md` | Low |
+| v1 | CI check: `full` without tests/fuzz fails | Medium |
+| v2 | Optional proc-macro or build script generating coverage table from annotations | Higher |
+| Later | Golden vectors per section; expand in-repo specs as human-readable index | Ongoing |
+
+### What not to do early
+
+- Do not invent a custom DSL inside comments that needs a parser before any annotations exist.
+- Do not require 100% section coverage before shipping; start with UDF (already tagged) + ISO directory/PVD + FAT BPB/LFN.
+- Do not replace external-tool interop tests — annotations **link** to them.
+
+### Relationship to full test suite
+
+A “full compliance suite” later should combine:
+
+1. Annotation coverage (traceability)
+2. Hand-built / corpus fixtures per section
+3. Existing roundtrip + external-tool jobs
+4. Fuzz corpus promotion for every fixed crash
+
+---
+
+## 7. Recommended workstream order (subsequent sessions)
+
+Ordered for **professional appearance first**, then correctness honesty, then depth.
+
+### Phase A — Release truth (docs only, high ROI)
+
+1. Fix P0 README lies: fat, part, io, root version pins + crate inventory.
+2. Populate CHANGELOG for `1.2.1` or clarify versioning.
+3. Gate/gut `hadris-cli` messaging; document fuzz as local-only (no CI job).
+4. Regenerate CLI READMEs from `--help` (iso, fat, udf binary name).
+
+*Exit:* A new user following any README Quick Start gets compiling examples.
+
+### Phase B — Shared-crate ergonomics
+
+Execute / extend [`plans/2026-07-09-shared-crates-professionalization.md`](../../../plans/2026-07-09-shared-crates-professionalization.md):
+
+- `PartitionError::Io` chaining
+- part default features / docs.rs
+- macros cookbook
+- common/io README accuracy
+- Cursor I/O tests for part
+
+### Phase C — Library honesty + missing APIs
+
+1. ISO Limitations in rustdoc; RRIP options or downgraded claims; Joliet/RRIP read docs.
+2. UDF file read API + size from ICB → unlock CLI cat/extract.
+3. UDF write→read roundtrips; FAT/exFAT limitation docs.
+4. `hadris-cd` error propagation + roundtrip verification.
+
+### Phase D — CI / process polish
+
+1. ~~Fuzz CI job~~ — **dropped:** fuzz remains a local developer tool; docs updated accordingly.
+2. Async feature tiers + CLI smoke tests.
+3. `rust-version` + `rust-toolchain.toml`.
+4. CONTRIBUTING, Dependabot, docs.rs metadata, `cargo doc` CI job.
+
+### Phase E — Spec compliance program
+
+1. Finish or restructure ISO `spec/` with coverage headers.
+2. Pilot `@hadris-spec` on UDF + key ISO/FAT types (v0 markdown table).
+3. Later: CI gate + expanded golden suite.
+
+---
+
+## 8. Strengths to preserve
+
+1. Consistent **no-std + dual sync/async** architecture via `hadris-macros`.
+2. **Security-conscious** parsers (ISO size caps, CPIO alloc_bomb, FAT loop guards, fuzz targets).
+3. **External interoperability** testing where it matters (xorriso, fsck, mkudffs).
+4. **Feature-gated** public surfaces mostly disciplined.
+5. **Miri** scoped to historically unsafe paths with CI enforcement.
+6. Strong crate-level rustdoc on several libraries (better than READMEs — keep that bar).
+7. Existing internal plan for shared crates shows intentional professionalization already underway.
+
+---
+
+## Appendix A — Workspace inventory reviewed
+
+| Member | Role |
+|--------|------|
+| hadris-io, hadris-common, hadris-macros | Shared foundation |
+| hadris-part | MBR/GPT/hybrid |
+| hadris-iso, hadris-fat, hadris-udf, hadris-cpio | Filesystems / archives |
+| hadris-cd | Hybrid ISO+UDF writer |
+| hadris | Meta re-exports |
+| hadris-iso-cli, hadris-fat-cli, hadris-cpio-cli, hadris-udf-cli, hadris-cli | CLIs |
+| fuzz/, .github/workflows/, .pre-commit-config.yaml | Quality infra |
+| crates/hadris-iso/spec/, CHANGELOG, READMEs, CLAUDE.md | Docs / specs |
+
+## Appendix B — Rubric
+
+| Field | Meaning |
+|-------|---------|
+| Severity | P0 blocking trust / wrong docs; P1 API or compliance gap; P2 polish |
+| Category | docs, api-ergonomics, missing-api, spec, code-quality, tests, ci |
+| Suggested follow-up | Later session workstream — not implemented in this review |

--- a/docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md
+++ b/docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md
@@ -1,0 +1,275 @@
+# Spec Compliance Program (Phase E) — Design
+
+**Date:** 2026-07-09
+**Status:** Design approved; implementation deferred
+**Parent review:** [`2026-07-09-professionalization-review.md`](./2026-07-09-professionalization-review.md) (§6 / Phase E)
+**Approach:** Comment tags only (no proc-macro in v0/v1)
+
+---
+
+## 1. Problem
+
+Hadris already cites standards in places (especially UDF `ECMA-167 …` module docs and scattered ISO `ECMA-119` comments), and proves behavior with roundtrips, external-tool interop, and local fuzz corpora. What is missing is **traceability**: a maintainer cannot quickly answer “do we implement §X, how completely, and which test proves it?”
+
+Phase E adds a lightweight compliance program — not formal verification — so claims stay honest and gaps stay visible.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals (v0 — first implementation pass)
+
+1. **Maintainer traceability first.** Annotate spec-facing types/parsers so `rg '@hadris-spec'` answers “where is §X?”
+2. **Single workspace index.** Hand-maintain [`docs/spec-coverage.md`](../../spec-coverage.md) (created during implementation) as the audit table for all crates.
+3. **Pilot, not completeness.** Tag UDF descriptors (already ECMA-titled) plus key ISO and FAT surfaces; leave full section coverage for later.
+4. **Fuzz stays local.** Annotations may *link* fuzz targets; CI never runs fuzz (see Phase D decision).
+
+### Goals (v1 — designed now, implement after v0)
+
+1. CI fails when `@hadris-compliance full` lacks `@hadris-tests` or `@hadris-fuzz`.
+2. Optionally fail when an annotated `@hadris-spec` is missing from `docs/spec-coverage.md` (or the reverse).
+
+### Non-goals
+
+- Formal verification or 100% standards coverage before shipping.
+- A custom comment DSL / parser before a useful set of annotations exists.
+- Replacing roundtrip / external-tool tests — annotations **point at** them.
+- A public marketing “compliance matrix” in v0 (the table may be promoted later).
+- Full rewrite of `crates/hadris-iso/spec/` in v0 (pointer + light headers only if useful).
+- Proc-macros or build-script table generation in v0/v1 (possible v2).
+
+---
+
+## 3. Design principles
+
+1. **Grepable over clever.** Tags are plain text in rustdoc/`//` comments; tooling is `rg` then a small script.
+2. **Spec-facing only.** Annotate on-disk structs and public parse/format entry points, not every helper.
+3. **Honesty over green cells.** Prefer `partial` + `@hadris-note` over claiming `full`.
+4. **Link existing evidence.** Prefer naming tests and fuzz targets that already exist; add tests only when a `full` claim needs them.
+5. **One index.** Workspace table in `docs/`; crate READMEs may later link to it, not fork it.
+
+---
+
+## 4. Annotation grammar
+
+Place tags immediately under the human-readable title (keep existing `ECMA-…` prose).
+
+```rust
+/// Partition Descriptor (ECMA-167 3/10.5)
+///
+/// @hadris-spec ECMA-167:3/10.5
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_udf::partition_descriptor
+/// @hadris-fuzz udf_read
+```
+
+ISO / FAT example:
+
+```rust
+/// Directory Record (ECMA-119 9.1)
+///
+/// @hadris-spec ECMA-119:9.1
+/// @hadris-compliance partial
+/// @hadris-tests directory::parse_roundtrip
+/// @hadris-note RRIP write ignores RripOptions
+```
+
+### Tag reference
+
+| Tag | Required? | Format / values |
+|-----|-----------|-----------------|
+| `@hadris-spec` | yes | `DOC:section` — e.g. `ECMA-167:3/10.5`, `ECMA-119:9.1`. When no ECMA section applies, use a short stable id (`FAT:BPB`, `FAT:LFN`, `UEFI:GPT`). |
+| `@hadris-compliance` | yes | `full` \| `partial` \| `none` \| `n/a` |
+| `@hadris-tests` | if claiming `full` (unless fuzz used) | Rust path: `module::test_name` or integration test identity maintainers can `cargo test` |
+| `@hadris-fuzz` | optional | Target name under `fuzz/` (documentation link only) |
+| `@hadris-note` | if `partial` | One-line gap description |
+
+### Rules
+
+1. One primary `@hadris-spec` per annotated item.
+2. `full` ⇒ at least one of `@hadris-tests` or `@hadris-fuzz`.
+3. `partial` ⇒ `@hadris-note` required.
+4. `none` = known unimplemented at this site; `n/a` = not applicable for this crate/feature.
+5. Do not invent a richer mini-language (no nested JSON in comments, no multi-line structured blocks beyond one tag per line).
+
+### What to annotate
+
+| Annotate | Skip |
+|----------|------|
+| On-disk `#[repr(C)]` / Pod structs that mirror a standard layout | Private helpers, iterators, CLI glue |
+| Public `parse` / `read_*` / `write_*` entry points for those layouts | Purely mechanical endian wrappers unless they *are* the spec type |
+| Feature-gated paths that change compliance (document with `partial`/`n/a`) | Every call site of an already-annotated type |
+
+---
+
+## 5. Coverage table (`docs/spec-coverage.md`)
+
+Created during v0 implementation. Hand-maintained; regenerated only by humans after `rg '@hadris-spec'`.
+
+Suggested shape:
+
+```markdown
+# Spec coverage
+
+Maintainer audit index for standards-facing types. See
+`docs/superpowers/specs/2026-07-09-spec-compliance-program-design.md`.
+
+Update: `rg '@hadris-spec' crates/` then sync this table.
+
+## hadris-udf
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| ECMA-167:3/10.5 | `PartitionDescriptor` | full | `…` | `udf_read` | |
+
+## hadris-iso
+…
+
+## hadris-fat
+…
+```
+
+**v0 drift policy:** Slight lag between code tags and the table is acceptable; fix when touching the area or before cutting a release that cites the table. v1 may enforce sync.
+
+**Public use:** Not linked from crate READMEs in v0 unless a later pass promotes it. Internal / contributor-facing first.
+
+---
+
+## 6. Pilot scope (v0 deliverables)
+
+Ordered for reuse of existing ECMA titles and high-traffic parsers.
+
+### 6.1 hadris-udf (first)
+
+Add tags to descriptor modules under `crates/hadris-udf/src/descriptor/` (anchor, partition, primary, logical, fileset, tag, …) and any other already-titled ECMA-167 items that are parse entry points.
+
+Populate the UDF section of `docs/spec-coverage.md`.
+
+### 6.2 hadris-iso
+
+Minimum:
+
+- Primary Volume Descriptor (`PrimaryVolumeDescriptor` / volume path)
+- Directory Record (`DirectoryRecord`)
+- El-Torito catalog / boot entry **only if** a clear type already exists and tagging is cheap
+
+Optional light touch: one-line pointer from `crates/hadris-iso/spec/Specification.md` (or README in that folder) to `docs/spec-coverage.md`. No full rewrite of in-repo ISO markdown specs in v0.
+
+### 6.3 hadris-fat
+
+Minimum:
+
+- BPB / boot sector layout (`FAT:BPB` or Microsoft/FAT section id if already cited)
+- LFN directory entry path (`FAT:LFN`)
+
+### 6.4 Explicitly out of pilot
+
+- Deep exFAT metadata
+- Full RRIP write compliance matrix (may appear as a single `partial` row)
+- GPT/MBR (`hadris-part`) and CPIO — add later as separate table sections
+- Golden vector suite per section (post-v1 “later”)
+
+### 6.5 Docs / process touchpoints
+
+- Short subsection in `CONTRIBUTING.md`: when to add tags; how to update the table; fuzz remains local.
+- Pointer from the professionalization review Phase E to this design (done when this file lands).
+- Do **not** add a fuzz CI job.
+
+---
+
+## 7. Tooling roadmap
+
+| Version | Deliverable | When |
+|---------|-------------|------|
+| **v0** | Convention (this doc) + pilot annotations + hand-maintained `docs/spec-coverage.md` + CONTRIBUTING blurb | First Phase E implementation session |
+| **v1** | CI check: `full` without tests/fuzz fails; optional table↔annotation sync | After pilot has enough tags to be useful |
+| **v2** | Optional generator (script preferred over proc-macro) that emits or checks the markdown table | Only if hand sync becomes painful |
+| **Later** | Golden vectors per section; richer in-repo human specs as an index into the same ids | Ongoing |
+
+### v1 CI sketch (not implemented in v0)
+
+- Input: `rg -n '@hadris-' crates/` (or a tiny Python/shell scanner).
+- Group consecutive tags belonging to one item (comment block above an `fn`/`struct`).
+- Fail if any block has `@hadris-compliance full` and neither `@hadris-tests` nor `@hadris-fuzz`.
+- Fail if any block has `@hadris-compliance partial` without `@hadris-note`.
+- Optional: every `@hadris-spec` value appears in `docs/spec-coverage.md`.
+- **Never** invoke `cargo fuzz` in CI.
+
+Keep the checker dumb: line-oriented tags, no AST. If that proves too fragile, escalate to v2 — still prefer a script over a proc-macro.
+
+---
+
+## 8. Relationship to the rest of the test pyramid
+
+A mature compliance story combines:
+
+1. **Annotation coverage** (this program) — traceability
+2. **Unit / integration tests** named by `@hadris-tests`
+3. **External-tool interop** (xorriso, fsck, mkudffs, …) — unchanged
+4. **Fuzz corpus promotion** for fixed crashes — local discovery, PR gate via normal tests
+5. **Golden vectors per section** — later, keyed by the same `@hadris-spec` ids
+
+Annotations do not replace (2)–(4); they make them findable from the standard section.
+
+---
+
+## 9. Success criteria
+
+**v0 is done when:**
+
+1. This design is the agreed source of truth (this file).
+2. UDF pilot descriptors are tagged; ISO PVD + directory record and FAT BPB + LFN are tagged.
+3. `docs/spec-coverage.md` exists with those rows and a short “how to update” header.
+4. `CONTRIBUTING.md` mentions the convention and that fuzz is not CI.
+5. No CI job runs fuzz; no proc-macro added.
+
+**v1 is done when:**
+
+1. A CI job or script enforces the `full` / `partial` tag rules above.
+2. Failures are actionable (print file:line and missing tag).
+
+---
+
+## 10. Open questions (defer until implementation)
+
+Resolved for design; revisit only if implementation hits friction:
+
+| Topic | Decision |
+|-------|----------|
+| Optimize for | Maintainer audit first; public matrix later |
+| Table location | `docs/spec-coverage.md` |
+| Tooling depth in first pass | v0 ship; v1 designed |
+| Mechanism | Comment tags only |
+| Spec id for FAT | Prefer existing citations; else stable `FAT:BPB` / `FAT:LFN` |
+
+Still open at implementation time (not blocking this design):
+
+- Exact test path strings for each pilot row (discover while tagging).
+- Whether El-Torito is in or out of the ISO pilot (default: in only if cheap).
+- Whether v1 table sync is required or optional on first CI landing.
+
+---
+
+## 11. Implementation outline (for a later session)
+
+Do **not** start this until Phase E is scheduled. Suggested order:
+
+1. Add `docs/spec-coverage.md` stub + CONTRIBUTING blurb.
+2. Tag UDF descriptors; fill UDF table rows.
+3. Tag ISO PVD + directory record; fill rows.
+4. Tag FAT BPB + LFN; fill rows.
+5. Optional: pointer from `crates/hadris-iso/spec/`.
+6. Stop. Schedule v1 CI checker separately.
+
+---
+
+## Appendix A — Mapping from review §6
+
+| Review note | This design |
+|-------------|-------------|
+| `@hadris-spec` convention | §4 |
+| v0 hand table | §5 → `docs/spec-coverage.md` |
+| v1 CI for `full` | §7 |
+| Start UDF + ISO PVD/dir + FAT BPB/LFN | §6 |
+| No early custom DSL / no 100% coverage | §2 non-goals |
+| Fuzz not CI | §2, §7 |


### PR DESCRIPTION
## Summary
- Scaffold `docs/spec-coverage.md`, CONTRIBUTING annotation guide, and commit the Phase E design/plan
- Tag UDF ECMA-167 descriptors, ISO PVD/directory/El-Torito validation, and FAT BPB/LFN with `@hadris-spec` links to existing tests/fuzz
- Point `crates/hadris-iso/spec/Specification.md` at the workspace coverage table

## Out of scope (by design)
- exFAT, GPT/MBR, CPIO, full RRIP write matrix
- v1 CI tag checker / table generator
- Fuzz CI (remains local-only)

## Test plan
- [x] `rg '@hadris-spec' crates/hadris-{udf,iso,fat}`
- [x] Every `full` has `@hadris-tests` and/or `@hadris-fuzz`
- [x] `RUSTFLAGS='-D warnings' cargo check -p hadris-udf --no-default-features --features 'read,sync'`
- [x] `RUSTFLAGS='-D warnings' cargo check -p hadris-fat --no-default-features --features 'read,sync,lfn'`
- [x] CI green on this PR
- Note: `hadris-iso` no-std `-D warnings` currently fails on `main` with pre-existing dead_code in `path.rs` (unrelated to comment tags)


Made with [Cursor](https://cursor.com)