### PR TITLE
feat(io): redesign portable io errors and adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
 name = "endian-num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,25 +445,13 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.2.0",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core",
 ]
 
@@ -548,6 +551,8 @@ version = "1.2.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
+ "embedded-io",
+ "embedded-io-async",
 ]
 
 [[package]]
@@ -879,12 +884,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -896,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
+ "getrandom",
  "rand_core",
 ]
 
@@ -1087,7 +1086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1215,15 +1214,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -1443,15 +1433,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.13.0",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ static_assertions = "1.1.0"
 criterion = "0.5.1"
 thiserror = { version = "2.0.12", default-features = false }
 cfg-if = "1.0.0"
+embedded-io = { version = "0.7", default-features = false }
+embedded-io-async = { version = "0.7", default-features = false }
 tempfile = "3.19.1"
 chrono = { version = "0.4.40", default-features = false }
 tracing = "0.1.41"

--- a/crates/hadris-cd/src/layout.rs
+++ b/crates/hadris-cd/src/layout.rs
@@ -150,7 +150,9 @@ impl LayoutManager {
     fn assign_file_extents(&mut self, dir: &mut Directory) -> CdResult<()> {
         // Assign extents to files
         for file in &mut dir.files {
-            let size = file.size().map_err(CdError::Io)?;
+            let size = file
+                .size()
+                .map_err(|error| CdError::Io(hadris_io::Error::from_source(error).erase()))?;
 
             if size == 0 {
                 // Zero-size files have no extent (sector 0 per ISO spec)

--- a/crates/hadris-cd/src/lib.rs
+++ b/crates/hadris-cd/src/lib.rs
@@ -71,7 +71,7 @@ pub mod tree;
 #[path = ""]
 pub mod sync {
     pub use hadris_io::SeekFrom;
-    pub use hadris_io::sync::{Read, Seek, Write};
+    pub use hadris_io::sync::{Borrowed, Read, Seek, Write};
 
     macro_rules! io_transform {
         ($($item:tt)*) => { hadris_macros::strip_async!{ $($item)* } };
@@ -105,7 +105,7 @@ pub mod sync {
 #[path = ""]
 pub mod r#async {
     pub use hadris_io::SeekFrom;
-    pub use hadris_io::r#async::{Read, Seek, Write};
+    pub use hadris_io::r#async::{Borrowed, Read, Seek, Write};
 
     macro_rules! io_transform {
         ($($item:tt)*) => { $($item)* };

--- a/crates/hadris-cd/src/writer.rs
+++ b/crates/hadris-cd/src/writer.rs
@@ -74,7 +74,10 @@ impl<W: Read + Write + Seek> CdWriter<W> {
 
             // Seek to the file's assigned sector
             let offset = (file.extent.sector as u64) * self.options.sector_size as u64;
-            self.writer.seek(SeekFrom::Start(offset)).await?;
+            self.writer
+                .seek(SeekFrom::Start(offset))
+                .await
+                .map_err(hadris_io::Error::erase)?;
 
             // Write the file data
             match &file.data {
@@ -143,7 +146,10 @@ impl<W: Read + Write + Seek> CdWriter<W> {
         };
 
         // Reset position and write ISO
-        self.writer.seek(SeekFrom::Start(0)).await?;
+        self.writer
+            .seek(SeekFrom::Start(0))
+            .await
+            .map_err(hadris_io::Error::erase)?;
         IsoImageWriter::format_new(
             Borrowed::new(&mut self.writer),
             input_files,

--- a/crates/hadris-cd/src/writer.rs
+++ b/crates/hadris-cd/src/writer.rs
@@ -7,7 +7,7 @@
 //! 4. Writing UDF metadata
 //! 5. Finalizing the image
 
-use super::super::{Read, Seek, SeekFrom, Write};
+use super::super::{Borrowed, Read, Seek, SeekFrom, Write};
 
 use hadris_iso::read::PathSeparator;
 use hadris_udf::descriptor::{
@@ -16,7 +16,7 @@ use hadris_udf::descriptor::{
 use hadris_udf::write::{UdfWriteOptions, UdfWriter};
 use hadris_udf::{FileType, SECTOR_SIZE as UDF_SECTOR_SIZE};
 
-use crate::error::{CdError, CdResult};
+use crate::error::CdResult;
 use crate::layout::{LayoutInfo, LayoutManager};
 use crate::options::CdOptions;
 use crate::tree::{Directory, FileData, FileTree};
@@ -82,7 +82,8 @@ impl<W: Read + Write + Seek> CdWriter<W> {
                     self.writer.write_all(data).await?;
                 }
                 FileData::Path(path) => {
-                    let data = std::fs::read(path)?;
+                    let data = std::fs::read(path)
+                        .map_err(|error| hadris_io::Error::from_source(error).erase())?;
                     self.writer.write_all(&data).await?;
                 }
             }
@@ -143,7 +144,11 @@ impl<W: Read + Write + Seek> CdWriter<W> {
 
         // Reset position and write ISO
         self.writer.seek(SeekFrom::Start(0)).await?;
-        IsoImageWriter::format_new(&mut self.writer, input_files, format_options)?;
+        IsoImageWriter::format_new(
+            Borrowed::new(&mut self.writer),
+            input_files,
+            format_options,
+        )?;
 
         Ok(())
     }
@@ -155,12 +160,8 @@ impl<W: Read + Write + Seek> CdWriter<W> {
         for file in &dir.files {
             let data = match &file.data {
                 FileData::Buffer(b) => b.clone(),
-                FileData::Path(p) => std::fs::read(p).map_err(|e| {
-                    CdError::Io(std::io::Error::new(
-                        e.kind(),
-                        format!("failed to read {}: {e}", p.display()),
-                    ))
-                })?,
+                FileData::Path(p) => std::fs::read(p)
+                    .map_err(|error| hadris_io::Error::from_source(error).erase())?,
             };
             files.push(hadris_iso::write::File::File {
                 name: file.name.clone(),
@@ -187,7 +188,7 @@ impl<W: Read + Write + Seek> CdWriter<W> {
             partition_length: layout_info.udf_partition_length(),
         };
 
-        let mut udf_writer = UdfWriter::new(&mut self.writer, udf_options);
+        let mut udf_writer = UdfWriter::new(Borrowed::new(&mut self.writer), udf_options);
 
         // Write Volume Recognition Sequence
         udf_writer.write_vrs()?;

--- a/crates/hadris-cpio/src/error.rs
+++ b/crates/hadris-cpio/src/error.rs
@@ -63,9 +63,9 @@ impl fmt::Display for CpioError {
 #[cfg(feature = "std")]
 impl std::error::Error for CpioError {}
 
-impl From<hadris_io::Error> for CpioError {
-    fn from(e: hadris_io::Error) -> Self {
-        Self::Io(e)
+impl<E: hadris_io::IoError> From<hadris_io::Error<E>> for CpioError {
+    fn from(e: hadris_io::Error<E>) -> Self {
+        Self::Io(e.erase())
     }
 }
 

--- a/crates/hadris-fat/src/dir.rs
+++ b/crates/hadris-fat/src/dir.rs
@@ -223,12 +223,12 @@ impl<DATA: Read + Seek> FatDirIter<'_, DATA> {
                     };
 
                     if let Err(e) = data.seek(SeekFrom::Start(seek_pos)).await {
-                        return Some(Err(FatError::Io(e)));
+                        return Some(Err(FatError::Io(e.erase())));
                     }
 
                     let mut buffer = alloc::vec![0u8; buffer_size];
                     if let Err(e) = data.read_exact(&mut buffer).await {
-                        return Some(Err(FatError::Io(e)));
+                        return Some(Err(FatError::Io(e.erase())));
                     }
 
                     self.cluster_buffer = Some(buffer);
@@ -608,12 +608,12 @@ impl<DATA: Read + Seek> Iterator for FatDirIter<'_, DATA> {
                     };
 
                     if let Err(e) = data.seek(SeekFrom::Start(seek_pos)) {
-                        return Some(Err(FatError::Io(e)));
+                        return Some(Err(FatError::Io(e.erase())));
                     }
 
                     let mut buffer = alloc::vec![0u8; buffer_size];
                     if let Err(e) = data.read_exact(&mut buffer) {
-                        return Some(Err(FatError::Io(e)));
+                        return Some(Err(FatError::Io(e.erase())));
                     }
 
                     self.cluster_buffer = Some(buffer);

--- a/crates/hadris-fat/src/error.rs
+++ b/crates/hadris-fat/src/error.rs
@@ -339,9 +339,9 @@ impl fmt::Display for FatError {
 #[cfg(feature = "std")]
 impl std::error::Error for FatError {}
 
-impl From<hadris_io::Error> for FatError {
-    fn from(e: hadris_io::Error) -> Self {
-        Self::Io(e)
+impl<E: hadris_io::IoError> From<hadris_io::Error<E>> for FatError {
+    fn from(e: hadris_io::Error<E>) -> Self {
+        Self::Io(e.erase())
     }
 }
 

--- a/crates/hadris-fat/src/exfat/file.rs
+++ b/crates/hadris-fat/src/exfat/file.rs
@@ -73,6 +73,8 @@ impl<'a, DATA: Read + Seek> ExFatFileReader<'a, DATA> {
 }
 
 impl<DATA: Read + Seek> Read for ExFatFileReader<'_, DATA> {
+    type Error = ErrorKind;
+
     fn read(&mut self, buf: &mut [u8]) -> crate::io::IoResult<usize> {
         if self.position >= self.valid_length {
             return Ok(0);
@@ -140,6 +142,8 @@ impl<DATA: Read + Seek> Read for ExFatFileReader<'_, DATA> {
 }
 
 impl<DATA: Read + Seek> Seek for ExFatFileReader<'_, DATA> {
+    type Error = ErrorKind;
+
     fn seek(&mut self, pos: SeekFrom) -> crate::io::IoResult<u64> {
         let new_pos = match pos {
             SeekFrom::Start(offset) => offset as i64,
@@ -290,6 +294,8 @@ impl<'a, DATA: Read + Write + Seek> ExFatFileWriter<'a, DATA> {
 
 #[cfg(feature = "write")]
 impl<DATA: Read + Write + Seek> Write for ExFatFileWriter<'_, DATA> {
+    type Error = ErrorKind;
+
     fn write(&mut self, buf: &[u8]) -> crate::io::IoResult<usize> {
         if buf.is_empty() {
             return Ok(0);

--- a/crates/hadris-fat/src/exfat/fs.rs
+++ b/crates/hadris-fat/src/exfat/fs.rs
@@ -299,7 +299,7 @@ where
     /// Flush any pending writes.
     pub(crate) fn flush(&self) -> crate::io::IoResult<()> {
         let mut guard = self.data.lock();
-        guard.flush()
+        guard.flush().map_err(hadris_io::Error::erase)
     }
 
     /// Allocate a single cluster.

--- a/crates/hadris-fat/src/format/mod.rs
+++ b/crates/hadris-fat/src/format/mod.rs
@@ -8,7 +8,7 @@
 //! use std::fs::OpenOptions;
 //! use hadris_fat::format::{FatVolumeFormatter, FormatOptions};
 //!
-//! # fn main() -> hadris_fat::Result<()> {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create or open a file for the volume
 //! let file = OpenOptions::new()
 //!     .read(true)

--- a/crates/hadris-fat/src/fs.rs
+++ b/crates/hadris-fat/src/fs.rs
@@ -335,7 +335,7 @@ where
             .map_err(|source| FatError::IoContext {
                 op: "boot sector",
                 sector: Some(0),
-                source,
+                source: source.erase(),
             })?;
         let sector_size = bpb.bytes_per_sector.get() as usize;
         let cluster_size = (bpb.sectors_per_cluster as usize) * sector_size;
@@ -369,7 +369,7 @@ where
             .map_err(|source| FatError::IoContext {
                 op: "boot sector (FAT12/16 extended fields)",
                 sector: Some(0),
-                source,
+                source: source.erase(),
             })?;
 
         // Validate boot signature
@@ -515,7 +515,7 @@ where
             .map_err(|source| FatError::IoContext {
                 op: "boot sector (FAT32 extended fields)",
                 sector: Some(0),
-                source,
+                source: source.erase(),
             })?;
 
         // Validate boot signature
@@ -542,7 +542,7 @@ where
             .map_err(|source| FatError::IoContext {
                 op: "FSInfo",
                 sector: Some(fs_info_sec.0 as u64),
-                source,
+                source: source.erase(),
             })?;
 
         // Validate FSInfo signatures

--- a/crates/hadris-fat/src/io.rs
+++ b/crates/hadris-fat/src/io.rs
@@ -95,6 +95,8 @@ impl<T> Seek for SectorCursor<T>
 where
     T: Seek,
 {
+    type Error = <T as Seek>::Error;
+
     async fn seek(&mut self, pos: hadris_io::SeekFrom) -> hadris_io::Result<u64> {
         self.data.seek(pos).await
     }
@@ -112,7 +114,9 @@ impl<T> Read for SectorCursor<T>
 where
     T: Read + Seek,
 {
-    async fn read(&mut self, buf: &mut [u8]) -> hadris_io::Result<usize> {
+    type Error = <T as Read>::Error;
+
+    async fn read(&mut self, buf: &mut [u8]) -> hadris_io::Result<usize, Self::Error> {
         self.data.read(buf).await
     }
 
@@ -126,11 +130,13 @@ impl<T> Write for SectorCursor<T>
 where
     T: Write + Seek,
 {
-    async fn write(&mut self, buf: &[u8]) -> hadris_io::Result<usize> {
+    type Error = <T as Write>::Error;
+
+    async fn write(&mut self, buf: &[u8]) -> hadris_io::Result<usize, Self::Error> {
         self.data.write(buf).await
     }
 
-    async fn flush(&mut self) -> hadris_io::Result<()> {
+    async fn flush(&mut self) -> hadris_io::Result<(), Self::Error> {
         self.data.flush().await
     }
 

--- a/crates/hadris-fat/src/io.rs
+++ b/crates/hadris-fat/src/io.rs
@@ -87,7 +87,9 @@ impl<DATA: Seek> SectorCursor<DATA> {
     }
 
     pub async fn seek_sector(&mut self, sector: impl SectorLike) -> hadris_io::Result<u64> {
-        self.seek(SeekFrom::Start(sector.to_bytes(self.sector_size) as u64)).await
+        self.seek(SeekFrom::Start(sector.to_bytes(self.sector_size) as u64))
+            .await
+            .map_err(hadris_io::Error::erase)
     }
 }
 
@@ -97,15 +99,15 @@ where
 {
     type Error = <T as Seek>::Error;
 
-    async fn seek(&mut self, pos: hadris_io::SeekFrom) -> hadris_io::Result<u64> {
+    async fn seek(&mut self, pos: hadris_io::SeekFrom) -> hadris_io::Result<u64, Self::Error> {
         self.data.seek(pos).await
     }
 
-    async fn stream_position(&mut self) -> hadris_io::Result<u64> {
+    async fn stream_position(&mut self) -> hadris_io::Result<u64, Self::Error> {
         self.data.stream_position().await
     }
 
-    async fn seek_relative(&mut self, offset: i64) -> hadris_io::Result<()> {
+    async fn seek_relative(&mut self, offset: i64) -> hadris_io::Result<(), Self::Error> {
         self.data.seek_relative(offset).await
     }
 }

--- a/crates/hadris-fat/tests/test_read.rs
+++ b/crates/hadris-fat/tests/test_read.rs
@@ -358,7 +358,7 @@ mod integration_tests {
             fs.set_root_label(b"pmOS_boot  ").expect("set_root_label");
         }
 
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
         let fs = FatFs::open(cursor).expect("re-open FAT32");
 
         let entries: Vec<_> = fs.root_dir().entries().filter_map(|e| e.ok()).collect();
@@ -377,7 +377,7 @@ mod integration_tests {
         use hadris_io::Seek;
 
         let mut cursor = create_test_fat32_image();
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
         let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
         let root = fs.root_dir();
@@ -416,7 +416,7 @@ mod integration_tests {
         use hadris_io::Seek;
 
         let mut cursor = create_test_fat32_image();
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
         let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
         let root = fs.root_dir();
@@ -443,7 +443,7 @@ mod integration_tests {
         // by other tools. This test verifies that the LFN parsing infrastructure
         // compiles and works correctly by testing with short filenames.
         let mut cursor = create_test_fat32_image();
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
         let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
         let root = fs.root_dir();
@@ -479,7 +479,7 @@ mod navigation_tests {
     #[test]
     fn test_find_nonexistent_returns_none() {
         let mut cursor = create_test_fat32_image();
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
         let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
         let root = fs.root_dir();
@@ -494,7 +494,7 @@ mod navigation_tests {
     #[test]
     fn test_open_dir_on_file_returns_error() {
         let mut cursor = create_test_fat32_image();
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
         let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
         let root = fs.root_dir();
@@ -512,7 +512,7 @@ mod navigation_tests {
     #[test]
     fn test_open_file_on_directory_returns_error() {
         let mut cursor = create_test_fat32_image();
-        cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+        cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
         let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
         let root = fs.root_dir();
@@ -557,7 +557,7 @@ mod navigation_tests {
             use hadris_io::Seek;
 
             let mut cursor = create_test_fat32_image();
-            cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+            cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
             let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
 
@@ -578,7 +578,7 @@ mod navigation_tests {
             use hadris_io::Seek;
 
             let mut cursor = create_test_fat32_image();
-            cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+            cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
             let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
 
@@ -599,7 +599,7 @@ mod navigation_tests {
             use hadris_io::Seek;
 
             let mut cursor = create_test_fat32_image();
-            cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+            cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
             let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
 
@@ -620,7 +620,7 @@ mod navigation_tests {
             use hadris_io::Seek;
 
             let mut cursor = create_test_fat32_image();
-            cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+            cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
             let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
 
@@ -638,7 +638,7 @@ mod navigation_tests {
             use hadris_io::Seek;
 
             let mut cursor = create_test_fat32_image();
-            cursor.seek(std::io::SeekFrom::Start(0)).unwrap();
+            cursor.seek(std::io::SeekFrom::Start(0).into()).unwrap();
 
             let fs = FatFs::open(cursor).expect("Failed to open FAT32 image");
 

--- a/crates/hadris-io/Cargo.toml
+++ b/crates/hadris-io/Cargo.toml
@@ -14,10 +14,12 @@ categories = ["no-std", "filesystem"]
 [features]
 default = ["sync", "std"]
 sync = []
-async = []
+async = ["dep:embedded-io-async"]
 alloc = []
-std = ["sync", "alloc"]
+std = ["sync", "alloc", "embedded-io/std", "embedded-io-async?/std"]
 
 [dependencies]
 cfg-if.workspace = true
 bytemuck.workspace = true
+embedded-io.workspace = true
+embedded-io-async = { workspace = true, optional = true }

--- a/crates/hadris-io/src/async_api.rs
+++ b/crates/hadris-io/src/async_api.rs
@@ -54,13 +54,13 @@ pub trait Seek {
     /// Error returned by the stream.
     type Error: embedded_io::Error;
     /// Seek to a new byte position.
-    async fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error>;
     /// Return the current position.
-    async fn stream_position(&mut self) -> Result<u64> {
+    async fn stream_position(&mut self) -> Result<u64, Self::Error> {
         self.seek(SeekFrom::Current(0)).await
     }
     /// Seek relative to the current position.
-    async fn seek_relative(&mut self, offset: i64) -> Result<()> {
+    async fn seek_relative(&mut self, offset: i64) -> Result<(), Self::Error> {
         self.seek(SeekFrom::Current(offset)).await?;
         Ok(())
     }
@@ -97,7 +97,7 @@ impl<T: Write + ?Sized> Write for &mut T {
 }
 impl<T: Seek + ?Sized> Seek for &mut T {
     type Error = T::Error;
-    async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         T::seek(self, pos).await
     }
 }
@@ -176,7 +176,7 @@ impl<T: Write + ?Sized> Write for Borrowed<'_, T> {
 }
 impl<T: Seek + ?Sized> Seek for Borrowed<'_, T> {
     type Error = T::Error;
-    async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         self.0.seek(pos).await
     }
 }
@@ -203,9 +203,9 @@ impl<T: embedded_io_async::Write> Write for FromEmbedded<T> {
 }
 impl<T: embedded_io_async::Seek> Seek for FromEmbedded<T> {
     type Error = T::Error;
-    async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         embedded_io_async::Seek::seek(&mut self.0, pos)
             .await
-            .map_err(|error| Error::from_source(error).erase())
+            .map_err(Error::from_source)
     }
 }

--- a/crates/hadris-io/src/async_api.rs
+++ b/crates/hadris-io/src/async_api.rs
@@ -1,68 +1,64 @@
-//! Asynchronous I/O traits using async fn in trait (AFIT).
-//!
-//! These mirror the synchronous traits in [`crate::sync`] but with `async`
-//! method signatures. No blanket impls are provided — async consumers
-//! implement these directly for their device types.
+//! Asynchronous portable I/O traits and adapters.
 
-use crate::{ErrorKind, Result, SeekFrom};
+use crate::{Error, ErrorKind, Result, SeekFrom};
 
-// ---------------------------------------------------------------------------
-// Core I/O traits (async)
-// ---------------------------------------------------------------------------
-
-/// Async version of [`crate::sync::Read`].
+/// Asynchronously read bytes from a source.
 pub trait Read {
-    /// Pull some bytes from this source into the specified buffer.
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+    /// Error returned by the source.
+    type Error: embedded_io::Error;
 
-    /// Read the exact number of bytes required to fill `buf`.
+    /// Read some bytes.
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
+
+    /// Fill `buf`, retrying interrupted operations.
     async fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-        let mut total_read = 0;
-        while total_read < buf.len() {
-            match self.read(&mut buf[total_read..]).await {
-                Ok(0) => return Err(ErrorKind::UnexpectedEof.into()),
-                Ok(n) => total_read += n,
-                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-                Err(e) => return Err(e),
+        let mut read = 0;
+        while read < buf.len() {
+            match self.read(&mut buf[read..]).await {
+                Ok(0) => return Err(Error::from_kind(ErrorKind::UnexpectedEof)),
+                Ok(n) => read += n,
+                Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error.erase()),
             }
         }
         Ok(())
     }
 }
 
-/// Async version of [`crate::sync::Write`].
+/// Asynchronously write bytes to a destination.
 pub trait Write {
-    /// Write a buffer into this writer.
-    async fn write(&mut self, buf: &[u8]) -> Result<usize>;
+    /// Error returned by the destination.
+    type Error: embedded_io::Error;
+    /// Write some bytes.
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
+    /// Flush buffered output.
+    async fn flush(&mut self) -> Result<(), Self::Error>;
 
-    /// Flush this output stream.
-    async fn flush(&mut self) -> Result<()>;
-
-    /// Attempts to write an entire buffer into this writer.
+    /// Write all bytes, retrying interrupted operations.
     async fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         let mut written = 0;
         while written < buf.len() {
             match self.write(&buf[written..]).await {
-                Ok(0) => return Err(ErrorKind::WriteZero.into()),
+                Ok(0) => return Err(Error::from_kind(ErrorKind::WriteZero)),
                 Ok(n) => written += n,
-                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-                Err(e) => return Err(e),
+                Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error.erase()),
             }
         }
         Ok(())
     }
 }
 
-/// Async version of [`crate::sync::Seek`].
+/// Asynchronously move within a stream.
 pub trait Seek {
-    /// Seek to an offset, in bytes, in a stream.
+    /// Error returned by the stream.
+    type Error: embedded_io::Error;
+    /// Seek to a new byte position.
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
-
-    /// Returns the current seek position from the start of the stream.
+    /// Return the current position.
     async fn stream_position(&mut self) -> Result<u64> {
         self.seek(SeekFrom::Current(0)).await
     }
-
     /// Seek relative to the current position.
     async fn seek_relative(&mut self, offset: i64) -> Result<()> {
         self.seek(SeekFrom::Current(offset)).await?;
@@ -70,81 +66,146 @@ pub trait Seek {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Blanket impls for &mut T (mirrors std::io behaviour)
-// ---------------------------------------------------------------------------
+/// Async reader and seeker with one common source error.
+pub trait ReadSeek: Read + Seek<Error = <Self as Read>::Error> {}
+impl<T: Read + Seek<Error = <T as Read>::Error> + ?Sized> ReadSeek for T {}
 
-impl<T: Read> Read for &mut T {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+/// Async reader, writer, and seeker with one common source error.
+pub trait ReadWriteSeek:
+    Read + Write<Error = <Self as Read>::Error> + Seek<Error = <Self as Read>::Error>
+{
+}
+impl<T> ReadWriteSeek for T where
+    T: Read + Write<Error = <T as Read>::Error> + Seek<Error = <T as Read>::Error> + ?Sized
+{
+}
+
+impl<T: Read + ?Sized> Read for &mut T {
+    type Error = T::Error;
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         T::read(self, buf).await
     }
-
-    async fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-        T::read_exact(self, buf).await
-    }
 }
-
-impl<T: Write> Write for &mut T {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize> {
+impl<T: Write + ?Sized> Write for &mut T {
+    type Error = T::Error;
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         T::write(self, buf).await
     }
-
-    async fn flush(&mut self) -> Result<()> {
+    async fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self).await
     }
-
-    async fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        T::write_all(self, buf).await
-    }
 }
-
-impl<T: Seek> Seek for &mut T {
+impl<T: Seek + ?Sized> Seek for &mut T {
+    type Error = T::Error;
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
         T::seek(self, pos).await
     }
-
-    async fn stream_position(&mut self) -> Result<u64> {
-        T::stream_position(self).await
-    }
-
-    async fn seek_relative(&mut self, offset: i64) -> Result<()> {
-        T::seek_relative(self, offset).await
-    }
 }
 
-// ---------------------------------------------------------------------------
-// Extension traits (async)
-// ---------------------------------------------------------------------------
-
-/// Async read extension: structured reads and parsing.
-pub trait ReadExt {
+/// Structured async-reading helpers.
+pub trait ReadExt: Read {
+    /// Read an arbitrary-bit-pattern value.
     async fn read_struct<T: bytemuck::Zeroable + bytemuck::NoUninit + bytemuck::AnyBitPattern>(
         &mut self,
-    ) -> Result<T>;
-
-    async fn parse<T: Parsable>(&mut self) -> Result<T>;
-}
-
-impl<T: Read> ReadExt for T {
-    async fn read_struct<S: bytemuck::Zeroable + bytemuck::NoUninit + bytemuck::AnyBitPattern>(
-        &mut self,
-    ) -> Result<S> {
-        let mut temp = S::zeroed();
+    ) -> Result<T> {
+        let mut temp = T::zeroed();
         self.read_exact(bytemuck::bytes_of_mut(&mut temp)).await?;
         Ok(temp)
     }
-
-    async fn parse<S: Parsable>(&mut self) -> Result<S> {
-        S::parse(self).await
+    /// Parse a value with its custom parser.
+    async fn parse<T: Parsable>(&mut self) -> Result<T>
+    where
+        Self: Sized,
+    {
+        T::parse(self).await
     }
 }
+impl<T: Read + ?Sized> ReadExt for T {}
 
-/// Async parse a type from a reader.
+/// Parse a value from an async reader.
 pub trait Parsable: Sized {
+    /// Parse `Self` while preserving the source error.
     async fn parse<R: Read>(reader: &mut R) -> Result<Self>;
 }
 
-/// Async write a type to a writer.
+/// Write a value to an async writer.
 pub trait Writable: Sized {
+    /// Write `Self` while preserving the source error.
     async fn write<W: Write>(&self, writer: &mut W) -> Result<()>;
+}
+
+/// Adapt an `embedded-io-async` value to Hadris async traits.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FromEmbedded<T>(pub T);
+
+impl<T> FromEmbedded<T> {
+    /// Wrap a value.
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+    /// Recover the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+/// Reborrow a Hadris async I/O value.
+#[derive(Debug)]
+pub struct Borrowed<'a, T: ?Sized>(pub &'a mut T);
+
+impl<'a, T: ?Sized> Borrowed<'a, T> {
+    /// Borrow an I/O value.
+    pub fn new(inner: &'a mut T) -> Self {
+        Self(inner)
+    }
+}
+impl<T: Read + ?Sized> Read for Borrowed<'_, T> {
+    type Error = T::Error;
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.0.read(buf).await
+    }
+}
+impl<T: Write + ?Sized> Write for Borrowed<'_, T> {
+    type Error = T::Error;
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.0.write(buf).await
+    }
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush().await
+    }
+}
+impl<T: Seek + ?Sized> Seek for Borrowed<'_, T> {
+    type Error = T::Error;
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        self.0.seek(pos).await
+    }
+}
+impl<T: embedded_io_async::Read> Read for FromEmbedded<T> {
+    type Error = T::Error;
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        embedded_io_async::Read::read(&mut self.0, buf)
+            .await
+            .map_err(Error::from_source)
+    }
+}
+impl<T: embedded_io_async::Write> Write for FromEmbedded<T> {
+    type Error = T::Error;
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        embedded_io_async::Write::write(&mut self.0, buf)
+            .await
+            .map_err(Error::from_source)
+    }
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        embedded_io_async::Write::flush(&mut self.0)
+            .await
+            .map_err(Error::from_source)
+    }
+}
+impl<T: embedded_io_async::Seek> Seek for FromEmbedded<T> {
+    type Error = T::Error;
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        embedded_io_async::Seek::seek(&mut self.0, pos)
+            .await
+            .map_err(|error| Error::from_source(error).erase())
+    }
 }

--- a/crates/hadris-io/src/error.rs
+++ b/crates/hadris-io/src/error.rs
@@ -1,204 +1,246 @@
-//! No-std compatible I/O error types
+//! Portable, allocation-free I/O errors.
 
 use core::fmt::{self, Display};
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
-/// Error kind for I/O operations (no-std compatible)
+/// Portable error classification. This is a superset of `embedded_io::ErrorKind`
+/// and retains the `std::io` conditions Hadris needs for helper operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ErrorKind {
-    /// An entity was not found
     NotFound,
-    /// Permission denied
     PermissionDenied,
-    /// Connection refused
     ConnectionRefused,
-    /// Connection reset
     ConnectionReset,
-    /// Connection aborted
     ConnectionAborted,
-    /// Not connected
     NotConnected,
-    /// Address in use
     AddrInUse,
-    /// Address not available
     AddrNotAvailable,
-    /// Broken pipe
     BrokenPipe,
-    /// Entity already exists
     AlreadyExists,
-    /// Operation would block
     WouldBlock,
-    /// Invalid input
     InvalidInput,
-    /// Invalid data
     InvalidData,
-    /// Timed out
     TimedOut,
-    /// Write zero
     WriteZero,
-    /// Interrupted
     Interrupted,
-    /// Unexpected end of file
     UnexpectedEof,
-    /// Out of memory
+    Unsupported,
     OutOfMemory,
-    /// Other error
     Other,
+}
+
+impl ErrorKind {
+    /// Return this already-normalized error kind.
+    pub const fn kind(&self) -> Self {
+        *self
+    }
+}
+
+impl From<embedded_io::ErrorKind> for ErrorKind {
+    fn from(kind: embedded_io::ErrorKind) -> Self {
+        use embedded_io::ErrorKind as E;
+        match kind {
+            E::NotFound => Self::NotFound,
+            E::PermissionDenied => Self::PermissionDenied,
+            E::ConnectionRefused => Self::ConnectionRefused,
+            E::ConnectionReset => Self::ConnectionReset,
+            E::ConnectionAborted => Self::ConnectionAborted,
+            E::NotConnected => Self::NotConnected,
+            E::AddrInUse => Self::AddrInUse,
+            E::AddrNotAvailable => Self::AddrNotAvailable,
+            E::BrokenPipe => Self::BrokenPipe,
+            E::AlreadyExists => Self::AlreadyExists,
+            E::InvalidInput => Self::InvalidInput,
+            E::InvalidData => Self::InvalidData,
+            E::TimedOut => Self::TimedOut,
+            E::WriteZero => Self::WriteZero,
+            E::Interrupted => Self::Interrupted,
+            E::Unsupported => Self::Unsupported,
+            E::OutOfMemory => Self::OutOfMemory,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl From<ErrorKind> for embedded_io::ErrorKind {
+    fn from(kind: ErrorKind) -> Self {
+        use embedded_io::ErrorKind as E;
+        match kind {
+            ErrorKind::NotFound => E::NotFound,
+            ErrorKind::PermissionDenied => E::PermissionDenied,
+            ErrorKind::ConnectionRefused => E::ConnectionRefused,
+            ErrorKind::ConnectionReset => E::ConnectionReset,
+            ErrorKind::ConnectionAborted => E::ConnectionAborted,
+            ErrorKind::NotConnected => E::NotConnected,
+            ErrorKind::AddrInUse => E::AddrInUse,
+            ErrorKind::AddrNotAvailable => E::AddrNotAvailable,
+            ErrorKind::BrokenPipe => E::BrokenPipe,
+            ErrorKind::AlreadyExists => E::AlreadyExists,
+            ErrorKind::InvalidInput => E::InvalidInput,
+            ErrorKind::InvalidData => E::InvalidData,
+            ErrorKind::TimedOut => E::TimedOut,
+            ErrorKind::WriteZero => E::WriteZero,
+            ErrorKind::Interrupted => E::Interrupted,
+            ErrorKind::Unsupported => E::Unsupported,
+            ErrorKind::OutOfMemory => E::OutOfMemory,
+            ErrorKind::WouldBlock | ErrorKind::UnexpectedEof | ErrorKind::Other => E::Other,
+        }
+    }
 }
 
 impl Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ErrorKind::NotFound => write!(f, "entity not found"),
-            ErrorKind::PermissionDenied => write!(f, "permission denied"),
-            ErrorKind::ConnectionRefused => write!(f, "connection refused"),
-            ErrorKind::ConnectionReset => write!(f, "connection reset"),
-            ErrorKind::ConnectionAborted => write!(f, "connection aborted"),
-            ErrorKind::NotConnected => write!(f, "not connected"),
-            ErrorKind::AddrInUse => write!(f, "address in use"),
-            ErrorKind::AddrNotAvailable => write!(f, "address not available"),
-            ErrorKind::BrokenPipe => write!(f, "broken pipe"),
-            ErrorKind::AlreadyExists => write!(f, "entity already exists"),
-            ErrorKind::WouldBlock => write!(f, "operation would block"),
-            ErrorKind::InvalidInput => write!(f, "invalid input parameter"),
-            ErrorKind::InvalidData => write!(f, "invalid data"),
-            ErrorKind::TimedOut => write!(f, "operation timed out"),
-            ErrorKind::WriteZero => write!(f, "write zero"),
-            ErrorKind::Interrupted => write!(f, "operation interrupted"),
-            ErrorKind::UnexpectedEof => write!(f, "unexpected end of file"),
-            ErrorKind::OutOfMemory => write!(f, "out of memory"),
-            ErrorKind::Other => write!(f, "other error"),
-        }
+        write!(f, "{self:?}")
     }
 }
 
-// ---------------------------------------------------------------------------
-// Error message storage
-// ---------------------------------------------------------------------------
+impl core::error::Error for ErrorKind {}
 
-/// Internal message representation.
-///
-/// Always has the `Static` variant. The `Dynamic` variant is only available
-/// when the `alloc` feature is enabled, allowing heap-allocated messages.
-#[derive(Debug)]
-enum ErrorMessage {
-    Static(&'static str),
-    #[cfg(feature = "alloc")]
-    Dynamic(alloc::string::String),
-}
-
-impl ErrorMessage {
-    fn as_str(&self) -> &str {
-        match self {
-            ErrorMessage::Static(s) => s,
-            #[cfg(feature = "alloc")]
-            ErrorMessage::Dynamic(s) => s.as_str(),
-        }
+impl embedded_io::Error for ErrorKind {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        (*self).into()
     }
 }
 
-// ---------------------------------------------------------------------------
-// Error type
-// ---------------------------------------------------------------------------
-
-/// I/O Error type for no-std environments
-///
-/// When the `alloc` feature is enabled, errors can store dynamic messages
-/// via heap allocation. Without `alloc`, only `&'static str` messages are
-/// supported.
-#[derive(Debug)]
-pub struct Error {
-    kind: ErrorKind,
-    msg: ErrorMessage,
+/// An error produced either by an underlying I/O object or by a Hadris helper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error<E = ErrorKind> {
+    /// Error returned by the underlying reader, writer, or seeker.
+    Source(E),
+    /// Error synthesized by Hadris, with optional allocation-free context.
+    Context {
+        /// Portable classification of the error.
+        kind: ErrorKind,
+        /// Static diagnostic context.
+        message: Option<&'static str>,
+    },
 }
 
-impl Error {
-    /// Create a new error with the given kind and a static message.
-    ///
-    /// This is always available and `const`-compatible.
-    pub const fn new_static(kind: ErrorKind, msg: &'static str) -> Self {
-        Self {
-            kind,
-            msg: ErrorMessage::Static(msg),
-        }
+impl<E> Error<E> {
+    /// Wrap an error returned by the underlying I/O object.
+    pub const fn from_source(source: E) -> Self {
+        Self::Source(source)
     }
 
-    /// Create a new error with the given kind and message.
-    ///
-    /// Without `alloc`, the message must be a `&'static str`.
-    /// With `alloc`, any type implementing `Into<String>` is accepted.
-    #[cfg(not(feature = "alloc"))]
-    pub const fn new(kind: ErrorKind, msg: &'static str) -> Self {
-        Self::new_static(kind, msg)
-    }
-
-    /// Create a new error with the given kind and message.
-    ///
-    /// Accepts any type implementing `Into<String>`, including `&str`,
-    /// `String`, and `format!(...)` results.
-    #[cfg(feature = "alloc")]
-    pub fn new(kind: ErrorKind, msg: impl Into<alloc::string::String>) -> Self {
-        Self {
-            kind,
-            msg: ErrorMessage::Dynamic(msg.into()),
-        }
-    }
-
-    /// Create a new error from an error kind
+    /// Construct a Hadris-generated error without additional context.
     pub const fn from_kind(kind: ErrorKind) -> Self {
-        Self {
+        Self::Context {
             kind,
-            msg: ErrorMessage::Static(""),
+            message: None,
         }
     }
 
-    /// Create an error with `ErrorKind::Other`.
-    ///
-    /// This mirrors `std::io::Error::other()` for no-std compatibility.
-    #[cfg(not(feature = "alloc"))]
-    pub const fn other(msg: &'static str) -> Self {
-        Self {
-            kind: ErrorKind::Other,
-            msg: ErrorMessage::Static(msg),
+    /// Construct a Hadris-generated error with static context.
+    pub const fn new(kind: ErrorKind, message: &'static str) -> Self {
+        Self::Context {
+            kind,
+            message: Some(message),
         }
     }
 
-    /// Create an error with `ErrorKind::Other`.
-    ///
-    /// This mirrors `std::io::Error::other()` for no-std compatibility.
-    /// Accepts any type implementing `Into<String>`.
-    #[cfg(feature = "alloc")]
-    pub fn other(msg: impl Into<alloc::string::String>) -> Self {
-        Self {
-            kind: ErrorKind::Other,
-            msg: ErrorMessage::Dynamic(msg.into()),
+    /// Construct an `Other` error with static context.
+    pub const fn other(message: &'static str) -> Self {
+        Self::new(ErrorKind::Other, message)
+    }
+
+    /// Borrow the underlying source, if present.
+    pub const fn source_ref(&self) -> Option<&E> {
+        match self {
+            Self::Source(source) => Some(source),
+            Self::Context { .. } => None,
         }
     }
 
-    /// Get the error kind
-    pub const fn kind(&self) -> ErrorKind {
-        self.kind
+    /// Consume the error and return its underlying source, if present.
+    pub fn into_source(self) -> Option<E> {
+        match self {
+            Self::Source(source) => Some(source),
+            Self::Context { .. } => None,
+        }
     }
 }
 
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Self {
-        Self::from_kind(kind)
+impl<E: embedded_io::Error> Error<E> {
+    /// Return the portable error kind.
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Source(source) => source.kind().into(),
+            Self::Context { kind, .. } => *kind,
+        }
+    }
+
+    /// Erase the concrete source while retaining its normalized kind.
+    pub fn erase(self) -> Error<ErrorKind> {
+        match self {
+            Self::Source(source) => Error::Source(source.kind().into()),
+            Self::Context { kind, message } => Error::Context { kind, message },
+        }
     }
 }
 
-impl Display for Error {
+impl<E: embedded_io::Error + 'static> embedded_io::Error for Error<E> {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        Error::<E>::kind(self).into()
+    }
+}
+
+impl<E: Display> Display for Error<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg = self.msg.as_str();
-        if msg.is_empty() {
-            write!(f, "{}", self.kind)
-        } else {
-            write!(f, "{}: {}", self.kind, msg)
+        match self {
+            Self::Source(source) => Display::fmt(source, f),
+            Self::Context {
+                kind,
+                message: Some(message),
+            } => {
+                write!(f, "{kind:?}: {message}")
+            }
+            Self::Context {
+                kind,
+                message: None,
+            } => write!(f, "{kind:?}"),
         }
     }
 }
 
-/// Result type alias for I/O operations
-pub type Result<T> = core::result::Result<T, Error>;
+impl<E> core::error::Error for Error<E>
+where
+    E: core::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.source_ref()
+            .map(|source| source as &(dyn core::error::Error + 'static))
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error<std::io::Error> {
+    fn from(error: std::io::Error) -> Self {
+        Self::Source(error)
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Error<std::io::Error>> for std::io::Error {
+    fn from(error: Error<std::io::Error>) -> Self {
+        match error {
+            Error::Source(source) => source,
+            Error::Context { kind, message } => match message {
+                Some(message) => std::io::Error::new(std::io::ErrorKind::from(kind), message),
+                None => std::io::Error::from(std::io::ErrorKind::from(kind)),
+            },
+        }
+    }
+}
+
+/// Result returned by Hadris helpers and filesystem operations.
+pub type Result<T, E = ErrorKind> = core::result::Result<T, Error<E>>;
+
+#[cfg(feature = "std")]
+impl From<ErrorKind> for std::io::ErrorKind {
+    fn from(kind: ErrorKind) -> Self {
+        match embedded_io::ErrorKind::from(kind) {
+            embedded => embedded.into(),
+        }
+    }
+}

--- a/crates/hadris-io/src/error.rs
+++ b/crates/hadris-io/src/error.rs
@@ -179,7 +179,7 @@ impl<E: embedded_io::Error> Error<E> {
     }
 }
 
-impl<E: embedded_io::Error + 'static> embedded_io::Error for Error<E> {
+impl<E: embedded_io::Error> embedded_io::Error for Error<E> {
     fn kind(&self) -> embedded_io::ErrorKind {
         Error::<E>::kind(self).into()
     }
@@ -203,15 +203,7 @@ impl<E: Display> Display for Error<E> {
     }
 }
 
-impl<E> core::error::Error for Error<E>
-where
-    E: core::error::Error + 'static,
-{
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        self.source_ref()
-            .map(|source| source as &(dyn core::error::Error + 'static))
-    }
-}
+impl<E: core::error::Error> core::error::Error for Error<E> {}
 
 #[cfg(feature = "std")]
 impl From<std::io::Error> for Error<std::io::Error> {

--- a/crates/hadris-io/src/lib.rs
+++ b/crates/hadris-io/src/lib.rs
@@ -70,28 +70,19 @@ extern crate std;
 // Shared types (always available)
 // ---------------------------------------------------------------------------
 
-/// No-std compatible I/O error types.
-#[cfg(not(feature = "std"))]
 mod error;
-#[cfg(not(feature = "std"))]
 pub use error::{Error, ErrorKind, Result};
-
-/// Re-export std error types when std is available.
-#[cfg(feature = "std")]
-pub use std::io::{Error, ErrorKind, Result};
 
 /// Re-export std path types when std is available.
 #[cfg(feature = "std")]
 pub use std::path::{Path, PathBuf};
 
-/// `SeekFrom` — re-exported from std or defined for no-std.
-#[cfg(feature = "std")]
-pub use std::io::SeekFrom;
+/// Portable seek position, convertible to and from `std::io::SeekFrom`.
+pub use embedded_io::SeekFrom;
 
-#[cfg(not(feature = "std"))]
-mod traits;
-#[cfg(not(feature = "std"))]
-pub use traits::SeekFrom;
+/// Error implemented by portable underlying I/O sources.
+pub trait IoError: embedded_io::Error {}
+impl<T: embedded_io::Error + ?Sized> IoError for T {}
 
 /// Helper macro: short-circuit an `Err` by returning `Some(Err(..))`.
 ///
@@ -214,7 +205,7 @@ impl<'a> Cursor<'a> {
     }
 
     #[allow(dead_code)]
-    fn read_impl(&mut self, buf: &mut [u8]) -> Result<usize> {
+    fn read_impl(&mut self, buf: &mut [u8]) -> core::result::Result<usize, ErrorKind> {
         let remaining = self.data.len().saturating_sub(self.cursor);
         let to_read = buf.len().min(remaining);
         if to_read > 0 {
@@ -225,7 +216,7 @@ impl<'a> Cursor<'a> {
     }
 
     #[allow(dead_code)]
-    fn seek_impl(&mut self, pos: SeekFrom) -> Result<u64> {
+    fn seek_impl(&mut self, pos: SeekFrom) -> core::result::Result<u64, ErrorKind> {
         let new_pos = match pos {
             SeekFrom::Start(offset) => offset as i64,
             SeekFrom::End(offset) => self.data.len() as i64 + offset,
@@ -233,16 +224,7 @@ impl<'a> Cursor<'a> {
         };
 
         if new_pos < 0 {
-            #[cfg(feature = "std")]
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "invalid seek to negative position",
-            ));
-            #[cfg(not(feature = "std"))]
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "invalid seek to negative position",
-            ));
+            return Err(ErrorKind::InvalidInput);
         }
 
         self.cursor = new_pos as usize;
@@ -270,28 +252,19 @@ pub mod sync {
 // Cursor: sync trait impls
 #[cfg(feature = "sync")]
 impl sync::Read for Cursor<'_> {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.read_impl(buf)
+    type Error = ErrorKind;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.read_impl(buf).map_err(Error::from_source)
     }
 }
 
-#[cfg(all(feature = "sync", not(feature = "std")))]
+#[cfg(feature = "sync")]
 impl sync::Seek for Cursor<'_> {
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        self.seek_impl(pos)
-    }
-}
+    type Error = ErrorKind;
 
-#[cfg(all(feature = "sync", feature = "std"))]
-impl std::io::Seek for Cursor<'_> {
-    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        // Convert std SeekFrom to our result
-        let our_pos = match pos {
-            std::io::SeekFrom::Start(n) => SeekFrom::Start(n),
-            std::io::SeekFrom::End(n) => SeekFrom::End(n),
-            std::io::SeekFrom::Current(n) => SeekFrom::Current(n),
-        };
-        self.seek_impl(our_pos)
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        self.seek_impl(pos).map_err(Error::from_source)
     }
 }
 
@@ -319,15 +292,19 @@ pub mod r#async {
 // Cursor: async trait impls
 #[cfg(feature = "async")]
 impl r#async::Read for Cursor<'_> {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.read_impl(buf)
+    type Error = ErrorKind;
+
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.read_impl(buf).map_err(Error::from_source)
     }
 }
 
 #[cfg(feature = "async")]
 impl r#async::Seek for Cursor<'_> {
+    type Error = ErrorKind;
+
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        self.seek_impl(pos)
+        self.seek_impl(pos).map_err(Error::from_source)
     }
 }
 

--- a/crates/hadris-io/src/lib.rs
+++ b/crates/hadris-io/src/lib.rs
@@ -113,7 +113,7 @@ macro_rules! try_io_result_option {
     ($expr:expr) => {
         match $expr {
             Ok(val) => val,
-            Err(err) => return Some(Err(err)),
+            Err(err) => return Some(Err(err.erase())),
         }
     };
 }

--- a/crates/hadris-io/src/sync_api.rs
+++ b/crates/hadris-io/src/sync_api.rs
@@ -57,15 +57,15 @@ pub trait Seek {
     type Error: embedded_io::Error;
 
     /// Seek to a new byte position.
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error>;
 
     /// Return the current byte position.
-    fn stream_position(&mut self) -> Result<u64> {
+    fn stream_position(&mut self) -> Result<u64, Self::Error> {
         self.seek(SeekFrom::Current(0))
     }
 
     /// Seek relative to the current byte position.
-    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+    fn seek_relative(&mut self, offset: i64) -> Result<(), Self::Error> {
         self.seek(SeekFrom::Current(offset))?;
         Ok(())
     }
@@ -115,8 +115,8 @@ impl<T: std::io::Write + ?Sized> Write for T {
 impl<T: std::io::Seek + ?Sized> Seek for T {
     type Error = std::io::Error;
 
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        std::io::Seek::seek(self, pos.into()).map_err(|error| Error::from_source(error).erase())
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        std::io::Seek::seek(self, pos.into()).map_err(Error::from_source)
     }
 }
 
@@ -146,8 +146,8 @@ impl<T: embedded_io::Write + ?Sized> Write for T {
 impl<T: embedded_io::Seek + ?Sized> Seek for T {
     type Error = T::Error;
 
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        embedded_io::Seek::seek(self, pos).map_err(|error| Error::from_source(error).erase())
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        embedded_io::Seek::seek(self, pos).map_err(Error::from_source)
     }
 }
 
@@ -202,7 +202,7 @@ impl<T: Write + ?Sized> Write for Borrowed<'_, T> {
 }
 impl<T: Seek + ?Sized> Seek for Borrowed<'_, T> {
     type Error = T::Error;
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         self.0.seek(pos)
     }
 }
@@ -226,8 +226,8 @@ impl<T: embedded_io::Write> Write for FromEmbedded<T> {
 
 impl<T: embedded_io::Seek> Seek for FromEmbedded<T> {
     type Error = T::Error;
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        embedded_io::Seek::seek(&mut self.0, pos).map_err(|error| Error::from_source(error).erase())
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        embedded_io::Seek::seek(&mut self.0, pos).map_err(Error::from_source)
     }
 }
 
@@ -246,16 +246,10 @@ impl<T> ToEmbedded<T> {
     }
 }
 
-impl<T: Read> embedded_io::ErrorType for ToEmbedded<T>
-where
-    T::Error: 'static,
-{
+impl<T: Read> embedded_io::ErrorType for ToEmbedded<T> {
     type Error = Error<T::Error>;
 }
-impl<T: Read> embedded_io::Read for ToEmbedded<T>
-where
-    T::Error: 'static,
-{
+impl<T: Read> embedded_io::Read for ToEmbedded<T> {
     fn read(&mut self, buf: &mut [u8]) -> core::result::Result<usize, Self::Error> {
         Read::read(&mut self.0, buf)
     }
@@ -263,7 +257,6 @@ where
 impl<T> embedded_io::Write for ToEmbedded<T>
 where
     T: Read + Write<Error = <T as Read>::Error>,
-    <T as Read>::Error: 'static,
 {
     fn write(&mut self, buf: &[u8]) -> core::result::Result<usize, Self::Error> {
         Write::write(&mut self.0, buf)
@@ -275,13 +268,9 @@ where
 impl<T> embedded_io::Seek for ToEmbedded<T>
 where
     T: Read + Seek<Error = <T as Read>::Error>,
-    <T as Read>::Error: 'static,
 {
     fn seek(&mut self, pos: SeekFrom) -> core::result::Result<u64, Self::Error> {
-        Seek::seek(&mut self.0, pos).map_err(|error| Error::Context {
-            kind: error.kind(),
-            message: None,
-        })
+        Seek::seek(&mut self.0, pos)
     }
 }
 

--- a/crates/hadris-io/src/sync_api.rs
+++ b/crates/hadris-io/src/sync_api.rs
@@ -1,172 +1,319 @@
-//! Synchronous I/O traits.
-//!
-//! When the `std` feature is enabled, [`Read`], [`Write`], and [`Seek`] are
-//! re-exported from `std::io` (so any `std::io` implementor works).
-//! In no-std mode, minimal custom trait definitions are provided.
+//! Synchronous portable I/O traits and interoperability adapters.
 
-use crate::Result;
-#[cfg(not(feature = "std"))]
-use crate::{Error, ErrorKind, SeekFrom};
+use crate::{Error, ErrorKind, Result, SeekFrom};
 
-// ---------------------------------------------------------------------------
-// Traits
-// ---------------------------------------------------------------------------
+/// Read bytes from a source.
+pub trait Read {
+    /// Error returned by the underlying source.
+    type Error: embedded_io::Error;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub use std::io::Read;
-        pub use std::io::Write;
-        pub use std::io::Seek;
-    } else {
-        /// The `Read` trait allows for reading bytes from a source.
-        pub trait Read {
-            /// Pull some bytes from this source into the specified buffer,
-            /// returning how many bytes were read.
-            fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+    /// Read some bytes, returning zero at end of input.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
 
-            /// Read the exact number of bytes required to fill `buf`.
-            fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-                let mut total_read = 0;
-                while total_read < buf.len() {
-                    match self.read(&mut buf[total_read..]) {
-                        Ok(0) => return Err(Error::from_kind(ErrorKind::UnexpectedEof)),
-                        Ok(n) => total_read += n,
-                        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-                        Err(e) => return Err(e),
-                    }
-                }
-                Ok(())
+    /// Fill `buf`, retrying interrupted operations.
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        let mut read = 0;
+        while read < buf.len() {
+            match self.read(&mut buf[read..]) {
+                Ok(0) => return Err(Error::from_kind(ErrorKind::UnexpectedEof)),
+                Ok(n) => read += n,
+                Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error.erase()),
             }
         }
-
-        /// The `Write` trait allows for writing bytes to a destination.
-        pub trait Write {
-            /// Write a buffer into this writer, returning how many bytes were
-            /// written.
-            fn write(&mut self, buf: &[u8]) -> Result<usize>;
-
-            /// Flush this output stream, ensuring that all intermediately
-            /// buffered contents reach their destination.
-            fn flush(&mut self) -> Result<()>;
-
-            /// Attempts to write an entire buffer into this writer.
-            fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-                let mut written = 0;
-                while written < buf.len() {
-                    match self.write(&buf[written..]) {
-                        Ok(0) => return Err(Error::from_kind(ErrorKind::WriteZero)),
-                        Ok(n) => written += n,
-                        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-                        Err(e) => return Err(e),
-                    }
-                }
-                Ok(())
-            }
-        }
-
-        /// The `Seek` trait provides a cursor which can be moved within a
-        /// stream of bytes.
-        pub trait Seek {
-            /// Seek to an offset, in bytes, in a stream.
-            fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
-
-            /// Returns the current seek position from the start of the stream.
-            fn stream_position(&mut self) -> Result<u64> {
-                self.seek(SeekFrom::Current(0))
-            }
-
-            /// Seek relative to the current position.
-            fn seek_relative(&mut self, offset: i64) -> Result<()> {
-                self.seek(SeekFrom::Current(offset))?;
-                Ok(())
-            }
-        }
+        Ok(())
     }
 }
 
-// ---------------------------------------------------------------------------
-// Extension traits
-// ---------------------------------------------------------------------------
+/// Write bytes to a destination.
+pub trait Write {
+    /// Error returned by the underlying destination.
+    type Error: embedded_io::Error;
 
-/// Read extension: structured reads and parsing.
-///
-/// Provides [`read_struct`](ReadExt::read_struct) for zero-copy deserialization
-/// via [`bytemuck`], and [`parse`](ReadExt::parse) for types implementing
-/// [`Parsable`].
-///
-/// This trait is automatically implemented for all types implementing [`Read`].
-///
-/// # Example
-///
-/// ```rust
-/// use hadris_io::{Cursor, ReadExt};
-///
-/// let bytes = 42u32.to_ne_bytes();
-/// let mut cursor = Cursor::new(&bytes);
-/// let value: u32 = cursor.read_struct().unwrap();
-/// assert_eq!(value, 42);
-/// ```
-pub trait ReadExt {
-    /// Reads a `T` from the stream using zero-copy deserialization.
-    ///
-    /// The type `T` must implement [`bytemuck::AnyBitPattern`] so any
-    /// byte pattern is a valid value.
-    fn read_struct<T: bytemuck::Zeroable + bytemuck::NoUninit + bytemuck::AnyBitPattern>(
-        &mut self,
-    ) -> Result<T>;
+    /// Write some bytes.
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
 
-    /// Parses a `T` from the stream using the [`Parsable`] trait.
-    fn parse<T: Parsable>(&mut self) -> Result<T>;
+    /// Flush buffered output.
+    fn flush(&mut self) -> Result<(), Self::Error>;
+
+    /// Write all bytes, retrying interrupted operations.
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        let mut written = 0;
+        while written < buf.len() {
+            match self.write(&buf[written..]) {
+                Ok(0) => return Err(Error::from_kind(ErrorKind::WriteZero)),
+                Ok(n) => written += n,
+                Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error.erase()),
+            }
+        }
+        Ok(())
+    }
 }
 
-impl<T: Read> ReadExt for T {
-    fn read_struct<S: bytemuck::Zeroable + bytemuck::NoUninit + bytemuck::AnyBitPattern>(
+/// Move within a stream.
+pub trait Seek {
+    /// Error returned by the underlying stream.
+    type Error: embedded_io::Error;
+
+    /// Seek to a new byte position.
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+
+    /// Return the current byte position.
+    fn stream_position(&mut self) -> Result<u64> {
+        self.seek(SeekFrom::Current(0))
+    }
+
+    /// Seek relative to the current byte position.
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        self.seek(SeekFrom::Current(offset))?;
+        Ok(())
+    }
+}
+
+/// Reader and seeker that use one common source error.
+pub trait ReadSeek: Read + Seek<Error = <Self as Read>::Error> {}
+impl<T: Read + Seek<Error = <T as Read>::Error> + ?Sized> ReadSeek for T {}
+
+/// Reader and writer that use one common source error.
+pub trait ReadWrite: Read + Write<Error = <Self as Read>::Error> {}
+impl<T: Read + Write<Error = <T as Read>::Error> + ?Sized> ReadWrite for T {}
+
+/// Reader, writer, and seeker that use one common source error.
+pub trait ReadWriteSeek:
+    Read + Write<Error = <Self as Read>::Error> + Seek<Error = <Self as Read>::Error>
+{
+}
+impl<T> ReadWriteSeek for T where
+    T: Read + Write<Error = <T as Read>::Error> + Seek<Error = <T as Read>::Error> + ?Sized
+{
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Read + ?Sized> Read for T {
+    type Error = std::io::Error;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        std::io::Read::read(self, buf).map_err(Error::from_source)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Write + ?Sized> Write for T {
+    type Error = std::io::Error;
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        std::io::Write::write(self, buf).map_err(Error::from_source)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        std::io::Write::flush(self).map_err(Error::from_source)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Seek + ?Sized> Seek for T {
+    type Error = std::io::Error;
+
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        std::io::Seek::seek(self, pos.into()).map_err(|error| Error::from_source(error).erase())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<T: embedded_io::Read + ?Sized> Read for T {
+    type Error = T::Error;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        embedded_io::Read::read(self, buf).map_err(Error::from_source)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<T: embedded_io::Write + ?Sized> Write for T {
+    type Error = T::Error;
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        embedded_io::Write::write(self, buf).map_err(Error::from_source)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        embedded_io::Write::flush(self).map_err(Error::from_source)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<T: embedded_io::Seek + ?Sized> Seek for T {
+    type Error = T::Error;
+
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        embedded_io::Seek::seek(self, pos).map_err(|error| Error::from_source(error).erase())
+    }
+}
+
+/// Explicitly expose an `embedded-io` value through Hadris traits.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FromEmbedded<T>(pub T);
+
+impl<T> FromEmbedded<T> {
+    /// Wrap an embedded I/O value.
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+    /// Recover the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+    /// Borrow the wrapped value.
+    pub const fn get_ref(&self) -> &T {
+        &self.0
+    }
+    /// Mutably borrow the wrapped value.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+/// Reborrow a Hadris I/O value without requiring a blanket implementation for `&mut T`.
+#[derive(Debug)]
+pub struct Borrowed<'a, T: ?Sized>(pub &'a mut T);
+
+impl<'a, T: ?Sized> Borrowed<'a, T> {
+    /// Borrow an I/O value.
+    pub fn new(inner: &'a mut T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T: Read + ?Sized> Read for Borrowed<'_, T> {
+    type Error = T::Error;
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.0.read(buf)
+    }
+}
+impl<T: Write + ?Sized> Write for Borrowed<'_, T> {
+    type Error = T::Error;
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.0.write(buf)
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush()
+    }
+}
+impl<T: Seek + ?Sized> Seek for Borrowed<'_, T> {
+    type Error = T::Error;
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        self.0.seek(pos)
+    }
+}
+
+impl<T: embedded_io::Read> Read for FromEmbedded<T> {
+    type Error = T::Error;
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        embedded_io::Read::read(&mut self.0, buf).map_err(Error::from_source)
+    }
+}
+
+impl<T: embedded_io::Write> Write for FromEmbedded<T> {
+    type Error = T::Error;
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        embedded_io::Write::write(&mut self.0, buf).map_err(Error::from_source)
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        embedded_io::Write::flush(&mut self.0).map_err(Error::from_source)
+    }
+}
+
+impl<T: embedded_io::Seek> Seek for FromEmbedded<T> {
+    type Error = T::Error;
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        embedded_io::Seek::seek(&mut self.0, pos).map_err(|error| Error::from_source(error).erase())
+    }
+}
+
+/// Explicitly expose a Hadris value through `embedded-io` traits.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToEmbedded<T>(pub T);
+
+impl<T> ToEmbedded<T> {
+    /// Wrap a Hadris I/O value.
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+    /// Recover the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: Read> embedded_io::ErrorType for ToEmbedded<T>
+where
+    T::Error: 'static,
+{
+    type Error = Error<T::Error>;
+}
+impl<T: Read> embedded_io::Read for ToEmbedded<T>
+where
+    T::Error: 'static,
+{
+    fn read(&mut self, buf: &mut [u8]) -> core::result::Result<usize, Self::Error> {
+        Read::read(&mut self.0, buf)
+    }
+}
+impl<T> embedded_io::Write for ToEmbedded<T>
+where
+    T: Read + Write<Error = <T as Read>::Error>,
+    <T as Read>::Error: 'static,
+{
+    fn write(&mut self, buf: &[u8]) -> core::result::Result<usize, Self::Error> {
+        Write::write(&mut self.0, buf)
+    }
+    fn flush(&mut self) -> core::result::Result<(), Self::Error> {
+        Write::flush(&mut self.0)
+    }
+}
+impl<T> embedded_io::Seek for ToEmbedded<T>
+where
+    T: Read + Seek<Error = <T as Read>::Error>,
+    <T as Read>::Error: 'static,
+{
+    fn seek(&mut self, pos: SeekFrom) -> core::result::Result<u64, Self::Error> {
+        Seek::seek(&mut self.0, pos).map_err(|error| Error::Context {
+            kind: error.kind(),
+            message: None,
+        })
+    }
+}
+
+/// Structured-reading helpers.
+pub trait ReadExt: Read {
+    /// Read an arbitrary-bit-pattern value.
+    fn read_struct<T: bytemuck::Zeroable + bytemuck::NoUninit + bytemuck::AnyBitPattern>(
         &mut self,
-    ) -> Result<S> {
-        let mut temp = S::zeroed();
+    ) -> Result<T> {
+        let mut temp = T::zeroed();
         self.read_exact(bytemuck::bytes_of_mut(&mut temp))?;
         Ok(temp)
     }
 
-    fn parse<S: Parsable>(&mut self) -> Result<S> {
-        S::parse(self)
+    /// Parse a value with its custom parser.
+    fn parse<T: Parsable>(&mut self) -> Result<T>
+    where
+        Self: Sized,
+    {
+        T::parse(self)
     }
 }
+impl<T: Read + ?Sized> ReadExt for T {}
 
-/// Parse a type from a reader.
-///
-/// Implement this trait for types that have a custom binary format
-/// that cannot be expressed as a simple `bytemuck` cast.
-///
-/// # Example
-///
-/// ```rust
-/// use hadris_io::{Cursor, Result, sync::{Read, Parsable, ReadExt}};
-///
-/// struct Magic(u16);
-///
-/// impl Parsable for Magic {
-///     fn parse<R: Read>(reader: &mut R) -> Result<Self> {
-///         let mut buf = [0u8; 2];
-///         reader.read_exact(&mut buf)?;
-///         Ok(Magic(u16::from_le_bytes(buf)))
-///     }
-/// }
-///
-/// let data = [0x34, 0x12];
-/// let mut cursor = Cursor::new(&data);
-/// let magic: Magic = cursor.parse().unwrap();
-/// assert_eq!(magic.0, 0x1234);
-/// ```
+/// Parse a value from a reader.
 pub trait Parsable: Sized {
-    /// Parse this type from the given reader.
+    /// Parse `Self` while preserving the reader's source error.
     fn parse<R: Read>(reader: &mut R) -> Result<Self>;
 }
 
-/// Write a type to a writer.
-///
-/// Implement this trait for types that need custom binary serialization.
+/// Write a value to a writer.
 pub trait Writable: Sized {
-    /// Write this type to the given writer.
+    /// Write `Self` while preserving the writer's source error.
     fn write<W: Write>(&self, writer: &mut W) -> Result<()>;
 }

--- a/crates/hadris-io/tests/interoperability.rs
+++ b/crates/hadris-io/tests/interoperability.rs
@@ -1,0 +1,56 @@
+use hadris_io::{Error, ErrorKind, Read};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeviceError;
+
+impl core::fmt::Display for DeviceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("device failed")
+    }
+}
+
+impl core::error::Error for DeviceError {}
+
+impl embedded_io::Error for DeviceError {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
+struct Device;
+
+impl embedded_io::ErrorType for Device {
+    type Error = DeviceError;
+}
+
+impl embedded_io::Read for Device {
+    fn read(&mut self, _buf: &mut [u8]) -> Result<usize, Self::Error> {
+        Err(DeviceError)
+    }
+}
+
+#[test]
+fn embedded_adapter_preserves_typed_source() {
+    let mut reader = hadris_io::sync::FromEmbedded::new(Device);
+    let error = Read::read(&mut reader, &mut [0]).unwrap_err();
+    assert_eq!(error.source_ref(), Some(&DeviceError));
+    assert_eq!(error.kind(), ErrorKind::Other);
+}
+
+#[test]
+fn std_reader_is_accepted_without_adapter() {
+    let mut reader = std::io::Cursor::new(b"ok".to_vec());
+    let mut bytes = [0; 2];
+    Read::read_exact(&mut reader, &mut bytes).unwrap();
+    assert_eq!(&bytes, b"ok");
+}
+
+#[test]
+fn std_source_round_trip_is_lossless() {
+    let source = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+    let wrapped: Error<std::io::Error> = source.into();
+    assert_eq!(wrapped.kind(), ErrorKind::PermissionDenied);
+    let source: std::io::Error = wrapped.into();
+    assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(source.to_string(), "denied");
+}

--- a/crates/hadris-io/tests/interoperability.rs
+++ b/crates/hadris-io/tests/interoperability.rs
@@ -1,4 +1,4 @@
-use hadris_io::{Error, ErrorKind, Read};
+use hadris_io::{Error, ErrorKind, Read, Seek, SeekFrom};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DeviceError;
@@ -29,12 +29,25 @@ impl embedded_io::Read for Device {
     }
 }
 
+impl embedded_io::Seek for Device {
+    fn seek(&mut self, _pos: embedded_io::SeekFrom) -> Result<u64, Self::Error> {
+        Err(DeviceError)
+    }
+}
+
 #[test]
 fn embedded_adapter_preserves_typed_source() {
     let mut reader = hadris_io::sync::FromEmbedded::new(Device);
     let error = Read::read(&mut reader, &mut [0]).unwrap_err();
     assert_eq!(error.source_ref(), Some(&DeviceError));
     assert_eq!(error.kind(), ErrorKind::Other);
+}
+
+#[test]
+fn embedded_seek_adapter_preserves_typed_source() {
+    let mut seeker = hadris_io::sync::FromEmbedded::new(Device);
+    let error = Seek::seek(&mut seeker, SeekFrom::Start(0)).unwrap_err();
+    assert_eq!(error.source_ref(), Some(&DeviceError));
 }
 
 #[test]

--- a/crates/hadris-iso/src/io.rs
+++ b/crates/hadris-iso/src/io.rs
@@ -50,15 +50,15 @@ impl<DATA: Read + Seek> Read for IsoCursor<DATA> {
 impl<DATA: Seek> Seek for IsoCursor<DATA> {
     type Error = DATA::Error;
 
-    async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         self.data.seek(pos).await
     }
 
-    async fn stream_position(&mut self) -> Result<u64> {
+    async fn stream_position(&mut self) -> Result<u64, Self::Error> {
         self.data.stream_position().await
     }
 
-    async fn seek_relative(&mut self, offset: i64) -> Result<()> {
+    async fn seek_relative(&mut self, offset: i64) -> Result<(), Self::Error> {
         self.data.seek_relative(offset).await
     }
 }
@@ -69,11 +69,13 @@ impl<DATA: Seek> IsoCursor<DATA> {
     }
 
     pub async fn pad_align_sector(&mut self) -> Result<LogicalSector> {
-        let stream_pos = self.stream_position().await?;
+        let stream_pos = self.stream_position().await.map_err(Error::erase)?;
         let sector_size_minus_one = self.sector_size as u64 - 1;
         let aligned_pos = (stream_pos + sector_size_minus_one) & !sector_size_minus_one;
         if aligned_pos != stream_pos {
-            self.seek(SeekFrom::Start(aligned_pos)).await?;
+            self.seek(SeekFrom::Start(aligned_pos))
+                .await
+                .map_err(Error::erase)?;
         }
         Ok(LogicalSector(
             (aligned_pos / self.sector_size as u64) as usize,
@@ -83,6 +85,7 @@ impl<DATA: Seek> IsoCursor<DATA> {
     pub async fn seek_sector(&mut self, sector: LogicalSector) -> Result<u64> {
         self.seek(SeekFrom::Start(sector.0 as u64 * self.sector_size as u64))
             .await
+            .map_err(Error::erase)
     }
 }
 

--- a/crates/hadris-iso/src/io.rs
+++ b/crates/hadris-iso/src/io.rs
@@ -36,7 +36,9 @@ pub struct IsoCursor<DATA: Seek> {
 io_transform! {
 
 impl<DATA: Read + Seek> Read for IsoCursor<DATA> {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+    type Error = <DATA as Read>::Error;
+
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.data.read(buf).await
     }
 
@@ -46,6 +48,8 @@ impl<DATA: Read + Seek> Read for IsoCursor<DATA> {
 }
 
 impl<DATA: Seek> Seek for IsoCursor<DATA> {
+    type Error = DATA::Error;
+
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
         self.data.seek(pos).await
     }
@@ -77,16 +81,19 @@ impl<DATA: Seek> IsoCursor<DATA> {
     }
 
     pub async fn seek_sector(&mut self, sector: LogicalSector) -> Result<u64> {
-        self.seek(SeekFrom::Start(sector.0 as u64 * self.sector_size as u64)).await
+        self.seek(SeekFrom::Start(sector.0 as u64 * self.sector_size as u64))
+            .await
     }
 }
 
 impl<DATA: Write + Seek> Write for IsoCursor<DATA> {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize> {
+    type Error = <DATA as Write>::Error;
+
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.data.write(buf).await
     }
 
-    async fn flush(&mut self) -> Result<()> {
+    async fn flush(&mut self) -> Result<(), Self::Error> {
         self.data.flush().await
     }
 

--- a/crates/hadris-iso/src/modify.rs
+++ b/crates/hadris-iso/src/modify.rs
@@ -345,7 +345,10 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
                 subdir.extent = Some(extent);
 
                 // Save current position
-                let current_pos = cursor.stream_position().await?;
+                let current_pos = cursor
+                    .stream_position()
+                    .await
+                    .map_err(io::Error::erase)?;
 
                 Self::read_directory_recursive(
                     cursor,
@@ -356,7 +359,10 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
                 ).await?;
 
                 // Restore position
-                cursor.seek(SeekFrom::Start(current_pos)).await?;
+                cursor
+                    .seek(SeekFrom::Start(current_pos))
+                    .await
+                    .map_err(io::Error::erase)?;
 
                 layout.add_subdir(subdir);
             } else {
@@ -697,7 +703,12 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
             endian,
         }
         .write(&mut self.inner).await?;
-        let size = self.inner.stream_position().await? as usize - (start.0 * self.sector_size);
+        let size = self
+            .inner
+            .stream_position()
+            .await
+            .map_err(io::Error::erase)? as usize
+            - (start.0 * self.sector_size);
         let _end = self.inner.pad_align_sector().await?;
         Ok(DirectoryRef {
             extent: start,
@@ -775,7 +786,10 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
             }
 
             // Write back the modified descriptor
-            self.inner.seek_relative(-(buffer.len() as i64)).await?;
+            self.inner
+                .seek_relative(-(buffer.len() as i64))
+                .await
+                .map_err(io::Error::erase)?;
             self.inner.write_all(&buffer).await?;
         }
 

--- a/crates/hadris-iso/src/modify.rs
+++ b/crates/hadris-iso/src/modify.rs
@@ -116,7 +116,8 @@ impl FileData {
             FileData::Buffer(data) => Ok(data.len() as u64),
             #[cfg(feature = "std")]
             FileData::Path(path) => {
-                let metadata = std::fs::metadata(path)?;
+                let metadata = std::fs::metadata(path)
+                    .map_err(|error| io::Error::from_source(error).erase())?;
                 Ok(metadata.len())
             }
         }
@@ -127,7 +128,9 @@ impl FileData {
         match self {
             FileData::Buffer(data) => Ok(data.clone()),
             #[cfg(feature = "std")]
-            FileData::Path(path) => std::fs::read(path),
+            FileData::Path(path) => {
+                std::fs::read(path).map_err(|error| io::Error::from_source(error).erase())
+            }
         }
     }
 }
@@ -207,10 +210,10 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
     }
 
     /// Opens an existing ISO image for modification with custom options.
-    pub async fn open_with_options(mut inner: RW, options: IsoModifyOptions) -> IsoModifyResult<Self> {
+    pub async fn open_with_options(inner: RW, options: IsoModifyOptions) -> IsoModifyResult<Self> {
         // Parse existing image
         let sector_size = 2048;
-        let mut cursor = IsoCursor::new(&mut inner, sector_size);
+        let mut cursor = IsoCursor::new(inner, sector_size);
 
         // Read volume descriptors to get image info
         cursor.seek_sector(LogicalSector(16)).await?;
@@ -255,9 +258,6 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
         let allocation_map =
             AllocationMap::from_existing(&used_extents, total_sectors, sector_size as u32);
 
-        // Create the cursor from the original inner
-        let cursor = IsoCursor::new(inner, sector_size);
-
         Ok(Self {
             inner: cursor,
             existing_layout,
@@ -272,7 +272,7 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
 
     /// Builds a DirectoryLayout from an existing ISO directory structure.
     async fn build_layout_from_directory(
-        cursor: &mut IsoCursor<&mut RW>,
+        cursor: &mut IsoCursor<RW>,
         root_ref: DirectoryRef,
         sector_size: usize,
     ) -> IsoModifyResult<(DirectoryLayout, Vec<Extent>)> {
@@ -296,7 +296,7 @@ impl<RW: Read + Write + Seek> IsoModifier<RW> {
     /// Recursively reads a directory and its contents.
     #[allow(clippy::only_used_in_recursion)]
     async fn read_directory_recursive(
-        cursor: &mut IsoCursor<&mut RW>,
+        cursor: &mut IsoCursor<RW>,
         dir_ref: DirectoryRef,
         layout: &mut DirectoryLayout,
         used_extents: &mut Vec<Extent>,

--- a/crates/hadris-iso/src/path.rs
+++ b/crates/hadris-iso/src/path.rs
@@ -133,7 +133,9 @@ impl<DATA: Read + Seek> Iterator for PathTableEntryIter<'_, DATA> {
             return None;
         }
         let mut data = self.data.lock();
-        try_io!(data.seek(SeekFrom::Start(self.current)));
+        try_io!(data
+            .seek(SeekFrom::Start(self.current))
+            .map_err(Error::erase));
         let entry = try_io!(PathTableEntry::parse(
             data.deref_mut(),
             EndianType::NativeEndian,

--- a/crates/hadris-iso/src/read/boot.rs
+++ b/crates/hadris-iso/src/read/boot.rs
@@ -79,7 +79,9 @@ impl<DATA: Read + Seek> Iterator for BootSectionIter<'_, DATA> {
             return None;
         }
         use super::super::io::try_io_result_option as try_io;
-        try_io!(data.seek(SeekFrom::Start(self.current_seek)));
+        try_io!(data
+            .seek(SeekFrom::Start(self.current_seek))
+            .map_err(io::Error::erase));
         let mut header = BootSectionHeaderEntry::zeroed();
 
         // Limit iterations to prevent infinite loop on malformed data

--- a/crates/hadris-iso/src/read/mod.rs
+++ b/crates/hadris-iso/src/read/mod.rs
@@ -179,7 +179,9 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
             };
             let start_byte = pt_start.0 as u64 * sector_size as u64;
             let end_byte = start_byte + path_table.size;
-            data.seek(super::io::SeekFrom::Start(start_byte)).await?;
+            data.seek(super::io::SeekFrom::Start(start_byte))
+                .await
+                .map_err(super::io::Error::erase)?;
             let mut entries = alloc::vec::Vec::new();
             let mut pos = start_byte;
             while pos < end_byte {
@@ -242,7 +244,9 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
     /// Read raw bytes from an absolute byte position in the image.
     pub async fn read_bytes_at(&self, byte_offset: u64, buf: &mut [u8]) -> io::Result<()> {
         let mut data = self.data.lock();
-        data.seek(super::io::SeekFrom::Start(byte_offset)).await?;
+        data.seek(super::io::SeekFrom::Start(byte_offset))
+            .await
+            .map_err(super::io::Error::erase)?;
         data.read_exact(buf).await?;
         Ok(())
     }
@@ -262,7 +266,9 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
         // process on no-overcommit / embedded targets.
         let image_len = {
             let mut data = self.data.lock();
-            data.seek(super::io::SeekFrom::End(0)).await?
+            data.seek(super::io::SeekFrom::End(0))
+                .await
+                .map_err(super::io::Error::erase)?
         };
         if total > image_len {
             return Err(io::Error::new(

--- a/crates/hadris-iso/src/read/rrip.rs
+++ b/crates/hadris-iso/src/read/rrip.rs
@@ -38,7 +38,9 @@ pub(crate) async fn detect_susp_rrip<DATA: Read + Seek>(
     let mut info = SuspInfo::default();
 
     // Seek to root directory and parse the first record ("." entry)
-    data.seek(SeekFrom::Start(root_extent.0 as u64 * 2048)).await?;
+    data.seek(SeekFrom::Start(root_extent.0 as u64 * 2048))
+        .await
+        .map_err(io::Error::erase)?;
     let dot_record = DirectoryRecord::parse(data).await?;
     let su = dot_record.system_use();
     if su.is_empty() {
@@ -86,7 +88,9 @@ pub(crate) async fn detect_susp_rrip<DATA: Read + Seek>(
             }
 
             let mut ce_buf = alloc::vec![0u8; ce_len];
-            data.seek(SeekFrom::Start(ce_offset)).await?;
+            data.seek(SeekFrom::Start(ce_offset))
+                .await
+                .map_err(io::Error::erase)?;
             data.read_exact(&mut ce_buf).await?;
 
             for field in SystemUseIter::new(&ce_buf, 0) {

--- a/crates/hadris-iso/src/write/mod.rs
+++ b/crates/hadris-iso/src/write/mod.rs
@@ -370,14 +370,14 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
     fn parse_iso_str<C: Charset, const N: usize>(
         &self,
         s: &str,
-        field_name: &str,
+        _field_name: &str,
     ) -> io::Result<IsoStr<C, N>> {
         if self.ops.strict_charset {
             IsoStr::from_str_lossy(s)
         } else {
             IsoStr::from_str_unchecked(s)
         }
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, alloc::format!("{field_name}: {e}")))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid ISO string"))
     }
 
     async fn write_volume_descriptors(&mut self, files: &mut InputFiles) -> io::Result<()> {
@@ -477,10 +477,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                     .ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::NotFound,
-                            alloc::format!(
-                                "boot image file not found: {}",
-                                entry.boot_image_path
-                            ),
+                            "boot image file not found",
                         )
                     })?;
                 let load_size = entry
@@ -561,11 +558,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                 if dir_ref.size < catalog.size() {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
-                        alloc::format!(
-                            "boot.catalog file too small: {} bytes, need {}",
-                            dir_ref.size,
-                            catalog.size()
-                        ),
+                        "boot.catalog file too small",
                     ));
                 }
                 catalog.write(&mut self.data).await?;
@@ -727,10 +720,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                         if depth > 8 {
                             return Err(io::Error::new(
                                 io::ErrorKind::InvalidInput,
-                                alloc::format!(
-                                    "Directory depth {} exceeds ISO 9660 limit of 8",
-                                    depth
-                                ),
+                                "directory depth exceeds ISO 9660 limit of 8",
                             ));
                         }
                         let name = dir.name();
@@ -1020,7 +1010,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             .protective_slot(0)
             .mirror_partition(0, MbrPartitionType::Iso9660, bootable)
             .build(&gpt_entries)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, alloc::format!("{:?}", e)))?;
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid hybrid MBR"))?;
 
         // Inject bootstrap code if provided
         if let Some(ref hybrid_opts) = self.ops.features.hybrid_boot

--- a/crates/hadris-iso/src/write/mod.rs
+++ b/crates/hadris-iso/src/write/mod.rs
@@ -370,14 +370,14 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
     fn parse_iso_str<C: Charset, const N: usize>(
         &self,
         s: &str,
-        _field_name: &str,
+        field_name: &'static str,
     ) -> io::Result<IsoStr<C, N>> {
         if self.ops.strict_charset {
             IsoStr::from_str_lossy(s)
         } else {
             IsoStr::from_str_unchecked(s)
         }
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid ISO string"))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, field_name))
     }
 
     async fn write_volume_descriptors(&mut self, files: &mut InputFiles) -> io::Result<()> {
@@ -509,7 +509,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                     let mut checksum = 0u32;
                     let mut buffer = [0u8; 4];
                     let byte_offset = (boot_image_lba as u64) * self.ops.sector_size as u64;
-                    self.data.seek(SeekFrom::Start(byte_offset + 64)).await?;
+                    self.data
+                        .seek(SeekFrom::Start(byte_offset + 64))
+                        .await
+                        .map_err(io::Error::erase)?;
                     // Calculate checksum for all 4-byte chunks from offset 64 to end
                     let checksum_bytes = dir_ref.size - 64;
                     for _ in 0..(checksum_bytes / 4) {
@@ -519,7 +522,9 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 
                     const TABLE_OFFSET: u64 = 8;
                     self.data
-                        .seek(SeekFrom::Start(byte_offset + TABLE_OFFSET)).await?;
+                        .seek(SeekFrom::Start(byte_offset + TABLE_OFFSET))
+                        .await
+                        .map_err(io::Error::erase)?;
 
                     if entry.grub2_boot_info {
                         // GRUB2/ISOLINUX uses extended 56-byte format with reserved bytes
@@ -698,7 +703,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             }
 
             // Write the new data
-            self.data.seek_relative(-(buffer.len() as i64)).await?;
+            self.data
+                .seek_relative(-(buffer.len() as i64))
+                .await
+                .map_err(io::Error::erase)?;
             self.data.write_all(&buffer).await?;
         }
 
@@ -778,12 +786,19 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             self.written_files.root_refs().clone()
         };
 
-        let pos = self.data.stream_position().await?;
+        let pos = self
+            .data
+            .stream_position()
+            .await
+            .map_err(io::Error::erase)?;
         for root in roots.values() {
             self.update_directory(*root, *root).await?;
         }
         // We need to seek back to this position
-        self.data.seek(SeekFrom::Start(pos)).await?;
+        self.data
+            .seek(SeekFrom::Start(pos))
+            .await
+            .map_err(io::Error::erase)?;
 
         Ok(roots)
     }
@@ -814,7 +829,12 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             endian,
         }
         .write(&mut self.data).await?;
-        let size = self.data.stream_position().await? as usize - (start.0 * self.data.sector_size);
+        let size = self
+            .data
+            .stream_position()
+            .await
+            .map_err(io::Error::erase)? as usize
+            - (start.0 * self.data.sector_size);
         let _end = self.data.pad_align_sector().await?;
         Ok(DirectoryRef {
             extent: start,
@@ -880,7 +900,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             mbr.bootstrap[..len].copy_from_slice(&bootstrap[..len]);
         }
 
-        self.data.seek(SeekFrom::Start(0)).await?;
+        self.data
+            .seek(SeekFrom::Start(0))
+            .await
+            .map_err(io::Error::erase)?;
         self.data.write_all(bytemuck::bytes_of(&mbr)).await?;
 
         Ok(())
@@ -915,7 +938,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             mbr.bootstrap[..len].copy_from_slice(&bootstrap[..len]);
         }
 
-        self.data.seek(SeekFrom::Start(0)).await?;
+        self.data
+            .seek(SeekFrom::Start(0))
+            .await
+            .map_err(io::Error::erase)?;
         self.data.write_all(bytemuck::bytes_of(&mbr)).await?;
 
         Ok(())
@@ -931,7 +957,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 
         // Write protective MBR
         let mbr = MasterBootRecord::protective(disk_size_512);
-        self.data.seek(SeekFrom::Start(0)).await?;
+        self.data
+            .seek(SeekFrom::Start(0))
+            .await
+            .map_err(io::Error::erase)?;
         self.data.write_all(bytemuck::bytes_of(&mbr)).await?;
 
         // Create GPT partition entry for the ISO data
@@ -969,11 +998,17 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
         );
 
         // Write primary GPT header
-        self.data.seek(SeekFrom::Start(512)).await?; // Sector 1
+        self.data
+            .seek(SeekFrom::Start(512))
+            .await
+            .map_err(io::Error::erase)?; // Sector 1
         self.data.write_all(&header_bytes).await?;
 
         // Write partition entries (starting at sector 2)
-        self.data.seek(SeekFrom::Start(1024)).await?; // Sector 2
+        self.data
+            .seek(SeekFrom::Start(1024))
+            .await
+            .map_err(io::Error::erase)?; // Sector 2
         self.data.write_all(entries_bytes).await?;
 
         // Note: In a full implementation, we'd also write the backup GPT at the end
@@ -1021,7 +1056,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
         }
 
         // Write hybrid MBR
-        self.data.seek(SeekFrom::Start(0)).await?;
+        self.data
+            .seek(SeekFrom::Start(0))
+            .await
+            .map_err(io::Error::erase)?;
         self.data.write_all(bytemuck::bytes_of(&mbr)).await?;
 
         // Calculate CRC32 of partition entries
@@ -1041,11 +1079,17 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
         );
 
         // Write primary GPT header
-        self.data.seek(SeekFrom::Start(512)).await?;
+        self.data
+            .seek(SeekFrom::Start(512))
+            .await
+            .map_err(io::Error::erase)?;
         self.data.write_all(&header_bytes).await?;
 
         // Write partition entries
-        self.data.seek(SeekFrom::Start(1024)).await?;
+        self.data
+            .seek(SeekFrom::Start(1024))
+            .await
+            .map_err(io::Error::erase)?;
         self.data.write_all(entries_bytes).await?;
 
         Ok(())
@@ -1153,7 +1197,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             if offset >= directory.size as u64 {
                 break;
             }
-            self.data.seek(SeekFrom::Start(start + offset)).await?;
+            self.data
+                .seek(SeekFrom::Start(start + offset))
+                .await
+                .map_err(io::Error::erase)?;
             let mut record = DirectoryRecord::parse(&mut self.data).await?;
             if record.header().len == 0 {
                 break;
@@ -1164,7 +1211,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                 let header = record.header_mut();
                 header.extent.write(dir_ref.extent.0 as u32);
                 header.data_len.write(dir_ref.size as u32);
-                self.data.seek(SeekFrom::Start(start + offset)).await?;
+                self.data
+                    .seek(SeekFrom::Start(start + offset))
+                    .await
+                    .map_err(io::Error::erase)?;
                 record.write(&mut self.data).await?;
                 offset += record.header().len as u64;
                 continue;

--- a/crates/hadris-part/src/error.rs
+++ b/crates/hadris-part/src/error.rs
@@ -209,9 +209,9 @@ impl Display for PartitionError {
     }
 }
 
-impl From<hadris_io::Error> for PartitionError {
-    fn from(err: hadris_io::Error) -> Self {
-        Self::Io(err)
+impl<E: hadris_io::IoError> From<hadris_io::Error<E>> for PartitionError {
+    fn from(err: hadris_io::Error<E>) -> Self {
+        Self::Io(err.erase())
     }
 }
 

--- a/crates/hadris-part/tests/io_roundtrip.rs
+++ b/crates/hadris-part/tests/io_roundtrip.rs
@@ -1,11 +1,12 @@
 //! I/O roundtrip tests for partition table extension traits.
 
 use hadris_io::Cursor;
+use hadris_io::ErrorKind;
 use hadris_part::{
     DiskPartitionScheme, DiskPartitionSchemeReadExt, MasterBootRecord, MasterBootRecordReadExt,
     MasterBootRecordWriteExt, MbrPartition, MbrPartitionType, PartitionError, PartitionSchemeType,
 };
-use std::io::{Cursor as StdCursor, ErrorKind};
+use std::io::Cursor as StdCursor;
 
 #[test]
 fn mbr_read_write_roundtrip() {

--- a/crates/hadris-part/tests/roundtrip.rs
+++ b/crates/hadris-part/tests/roundtrip.rs
@@ -302,8 +302,8 @@ fn partition_error_display() {
 #[test]
 fn partition_io_error_preserves_kind() {
     use hadris_io::Cursor;
+    use hadris_io::ErrorKind;
     use hadris_part::MasterBootRecordReadExt;
-    use std::io::ErrorKind;
 
     let mut cursor = Cursor::new(&[0u8; 10]); // too short for a 512-byte MBR
     let err = MasterBootRecord::read_from(&mut cursor).unwrap_err();

--- a/crates/hadris-udf/src/error.rs
+++ b/crates/hadris-udf/src/error.rs
@@ -39,9 +39,9 @@ pub enum UdfError {
     PodCastError(bytemuck::PodCastError),
 }
 
-impl From<io::Error> for UdfError {
-    fn from(err: io::Error) -> Self {
-        Self::Io(err)
+impl<E: io::IoError> From<io::Error<E>> for UdfError {
+    fn from(err: io::Error<E>) -> Self {
+        Self::Io(err.erase())
     }
 }
 

--- a/crates/hadris-udf/src/modify.rs
+++ b/crates/hadris-udf/src/modify.rs
@@ -102,7 +102,8 @@ impl FileData {
             FileData::Buffer(data) => Ok(data.len() as u64),
             #[cfg(feature = "std")]
             FileData::Path(path) => {
-                let metadata = std::fs::metadata(path)?;
+                let metadata = std::fs::metadata(path)
+                    .map_err(|error| io::Error::from_source(error).erase())?;
                 Ok(metadata.len())
             }
         }
@@ -113,7 +114,9 @@ impl FileData {
         match self {
             FileData::Buffer(data) => Ok(data.clone()),
             #[cfg(feature = "std")]
-            FileData::Path(path) => std::fs::read(path),
+            FileData::Path(path) => {
+                std::fs::read(path).map_err(|error| io::Error::from_source(error).erase())
+            }
         }
     }
 }

--- a/crates/hadris-udf/src/modify.rs
+++ b/crates/hadris-udf/src/modify.rs
@@ -196,7 +196,9 @@ impl<RW: Read + Write + Seek> UdfModifier<RW> {
     /// Opens an existing UDF image for modification with custom options.
     pub fn open_with_options(mut inner: RW, options: UdfModifyOptions) -> UdfModifyResult<Self> {
         // Read AVDP to get VDS location
-        inner.seek(SeekFrom::Start(AVDP_LOCATION as u64 * SECTOR_SIZE as u64))?;
+        inner
+            .seek(SeekFrom::Start(AVDP_LOCATION as u64 * SECTOR_SIZE as u64))
+            .map_err(io::Error::erase)?;
         let mut avdp_buf = [0u8; SECTOR_SIZE];
         inner.read_exact(&mut avdp_buf)?;
         let avdp: &AnchorVolumeDescriptorPointer = bytemuck::from_bytes(&avdp_buf[..512]);
@@ -358,7 +360,8 @@ impl<RW: Read + Write + Seek> UdfModifier<RW> {
 
                     // Write data
                     self.inner
-                        .seek(SeekFrom::Start(current_sector as u64 * SECTOR_SIZE as u64))?;
+                        .seek(SeekFrom::Start(current_sector as u64 * SECTOR_SIZE as u64))
+                        .map_err(io::Error::erase)?;
                     let content = data.read_all()?;
                     self.inner.write_all(&content)?;
 
@@ -370,7 +373,7 @@ impl<RW: Read + Write + Seek> UdfModifier<RW> {
         }
 
         // Pad to sector boundary
-        let pos = self.inner.stream_position()?;
+        let pos = self.inner.stream_position().map_err(io::Error::erase)?;
         let remainder = pos % SECTOR_SIZE as u64;
         if remainder != 0 {
             let padding = SECTOR_SIZE as u64 - remainder;


### PR DESCRIPTION
## Summary

Redesigns `hadris-io` to provide a cleaner portable I/O interface for embedded and standard-library environments.

Closes #16.

## Changes
- Adds `embedded-io` and `embedded-io-async` 0.7 interoperability.
- Introduces associated source-error types for synchronous and asynchronous I/O traits.
- Replaces the feature-dependent error implementation with an allocation-free generic `Error<E>`.
- Preserves typed underlying errors through raw I/O operations.
- Adds portable `ErrorKind` conversion between Hadris, `embedded-io`, and `std::io`.
- Supports lossless wrapping and recovery of `std::io::Error`.
- Adds native blanket implementations for standard-library readers, writers, and seekers.
- Adds explicit `FromEmbedded`, `ToEmbedded`, and `Borrowed` adapters.
- Adds common-error marker traits for combined read/write/seek capabilities.
- Migrates ISO, FAT, UDF, CPIO, partition, and CD code to the new interface.
- Replaces dynamically allocated core I/O messages with static structural context.
- Adds interoperability tests for embedded errors and native `std::io` types.

## Compatibility

This is a breaking I/O API change intended for the next major release.

Standard-library types such as `File`, `BufReader`, and `std::io::Cursor` can be used directly. Embedded implementations work directly in `no_std` builds and through explicit adapters when `std` is enabled.

## Verification

- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- no-std synchronous and asynchronous `hadris-io` checks
- no-std synchronous and asynchronous `hadris-iso` checks
- `cargo fmt`
- `cargo clippy`