### PR TITLE
test: vertical slices for UDF partition + ISO directory record

### DIFF
--- a/crates/hadris-iso/src/directory.rs
+++ b/crates/hadris-iso/src/directory.rs
@@ -9,7 +9,7 @@ use crate::types::{U16LsbMsb, U32LsbMsb};
 ///
 /// @hadris-spec ECMA-119:9.1
 /// @hadris-compliance full
-/// @hadris-tests comprehensive_iso::test_directory_record_structure
+/// @hadris-tests directory::tests::directory_record_parse_roundtrip
 /// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
@@ -63,7 +63,7 @@ impl DirectoryRecordHeader {
 ///
 /// @hadris-spec ECMA-119:9.1
 /// @hadris-compliance partial
-/// @hadris-tests comprehensive_iso::test_directory_record_structure
+/// @hadris-tests directory::tests::directory_record_parse_roundtrip
 /// @hadris-fuzz iso_read
 /// @hadris-note Joliet+RRIP coexistence on read may hide one namespace; see crate Known Limitations
 #[repr(transparent)]
@@ -284,6 +284,71 @@ impl DirDateTime {
 pub struct DirectoryRef {
     pub extent: LogicalSector,
     pub size: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use std::io::Cursor;
+
+    /// Vertical slice for ECMA-119:9.1 — parse `.` / `..` records from a sector.
+    #[test]
+    fn directory_record_parse_roundtrip() {
+        // Minimal root directory sector (same layout as comprehensive_iso helper)
+        let mut dir = vec![0u8; 2048];
+        let mut offset = 0usize;
+        for (id, flags) in [(0x00u8, 0x02u8), (0x01u8, 0x02u8)] {
+            dir[offset] = 34;
+            dir[offset + 2..offset + 6].copy_from_slice(&20u32.to_le_bytes());
+            dir[offset + 6..offset + 10].copy_from_slice(&20u32.to_be_bytes());
+            dir[offset + 10..offset + 14].copy_from_slice(&2048u32.to_le_bytes());
+            dir[offset + 14..offset + 18].copy_from_slice(&2048u32.to_be_bytes());
+            dir[offset + 25] = flags;
+            dir[offset + 28..offset + 30].copy_from_slice(&1u16.to_le_bytes());
+            dir[offset + 30..offset + 32].copy_from_slice(&1u16.to_be_bytes());
+            dir[offset + 32] = 1;
+            dir[offset + 33] = id;
+            offset += 34;
+        }
+
+        let mut cursor = Cursor::new(&dir[..]);
+        let dot = DirectoryRecord::parse(&mut cursor).expect("parse .");
+        assert_eq!(dot.size(), 34);
+        assert_eq!(core::mem::size_of::<DirectoryRecordHeader>(), 33);
+        assert!(dot.is_directory());
+        assert_eq!(dot.name(), b"\x00");
+        assert_eq!(dot.header().extent.read(), 20);
+        assert_eq!(dot.header().data_len.read(), 2048);
+
+        let dotdot = DirectoryRecord::parse(&mut cursor).expect("parse ..");
+        assert_eq!(dotdot.name(), b"\x01");
+        assert!(dotdot.is_special());
+
+        // new() + write/parse roundtrip for a file identifier
+        let made = DirectoryRecord::new(
+            b"README.;1",
+            &[],
+            DirectoryRef {
+                extent: LogicalSector(42),
+                size: 100,
+            },
+            FileFlags::empty(),
+        );
+        assert!(made.size() >= 33 + b"README.;1".len());
+        assert!(!made.is_directory());
+        assert_eq!(made.name(), b"README.;1");
+        assert_eq!(made.header().extent.read(), 42);
+
+        let mut out = Vec::new();
+        made.write(&mut out).expect("write");
+        let mut round = Cursor::new(&out[..]);
+        let parsed = DirectoryRecord::parse(&mut round).expect("re-parse");
+        assert_eq!(parsed.name(), made.name());
+        assert_eq!(parsed.size(), made.size());
+        assert_eq!(parsed.header().extent.read(), 42);
+    }
 }
 
 bitflags::bitflags! {

--- a/crates/hadris-udf/src/descriptor/partition.rs
+++ b/crates/hadris-udf/src/descriptor/partition.rs
@@ -7,7 +7,7 @@ use crate::error::UdfResult;
 ///
 /// @hadris-spec ECMA-167:3/10.5
 /// @hadris-compliance full
-/// @hadris-tests comprehensive_udf::test_partition_contents
+/// @hadris-tests descriptor::partition::tests::partition_descriptor_layout_and_validate
 /// @hadris-fuzz udf_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -89,4 +89,69 @@ mod tests {
     use super::*;
 
     static_assertions::const_assert_eq!(size_of::<PartitionDescriptor>(), 512);
+
+    fn tag_with_checksum(identifier: TagIdentifier, location: u32) -> DescriptorTag {
+        let mut tag = DescriptorTag {
+            tag_identifier: identifier.to_u16(),
+            descriptor_version: 2,
+            tag_checksum: 0,
+            reserved: 0,
+            tag_serial_number: 0,
+            descriptor_crc: 0,
+            descriptor_crc_length: 0,
+            tag_location: location,
+        };
+        let bytes = bytemuck::bytes_of(&tag);
+        let mut sum: u8 = 0;
+        for (i, &byte) in bytes.iter().enumerate() {
+            if i != 4 {
+                sum = sum.wrapping_add(byte);
+            }
+        }
+        tag.tag_checksum = sum;
+        tag
+    }
+
+    fn entity_id(id: &[u8]) -> EntityIdentifier {
+        let mut entity = EntityIdentifier::EMPTY;
+        entity.identifier[..id.len()].copy_from_slice(id);
+        entity
+    }
+
+    /// Vertical slice for ECMA-167:3/10.5 — layout, validate, contents helpers.
+    #[test]
+    fn partition_descriptor_layout_and_validate() {
+        let location = 20u32;
+        let mut desc = PartitionDescriptor {
+            tag: tag_with_checksum(TagIdentifier::PartitionDescriptor, location),
+            vds_number: 1,
+            partition_flags: 0x0001,
+            partition_number: 0,
+            partition_contents: entity_id(b"+NSR03"),
+            partition_contents_use: [0; 128],
+            access_type: 1,
+            partition_starting_location: 0,
+            partition_length: 1000,
+            implementation_identifier: EntityIdentifier::EMPTY,
+            implementation_use: [0; 128],
+            reserved: [0; 156],
+        };
+
+        assert_eq!(core::mem::size_of_val(&desc), 512);
+        assert!(desc.validate(location).is_ok());
+        assert!(desc.is_allocated());
+        assert_eq!(desc.contents_type(), PartitionContents::Nsr03);
+
+        // Wrong tag id fails closed
+        desc.tag.tag_identifier = TagIdentifier::PrimaryVolumeDescriptor.to_u16();
+        let bytes = bytemuck::bytes_of(&desc.tag);
+        let mut sum: u8 = 0;
+        for (i, &byte) in bytes.iter().enumerate() {
+            if i != 4 {
+                sum = sum.wrapping_add(byte);
+            }
+        }
+        desc.tag.tag_checksum = sum;
+        assert!(desc.validate(location).is_err());
+    }
 }

--- a/crates/hadris-udf/src/descriptor/partition.rs
+++ b/crates/hadris-udf/src/descriptor/partition.rs
@@ -113,6 +113,11 @@ mod tests {
     }
 
     fn entity_id(id: &[u8]) -> EntityIdentifier {
+        assert!(
+            id.len() <= 23,
+            "EntityIdentifier::identifier is 23 bytes; got {}",
+            id.len()
+        );
         let mut entity = EntityIdentifier::EMPTY;
         entity.identifier[..id.len()].copy_from_slice(id);
         entity
@@ -143,15 +148,7 @@ mod tests {
         assert_eq!(desc.contents_type(), PartitionContents::Nsr03);
 
         // Wrong tag id fails closed
-        desc.tag.tag_identifier = TagIdentifier::PrimaryVolumeDescriptor.to_u16();
-        let bytes = bytemuck::bytes_of(&desc.tag);
-        let mut sum: u8 = 0;
-        for (i, &byte) in bytes.iter().enumerate() {
-            if i != 4 {
-                sum = sum.wrapping_add(byte);
-            }
-        }
-        desc.tag.tag_checksum = sum;
+        desc.tag = tag_with_checksum(TagIdentifier::PrimaryVolumeDescriptor, location);
         assert!(desc.validate(location).is_err());
     }
 }

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -26,7 +26,7 @@ Fuzz columns name targets under `fuzz/` (local only — not PR CI).
 | ECMA-167:4/14.14.1 | `ShortAllocationDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
 | ECMA-167:3/10.2 | `AnchorVolumeDescriptorPointer` | full | `comprehensive_udf::test_avdp_structure` | `udf_read` | |
 | ECMA-167:3/10.1 | `PrimaryVolumeDescriptor` | full | | `udf_read` | |
-| ECMA-167:3/10.5 | `PartitionDescriptor` | full | `comprehensive_udf::test_partition_contents` | `udf_read` | |
+| ECMA-167:3/10.5 | `PartitionDescriptor` | full | `descriptor::partition::tests::partition_descriptor_layout_and_validate` | `udf_read` | Vertical-slice unit test |
 | ECMA-167:3/10.6 | `LogicalVolumeDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
 | ECMA-167:3/10.7.2 | `Type1PartitionMap` | full | `descriptor::logical::tests::type1_partition_maps_parses_embedded_table` | `udf_read` | |
 | ECMA-167:4/14.1 | `FileSetDescriptor` | full | `comprehensive_udf::test_allocation_descriptor_sizes` | `udf_read` | |
@@ -36,8 +36,8 @@ Fuzz columns name targets under `fuzz/` (local only — not PR CI).
 | Spec | Item | Compliance | Tests | Fuzz | Notes |
 |------|------|------------|-------|------|-------|
 | ECMA-119:8.4 | `PrimaryVolumeDescriptor` | full | `comprehensive_iso::test_pvd_standard_identifier` | `iso_read` | |
-| ECMA-119:9.1 | `DirectoryRecordHeader` | full | `comprehensive_iso::test_directory_record_structure` | `iso_read` | Fixed fields of the directory record |
-| ECMA-119:9.1 | `DirectoryRecord` | partial | `comprehensive_iso::test_directory_record_structure` | `iso_read` | Joliet+RRIP coexistence on read may hide one namespace |
+| ECMA-119:9.1 | `DirectoryRecordHeader` | full | `directory::tests::directory_record_parse_roundtrip` | `iso_read` | Fixed fields; covered by parse roundtrip |
+| ECMA-119:9.1 | `DirectoryRecord` | partial | `directory::tests::directory_record_parse_roundtrip` | `iso_read` | Joliet+RRIP coexistence on read may hide one namespace |
 | El-Torito:validation | `BootValidationEntry` | full | `xorriso_boot::test_eltorito_boot_catalog_comparison` | `iso_read` | |
 
 ## hadris-fat


### PR DESCRIPTION
## Summary
- Prove Phase E tags are not aspirational for two pilot rows:
  - **UDF** `ECMA-167:3/10.5` `PartitionDescriptor` — layout, checksum validate, contents helpers
  - **ISO** `ECMA-119:9.1` `DirectoryRecord` — parse `.`/`..`, `new`+write/parse roundtrip
- Update `@hadris-tests` + `docs/spec-coverage.md` to the real unit-test paths

## Test plan
- [x] `cargo test -p hadris-udf --lib partition_descriptor_layout_and_validate`
- [x] `cargo test -p hadris-iso --lib directory_record_parse_roundtrip`
- [x] `RUSTFLAGS='-D warnings' cargo check -p hadris-udf -p hadris-iso`
- [x] CI green


Made with [Cursor](https://cursor.com)