### PR TITLE
Fix RC crates.io publication cycle

### DIFF
--- a/crates/optical/hadris-cd/Cargo.toml
+++ b/crates/optical/hadris-cd/Cargo.toml
@@ -24,4 +24,7 @@ hadris-macros = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
-hadris-optical = { workspace = true, features = ["detect", "sync"] }
+# Local integration-test dependency only. Keeping it path-only avoids a
+# crates.io publication cycle because hadris-optical optionally depends on
+# hadris-cd.
+hadris-optical = { path = "../hadris-optical", features = ["detect", "sync"] }


### PR DESCRIPTION
Makes the hadris-cd integration-test dependency on hadris-optical path-only. This preserves local tests while preventing Cargo from treating the dev dependency as a registry dependency, breaking the hadris-cd/hadris-optical publication cycle discovered during the 2.0.0-rc.1 release.