### PR TITLE
feat(iso): add allocation-free reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+### Added
+
+- **hadris-iso:** Added a zero-allocation `IsoReader` for sync and async
+  `no_std` builds, including ISO 9660/Joliet namespace selection, nested path
+  lookup, caller-buffered reads, and multi-extent file streaming.
+
 ### Documentation
 
 - Added a Docusaurus documentation site with getting-started, crate-selection,

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ organizational only: published package names such as `hadris-fat` are unchanged.
 
 - **[hadris-optical](crates/optical/hadris-optical)** - Category facade with multi-format ISO/UDF/bridge detection and image composition
 - **[hadris-iso](crates/optical/hadris-iso)** - ISO 9660 filesystem implementation
+  - Allocation-free sync/async ISO 9660 and Joliet navigation with caller-buffered file streaming
   - ISO 9660 Level 1-3 and ISO 9660:1999 (long filenames)
   - Joliet extension (UTF-16 Unicode filenames)
   - Rock Ridge (RRIP) and SUSP (POSIX semantics, symlinks)
@@ -131,6 +132,8 @@ organizational only: published package names such as `hadris-fat` are unchanged.
 ## Key Features
 
 - **No-std compatible** - Use in bootloaders, kernels, firmware, and embedded systems
+- **Allocation-free ISO reading** - Navigate ISO 9660/Joliet paths and stream
+  multi-extent files with caller-owned buffers in sync or async builds
 - **Configurable** - Feature flags for read-only, write support, and extensions
 - **Dual sync/async** - Shared implementations via `hadris-macros`
 - **Standards oriented** - ECMA-119, IEEE P1282 / Rock Ridge, El-Torito, Microsoft FAT, ECMA-167 / UDF, CPIO newc
@@ -164,13 +167,17 @@ hadris-fixed = "2.0.0-rc.1"
 hadris-path = "2.0.0-rc.1"
 ```
 
-For no-std environments:
+For allocation-free `no_std` ISO reading:
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "alloc"] }
+# No heap allocator: ISO 9660/Joliet lookup and streamed file reads.
+hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
 hadris-fat = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
 ```
+
+Add the `alloc` feature to `hadris-iso` when owned collections, convenience
+reads, and Rock Ridge metadata enrichment are needed without full `std`.
 
 ## Building
 

--- a/api-snapshots/hadris-iso.txt
+++ b/api-snapshots/hadris-iso.txt
@@ -374,6 +374,15 @@ pub mod hadris_iso::async::read
 pub enum hadris_iso::async::read::FilenameType
 pub hadris_iso::async::read::FilenameType::Builtin
 pub hadris_iso::async::read::FilenameType::Joliet
+pub enum hadris_iso::async::read::IsoNamespace
+pub hadris_iso::async::read::IsoNamespace::Joliet(hadris_iso::joliet::JolietLevel)
+pub hadris_iso::async::read::IsoNamespace::Primary
+pub enum hadris_iso::async::read::NameError
+pub hadris_iso::async::read::NameError::BufferTooSmall
+pub hadris_iso::async::read::NameError::InvalidEncoding
+impl core::error::Error for hadris_iso::async::read::NameError
+impl core::fmt::Display for hadris_iso::async::read::NameError
+pub fn hadris_iso::async::read::NameError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[repr(u8)] pub enum hadris_iso::async::read::PathSeparator
 pub hadris_iso::async::read::PathSeparator::Backslash = 92
 pub hadris_iso::async::read::PathSeparator::ForwardSlash = 47
@@ -421,6 +430,25 @@ pub struct hadris_iso::async::read::IsoDir<'a, T: hadris_io::async_api::Read + h
 impl<T: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_iso::async::read::IsoDir<'_, T>
 pub async fn hadris_iso::async::read::IsoDir<'_, T>::find(&self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::async::read::DirEntry>>
 pub async fn hadris_iso::async::read::IsoDir<'_, T>::read_entries(&self) -> hadris_io::error::Result<alloc::vec::Vec<hadris_iso::async::read::DirEntry>>
+pub struct hadris_iso::async::read::IsoDirEntry
+impl hadris_iso::async::read::IsoDirEntry
+pub fn hadris_iso::async::read::IsoDirEntry::is_directory(&self) -> bool
+pub fn hadris_iso::async::read::IsoDirEntry::is_file(&self) -> bool
+pub const fn hadris_iso::async::read::IsoDirEntry::is_multi_extent(&self) -> bool
+pub fn hadris_iso::async::read::IsoDirEntry::name(&self) -> hadris_iso::async::read::IsoName<'_>
+pub const fn hadris_iso::async::read::IsoDirEntry::record(&self) -> &hadris_iso::async::directory::DirectoryRecord
+pub fn hadris_iso::async::read::IsoDirEntry::system_use(&self) -> &[u8]
+pub const fn hadris_iso::async::read::IsoDirEntry::total_size(&self) -> u64
+pub struct hadris_iso::async::read::IsoDirReader<'a, R>
+impl<R: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_iso::async::read::IsoDirReader<'_, R>
+pub async fn hadris_iso::async::read::IsoDirReader<'_, R>::next_entry(&mut self) -> hadris_io::error::Result<core::option::Option<hadris_iso::async::read::IsoDirEntry>>
+pub struct hadris_iso::async::read::IsoFileReader<'a, R>
+impl<R: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_iso::async::read::IsoFileReader<'_, R>
+pub async fn hadris_iso::async::read::IsoFileReader<'_, R>::read_chunk(&mut self, &mut [u8]) -> hadris_io::error::Result<usize>
+impl<R> hadris_iso::async::read::IsoFileReader<'_, R>
+pub const fn hadris_iso::async::read::IsoFileReader<'_, R>::is_empty(&self) -> bool
+pub const fn hadris_iso::async::read::IsoFileReader<'_, R>::len(&self) -> u64
+pub const fn hadris_iso::async::read::IsoFileReader<'_, R>::position(&self) -> u64
 pub struct hadris_iso::async::read::IsoImage<DATA: hadris_io::async_api::Seek>
 impl<DATA: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_iso::async::read::IsoImage<DATA>
 pub async fn hadris_iso::async::read::IsoImage<DATA>::find_path(&self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::async::read::DirEntry>>
@@ -441,6 +469,31 @@ pub async fn hadris_iso::async::read::IsoImage<DATA>::read_pvd(&self) -> hadris_
 impl<DATA: hadris_io::async_api::Seek> hadris_iso::async::read::IsoImage<DATA>
 pub fn hadris_iso::async::read::IsoImage<DATA>::into_inner(self) -> DATA
 pub struct hadris_iso::async::read::IsoImageInfo
+pub struct hadris_iso::async::read::IsoName<'a>
+impl<'a> hadris_iso::async::read::IsoName<'a>
+pub fn hadris_iso::async::read::IsoName<'a>::decode_into(self, &mut [u8]) -> core::result::Result<&str, hadris_iso::async::read::NameError>
+pub fn hadris_iso::async::read::IsoName<'a>::matches(self, &str) -> bool
+pub const fn hadris_iso::async::read::IsoName<'a>::namespace(self) -> hadris_iso::async::read::IsoNamespace
+pub const fn hadris_iso::async::read::IsoName<'a>::raw(self) -> &'a [u8]
+pub struct hadris_iso::async::read::IsoReader<R>
+impl<R: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_iso::async::read::IsoReader<R>
+pub async fn hadris_iso::async::read::IsoReader<R>::find_path(&mut self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::async::read::IsoDirEntry>>
+pub async fn hadris_iso::async::read::IsoReader<R>::find_path_in(&mut self, hadris_iso::async::read::IsoRoot, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::async::read::IsoDirEntry>>
+pub async fn hadris_iso::async::read::IsoReader<R>::open(R) -> hadris_io::error::Result<Self>
+pub fn hadris_iso::async::read::IsoReader<R>::open_dir(&mut self, hadris_iso::async::read::IsoRoot) -> hadris_iso::async::read::IsoDirReader<'_, R>
+pub fn hadris_iso::async::read::IsoReader<R>::open_file<'a>(&'a mut self, &hadris_iso::async::read::IsoDirEntry) -> hadris_io::error::Result<hadris_iso::async::read::IsoFileReader<'a, R>>
+impl<R> hadris_iso::async::read::IsoReader<R>
+pub fn hadris_iso::async::read::IsoReader<R>::into_inner(self) -> R
+pub const fn hadris_iso::async::read::IsoReader<R>::joliet_root(&self) -> core::option::Option<hadris_iso::async::read::IsoRoot>
+pub const fn hadris_iso::async::read::IsoReader<R>::preferred_root(&self) -> hadris_iso::async::read::IsoRoot
+pub const fn hadris_iso::async::read::IsoReader<R>::primary_root(&self) -> hadris_iso::async::read::IsoRoot
+pub fn hadris_iso::async::read::IsoReader<R>::root(&self, hadris_iso::async::read::IsoNamespace) -> core::option::Option<hadris_iso::async::read::IsoRoot>
+pub fn hadris_iso::async::read::IsoReader<R>::roots(&self) -> impl core::iter::traits::iterator::Iterator<Item = hadris_iso::async::read::IsoRoot>
+pub struct hadris_iso::async::read::IsoRoot
+impl hadris_iso::async::read::IsoRoot
+pub const fn hadris_iso::async::read::IsoRoot::block_size(self) -> u16
+pub const fn hadris_iso::async::read::IsoRoot::namespace(self) -> hadris_iso::async::read::IsoNamespace
+pub const fn hadris_iso::async::read::IsoRoot::size(self) -> u32
 pub struct hadris_iso::async::read::RootDir
 impl hadris_iso::async::read::RootDir
 pub fn hadris_iso::async::read::RootDir::dir_ref(&self) -> hadris_iso::async::directory::DirectoryRef
@@ -1823,6 +1876,15 @@ pub mod hadris_iso::read
 pub enum hadris_iso::read::FilenameType
 pub hadris_iso::read::FilenameType::Builtin
 pub hadris_iso::read::FilenameType::Joliet
+pub enum hadris_iso::read::IsoNamespace
+pub hadris_iso::read::IsoNamespace::Joliet(hadris_iso::joliet::JolietLevel)
+pub hadris_iso::read::IsoNamespace::Primary
+pub enum hadris_iso::read::NameError
+pub hadris_iso::read::NameError::BufferTooSmall
+pub hadris_iso::read::NameError::InvalidEncoding
+impl core::error::Error for hadris_iso::read::NameError
+impl core::fmt::Display for hadris_iso::read::NameError
+pub fn hadris_iso::read::NameError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[repr(u8)] pub enum hadris_iso::read::PathSeparator
 pub hadris_iso::read::PathSeparator::Backslash = 92
 pub hadris_iso::read::PathSeparator::ForwardSlash = 47
@@ -1876,12 +1938,34 @@ pub fn hadris_iso::read::IsoDir<'a, T>::raw_entries(&self) -> hadris_iso::read::
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoDir<'_, T>
 pub fn hadris_iso::read::IsoDir<'_, T>::find(&self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::DirEntry>>
 pub fn hadris_iso::read::IsoDir<'_, T>::read_entries(&self) -> hadris_io::error::Result<alloc::vec::Vec<hadris_iso::read::DirEntry>>
+pub struct hadris_iso::read::IsoDirEntry
+impl hadris_iso::read::IsoDirEntry
+pub fn hadris_iso::read::IsoDirEntry::is_directory(&self) -> bool
+pub fn hadris_iso::read::IsoDirEntry::is_file(&self) -> bool
+pub const fn hadris_iso::read::IsoDirEntry::is_multi_extent(&self) -> bool
+pub fn hadris_iso::read::IsoDirEntry::name(&self) -> hadris_iso::read::IsoName<'_>
+pub const fn hadris_iso::read::IsoDirEntry::record(&self) -> &hadris_iso::directory::DirectoryRecord
+pub fn hadris_iso::read::IsoDirEntry::system_use(&self) -> &[u8]
+pub const fn hadris_iso::read::IsoDirEntry::total_size(&self) -> u64
 pub struct hadris_iso::read::IsoDirIter<'a, T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoDirIter<'_, T>
 pub fn hadris_iso::read::IsoDirIter<'_, T>::offset(&self) -> usize
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> core::iter::traits::iterator::Iterator for hadris_iso::read::IsoDirIter<'_, T>
 pub type hadris_iso::read::IsoDirIter<'_, T>::Item = core::result::Result<hadris_iso::read::DirEntry, hadris_io::error::Error>
 pub fn hadris_iso::read::IsoDirIter<'_, T>::next(&mut self) -> core::option::Option<Self::Item>
+pub struct hadris_iso::read::IsoDirReader<'a, R>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoDirReader<'_, R>
+pub fn hadris_iso::read::IsoDirReader<'_, R>::next_entry(&mut self) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::IsoDirEntry>>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> core::iter::traits::iterator::Iterator for hadris_iso::read::IsoDirReader<'_, R>
+pub type hadris_iso::read::IsoDirReader<'_, R>::Item = core::result::Result<hadris_iso::read::IsoDirEntry, hadris_io::error::Error>
+pub fn hadris_iso::read::IsoDirReader<'_, R>::next(&mut self) -> core::option::Option<Self::Item>
+pub struct hadris_iso::read::IsoFileReader<'a, R>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoFileReader<'_, R>
+pub fn hadris_iso::read::IsoFileReader<'_, R>::read_chunk(&mut self, &mut [u8]) -> hadris_io::error::Result<usize>
+impl<R> hadris_iso::read::IsoFileReader<'_, R>
+pub const fn hadris_iso::read::IsoFileReader<'_, R>::is_empty(&self) -> bool
+pub const fn hadris_iso::read::IsoFileReader<'_, R>::len(&self) -> u64
+pub const fn hadris_iso::read::IsoFileReader<'_, R>::position(&self) -> u64
 pub struct hadris_iso::read::IsoImage<DATA: hadris_io::sync_api::Seek>
 impl<DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoImage<DATA>
 pub fn hadris_iso::read::IsoImage<DATA>::find_path(&self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::DirEntry>>
@@ -1902,6 +1986,31 @@ pub fn hadris_iso::read::IsoImage<DATA>::read_pvd(&self) -> hadris_io::error::Re
 impl<DATA: hadris_io::sync_api::Seek> hadris_iso::read::IsoImage<DATA>
 pub fn hadris_iso::read::IsoImage<DATA>::into_inner(self) -> DATA
 pub struct hadris_iso::read::IsoImageInfo
+pub struct hadris_iso::read::IsoName<'a>
+impl<'a> hadris_iso::read::IsoName<'a>
+pub fn hadris_iso::read::IsoName<'a>::decode_into(self, &mut [u8]) -> core::result::Result<&str, hadris_iso::read::NameError>
+pub fn hadris_iso::read::IsoName<'a>::matches(self, &str) -> bool
+pub const fn hadris_iso::read::IsoName<'a>::namespace(self) -> hadris_iso::read::IsoNamespace
+pub const fn hadris_iso::read::IsoName<'a>::raw(self) -> &'a [u8]
+pub struct hadris_iso::read::IsoReader<R>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoReader<R>
+pub fn hadris_iso::read::IsoReader<R>::find_path(&mut self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::IsoDirEntry>>
+pub fn hadris_iso::read::IsoReader<R>::find_path_in(&mut self, hadris_iso::read::IsoRoot, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::IsoDirEntry>>
+pub fn hadris_iso::read::IsoReader<R>::open(R) -> hadris_io::error::Result<Self>
+pub fn hadris_iso::read::IsoReader<R>::open_dir(&mut self, hadris_iso::read::IsoRoot) -> hadris_iso::read::IsoDirReader<'_, R>
+pub fn hadris_iso::read::IsoReader<R>::open_file<'a>(&'a mut self, &hadris_iso::read::IsoDirEntry) -> hadris_io::error::Result<hadris_iso::read::IsoFileReader<'a, R>>
+impl<R> hadris_iso::read::IsoReader<R>
+pub fn hadris_iso::read::IsoReader<R>::into_inner(self) -> R
+pub const fn hadris_iso::read::IsoReader<R>::joliet_root(&self) -> core::option::Option<hadris_iso::read::IsoRoot>
+pub const fn hadris_iso::read::IsoReader<R>::preferred_root(&self) -> hadris_iso::read::IsoRoot
+pub const fn hadris_iso::read::IsoReader<R>::primary_root(&self) -> hadris_iso::read::IsoRoot
+pub fn hadris_iso::read::IsoReader<R>::root(&self, hadris_iso::read::IsoNamespace) -> core::option::Option<hadris_iso::read::IsoRoot>
+pub fn hadris_iso::read::IsoReader<R>::roots(&self) -> impl core::iter::traits::iterator::Iterator<Item = hadris_iso::read::IsoRoot>
+pub struct hadris_iso::read::IsoRoot
+impl hadris_iso::read::IsoRoot
+pub const fn hadris_iso::read::IsoRoot::block_size(self) -> u16
+pub const fn hadris_iso::read::IsoRoot::namespace(self) -> hadris_iso::read::IsoNamespace
+pub const fn hadris_iso::read::IsoRoot::size(self) -> u32
 pub struct hadris_iso::read::RawDirIter<'a, T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::RawDirIter<'_, T>
 pub fn hadris_iso::read::RawDirIter<'_, T>::offset(&self) -> usize
@@ -3062,6 +3171,15 @@ pub mod hadris_iso::sync::read
 pub enum hadris_iso::sync::read::FilenameType
 pub hadris_iso::sync::read::FilenameType::Builtin
 pub hadris_iso::sync::read::FilenameType::Joliet
+pub enum hadris_iso::sync::read::IsoNamespace
+pub hadris_iso::sync::read::IsoNamespace::Joliet(hadris_iso::joliet::JolietLevel)
+pub hadris_iso::sync::read::IsoNamespace::Primary
+pub enum hadris_iso::sync::read::NameError
+pub hadris_iso::sync::read::NameError::BufferTooSmall
+pub hadris_iso::sync::read::NameError::InvalidEncoding
+impl core::error::Error for hadris_iso::read::NameError
+impl core::fmt::Display for hadris_iso::read::NameError
+pub fn hadris_iso::read::NameError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[repr(u8)] pub enum hadris_iso::sync::read::PathSeparator
 pub hadris_iso::sync::read::PathSeparator::Backslash = 92
 pub hadris_iso::sync::read::PathSeparator::ForwardSlash = 47
@@ -3115,12 +3233,34 @@ pub fn hadris_iso::read::IsoDir<'a, T>::raw_entries(&self) -> hadris_iso::read::
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoDir<'_, T>
 pub fn hadris_iso::read::IsoDir<'_, T>::find(&self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::DirEntry>>
 pub fn hadris_iso::read::IsoDir<'_, T>::read_entries(&self) -> hadris_io::error::Result<alloc::vec::Vec<hadris_iso::read::DirEntry>>
+pub struct hadris_iso::sync::read::IsoDirEntry
+impl hadris_iso::read::IsoDirEntry
+pub fn hadris_iso::read::IsoDirEntry::is_directory(&self) -> bool
+pub fn hadris_iso::read::IsoDirEntry::is_file(&self) -> bool
+pub const fn hadris_iso::read::IsoDirEntry::is_multi_extent(&self) -> bool
+pub fn hadris_iso::read::IsoDirEntry::name(&self) -> hadris_iso::read::IsoName<'_>
+pub const fn hadris_iso::read::IsoDirEntry::record(&self) -> &hadris_iso::directory::DirectoryRecord
+pub fn hadris_iso::read::IsoDirEntry::system_use(&self) -> &[u8]
+pub const fn hadris_iso::read::IsoDirEntry::total_size(&self) -> u64
 pub struct hadris_iso::sync::read::IsoDirIter<'a, T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoDirIter<'_, T>
 pub fn hadris_iso::read::IsoDirIter<'_, T>::offset(&self) -> usize
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> core::iter::traits::iterator::Iterator for hadris_iso::read::IsoDirIter<'_, T>
 pub type hadris_iso::read::IsoDirIter<'_, T>::Item = core::result::Result<hadris_iso::read::DirEntry, hadris_io::error::Error>
 pub fn hadris_iso::read::IsoDirIter<'_, T>::next(&mut self) -> core::option::Option<Self::Item>
+pub struct hadris_iso::sync::read::IsoDirReader<'a, R>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoDirReader<'_, R>
+pub fn hadris_iso::read::IsoDirReader<'_, R>::next_entry(&mut self) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::IsoDirEntry>>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> core::iter::traits::iterator::Iterator for hadris_iso::read::IsoDirReader<'_, R>
+pub type hadris_iso::read::IsoDirReader<'_, R>::Item = core::result::Result<hadris_iso::read::IsoDirEntry, hadris_io::error::Error>
+pub fn hadris_iso::read::IsoDirReader<'_, R>::next(&mut self) -> core::option::Option<Self::Item>
+pub struct hadris_iso::sync::read::IsoFileReader<'a, R>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoFileReader<'_, R>
+pub fn hadris_iso::read::IsoFileReader<'_, R>::read_chunk(&mut self, &mut [u8]) -> hadris_io::error::Result<usize>
+impl<R> hadris_iso::read::IsoFileReader<'_, R>
+pub const fn hadris_iso::read::IsoFileReader<'_, R>::is_empty(&self) -> bool
+pub const fn hadris_iso::read::IsoFileReader<'_, R>::len(&self) -> u64
+pub const fn hadris_iso::read::IsoFileReader<'_, R>::position(&self) -> u64
 pub struct hadris_iso::sync::read::IsoImage<DATA: hadris_io::sync_api::Seek>
 impl<DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoImage<DATA>
 pub fn hadris_iso::read::IsoImage<DATA>::find_path(&self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::DirEntry>>
@@ -3141,6 +3281,31 @@ pub fn hadris_iso::read::IsoImage<DATA>::read_pvd(&self) -> hadris_io::error::Re
 impl<DATA: hadris_io::sync_api::Seek> hadris_iso::read::IsoImage<DATA>
 pub fn hadris_iso::read::IsoImage<DATA>::into_inner(self) -> DATA
 pub struct hadris_iso::sync::read::IsoImageInfo
+pub struct hadris_iso::sync::read::IsoName<'a>
+impl<'a> hadris_iso::read::IsoName<'a>
+pub fn hadris_iso::read::IsoName<'a>::decode_into(self, &mut [u8]) -> core::result::Result<&str, hadris_iso::read::NameError>
+pub fn hadris_iso::read::IsoName<'a>::matches(self, &str) -> bool
+pub const fn hadris_iso::read::IsoName<'a>::namespace(self) -> hadris_iso::read::IsoNamespace
+pub const fn hadris_iso::read::IsoName<'a>::raw(self) -> &'a [u8]
+pub struct hadris_iso::sync::read::IsoReader<R>
+impl<R: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::IsoReader<R>
+pub fn hadris_iso::read::IsoReader<R>::find_path(&mut self, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::IsoDirEntry>>
+pub fn hadris_iso::read::IsoReader<R>::find_path_in(&mut self, hadris_iso::read::IsoRoot, &str) -> hadris_io::error::Result<core::option::Option<hadris_iso::read::IsoDirEntry>>
+pub fn hadris_iso::read::IsoReader<R>::open(R) -> hadris_io::error::Result<Self>
+pub fn hadris_iso::read::IsoReader<R>::open_dir(&mut self, hadris_iso::read::IsoRoot) -> hadris_iso::read::IsoDirReader<'_, R>
+pub fn hadris_iso::read::IsoReader<R>::open_file<'a>(&'a mut self, &hadris_iso::read::IsoDirEntry) -> hadris_io::error::Result<hadris_iso::read::IsoFileReader<'a, R>>
+impl<R> hadris_iso::read::IsoReader<R>
+pub fn hadris_iso::read::IsoReader<R>::into_inner(self) -> R
+pub const fn hadris_iso::read::IsoReader<R>::joliet_root(&self) -> core::option::Option<hadris_iso::read::IsoRoot>
+pub const fn hadris_iso::read::IsoReader<R>::preferred_root(&self) -> hadris_iso::read::IsoRoot
+pub const fn hadris_iso::read::IsoReader<R>::primary_root(&self) -> hadris_iso::read::IsoRoot
+pub fn hadris_iso::read::IsoReader<R>::root(&self, hadris_iso::read::IsoNamespace) -> core::option::Option<hadris_iso::read::IsoRoot>
+pub fn hadris_iso::read::IsoReader<R>::roots(&self) -> impl core::iter::traits::iterator::Iterator<Item = hadris_iso::read::IsoRoot>
+pub struct hadris_iso::sync::read::IsoRoot
+impl hadris_iso::read::IsoRoot
+pub const fn hadris_iso::read::IsoRoot::block_size(self) -> u16
+pub const fn hadris_iso::read::IsoRoot::namespace(self) -> hadris_iso::read::IsoNamespace
+pub const fn hadris_iso::read::IsoRoot::size(self) -> u32
 pub struct hadris_iso::sync::read::RawDirIter<'a, T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::RawDirIter<'_, T>
 pub fn hadris_iso::read::RawDirIter<'_, T>::offset(&self) -> usize

--- a/api-snapshots/hadris-optical.txt
+++ b/api-snapshots/hadris-optical.txt
@@ -4,11 +4,11 @@ pub use hadris_optical::iso
 pub use hadris_optical::udf
 pub mod hadris_optical::async
 #[non_exhaustive] pub enum hadris_optical::async::OpenOpticalImage<'a, S> where S: hadris_io::async_api::Read + hadris_io::async_api::Seek<Error = <S as hadris_io::async_api::Read>::Error>
-pub hadris_optical::async::OpenOpticalImage::Iso9660(hadris_iso::async::__inner::read::IsoImage<hadris_io::async_api::Borrowed<'a, S>>)
+pub hadris_optical::async::OpenOpticalImage::Iso9660(hadris_iso::async::__inner::owned_read::IsoImage<hadris_io::async_api::Borrowed<'a, S>>)
 pub hadris_optical::async::OpenOpticalImage::Udf(hadris_udf::async::__inner::fs::UdfFs<hadris_io::async_api::Borrowed<'a, S>>)
 impl<'a, S> hadris_optical::async::OpenOpticalImage<'a, S> where S: hadris_io::async_api::Read + hadris_io::async_api::Seek<Error = <S as hadris_io::async_api::Read>::Error>
-pub fn hadris_optical::async::OpenOpticalImage<'a, S>::as_iso9660(&self) -> core::option::Option<&hadris_iso::async::__inner::read::IsoImage<hadris_io::async_api::Borrowed<'a, S>>>
-pub fn hadris_optical::async::OpenOpticalImage<'a, S>::as_iso9660_mut(&mut self) -> core::option::Option<&mut hadris_iso::async::__inner::read::IsoImage<hadris_io::async_api::Borrowed<'a, S>>>
+pub fn hadris_optical::async::OpenOpticalImage<'a, S>::as_iso9660(&self) -> core::option::Option<&hadris_iso::async::__inner::owned_read::IsoImage<hadris_io::async_api::Borrowed<'a, S>>>
+pub fn hadris_optical::async::OpenOpticalImage<'a, S>::as_iso9660_mut(&mut self) -> core::option::Option<&mut hadris_iso::async::__inner::owned_read::IsoImage<hadris_io::async_api::Borrowed<'a, S>>>
 pub fn hadris_optical::async::OpenOpticalImage<'a, S>::as_udf(&self) -> core::option::Option<&hadris_udf::async::__inner::fs::UdfFs<hadris_io::async_api::Borrowed<'a, S>>>
 pub fn hadris_optical::async::OpenOpticalImage<'a, S>::as_udf_mut(&mut self) -> core::option::Option<&mut hadris_udf::async::__inner::fs::UdfFs<hadris_io::async_api::Borrowed<'a, S>>>
 pub const fn hadris_optical::async::OpenOpticalImage<'a, S>::format(&self) -> hadris_optical::OpticalFormat
@@ -31,11 +31,11 @@ pub const fn hadris_optical::detect::OpticalFormats::is_empty(self) -> bool
 pub const fn hadris_optical::detect::OpticalFormats::udf(self) -> core::option::Option<hadris_optical::detect::UdfVrs>
 pub mod hadris_optical::sync
 #[non_exhaustive] pub enum hadris_optical::sync::OpenOpticalImage<'a, S> where S: hadris_io::sync_api::Read + hadris_io::sync_api::Seek<Error = <S as hadris_io::sync_api::Read>::Error>
-pub hadris_optical::sync::OpenOpticalImage::Iso9660(hadris_iso::sync::__inner::read::IsoImage<hadris_io::sync_api::Borrowed<'a, S>>)
+pub hadris_optical::sync::OpenOpticalImage::Iso9660(hadris_iso::sync::__inner::owned_read::IsoImage<hadris_io::sync_api::Borrowed<'a, S>>)
 pub hadris_optical::sync::OpenOpticalImage::Udf(hadris_udf::sync::__inner::fs::UdfFs<hadris_io::sync_api::Borrowed<'a, S>>)
 impl<'a, S> hadris_optical::sync::OpenOpticalImage<'a, S> where S: hadris_io::sync_api::Read + hadris_io::sync_api::Seek<Error = <S as hadris_io::sync_api::Read>::Error>
-pub fn hadris_optical::sync::OpenOpticalImage<'a, S>::as_iso9660(&self) -> core::option::Option<&hadris_iso::sync::__inner::read::IsoImage<hadris_io::sync_api::Borrowed<'a, S>>>
-pub fn hadris_optical::sync::OpenOpticalImage<'a, S>::as_iso9660_mut(&mut self) -> core::option::Option<&mut hadris_iso::sync::__inner::read::IsoImage<hadris_io::sync_api::Borrowed<'a, S>>>
+pub fn hadris_optical::sync::OpenOpticalImage<'a, S>::as_iso9660(&self) -> core::option::Option<&hadris_iso::sync::__inner::owned_read::IsoImage<hadris_io::sync_api::Borrowed<'a, S>>>
+pub fn hadris_optical::sync::OpenOpticalImage<'a, S>::as_iso9660_mut(&mut self) -> core::option::Option<&mut hadris_iso::sync::__inner::owned_read::IsoImage<hadris_io::sync_api::Borrowed<'a, S>>>
 pub fn hadris_optical::sync::OpenOpticalImage<'a, S>::as_udf(&self) -> core::option::Option<&hadris_udf::sync::__inner::fs::UdfFs<hadris_io::sync_api::Borrowed<'a, S>>>
 pub fn hadris_optical::sync::OpenOpticalImage<'a, S>::as_udf_mut(&mut self) -> core::option::Option<&mut hadris_udf::sync::__inner::fs::UdfFs<hadris_io::sync_api::Borrowed<'a, S>>>
 pub const fn hadris_optical::sync::OpenOpticalImage<'a, S>::format(&self) -> hadris_optical::OpticalFormat

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std", "write", "sync"]
 # No-std + no-alloc read support (minimal, for bootloaders)
 read = ["hadris-common/bytemuck"]
 # Heap allocation without full std
-alloc = ["read", "hadris-io/alloc", "hadris-path/alloc"]
+alloc = ["read", "hadris-io/alloc", "hadris-path/alloc", "hadris-common/alloc"]
 # Standard library support (includes alloc)
 std = ["hadris-io/std", "hadris-common/std", "hadris-common/bytemuck", "alloc", "dep:thiserror", "dep:tracing", "dep:chrono", "chrono/std", "chrono/clock"]
 
@@ -41,7 +41,7 @@ hadris-io = { workspace = true }
 hadris-fixed = { workspace = true }
 hadris-path = { workspace = true }
 hadris-macros = { workspace = true }
-hadris-common = { workspace = true, features = ["alloc", "bytemuck"] }
+hadris-common = { workspace = true, features = ["bytemuck"] }
 hadris-part = { workspace = true, default-features = false }
 spin.workspace = true
 

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "README.md"
-description = "Pure Rust ISO 9660 filesystem library with Joliet, Rock Ridge, and El Torito support"
+description = "Pure Rust ISO 9660 library with allocation-free reading, Joliet, Rock Ridge, and El Torito"
 keywords = ["iso9660", "joliet", "rock-ridge", "el-torito", "no-std"]
 categories = ["filesystem", "embedded", "no-std"]
 exclude = ["/spec"]
@@ -21,7 +21,7 @@ default = ["std", "write", "sync"]
 # No-std + no-alloc read support (minimal, for bootloaders)
 read = ["hadris-common/bytemuck"]
 # Heap allocation without full std
-alloc = ["hadris-io/alloc", "hadris-path/alloc"]
+alloc = ["read", "hadris-io/alloc", "hadris-path/alloc"]
 # Standard library support (includes alloc)
 std = ["hadris-io/std", "hadris-common/std", "hadris-common/bytemuck", "alloc", "dep:thiserror", "dep:tracing", "dep:chrono", "chrono/std", "chrono/clock"]
 

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -1,15 +1,18 @@
 # Hadris ISO
 
-A pure Rust ISO 9660 filesystem and ISO image library with read and write
-support for Joliet, Rock Ridge (RRIP), SUSP, El Torito, and ISO 9660:1999.
-Hadris ISO is designed for desktop applications and `no_std` bootloaders,
-operating-system kernels, firmware, and embedded systems working with CD-ROM,
-DVD, and bootable optical-disc images.
+A pure Rust ISO 9660 filesystem and ISO image library with allocation-free
+reading plus full-featured read/write support for Joliet, Rock Ridge (RRIP),
+SUSP, El Torito, and ISO 9660:1999. Hadris ISO is designed for desktop
+applications and `no_std` bootloaders, operating-system kernels, firmware, and
+embedded systems working with CD-ROM, DVD, and bootable optical-disc images.
 
 ## Features
 
 - **Read & Write Support** - Full-featured ISO creation and extraction
-- **No-std Compatible** - Use in bootloaders and custom kernels
+- **Zero-allocation Reader** - Navigate ISO 9660 and Joliet trees and stream
+  multi-extent files entirely through caller-owned buffers
+- **No-std Compatible** - Use the sync or async reader in bootloaders, firmware,
+  and custom kernels without a global allocator
 - **El-Torito Boot** - Create bootable CD/DVD images for BIOS systems
 - **Joliet Extension** - UTF-16 Unicode filenames (up to 64 characters)
 - **Rock Ridge (RRIP) Extension** - POSIX filesystem semantics (long names, permissions, symlinks)
@@ -97,13 +100,13 @@ IsoImageWriter::create(&mut buffer, files, format_options)?;
 
 | Feature | Description | Dependencies |
 |---------|-------------|--------------|
-| `read` | Minimal read support (no-std, no-alloc) | None |
-| `alloc` | Heap allocation without full std | `alloc` crate |
+| `read` | Allocation-free ISO 9660/Joliet navigation and streamed file reads | No heap allocator |
+| `alloc` | Owned collections, names, RRIP enrichment, and convenience reads | `read`, `alloc` crate |
 | `std` | Full standard library support | `std`, `alloc` |
 | `sync` | Synchronous API under `hadris_iso::sync` | — |
 | `async` | Asynchronous read API under `hadris_iso::r#async` | — |
 | `write` | Synchronous ISO creation/formatting | `std`, `alloc` |
-| `joliet` | UTF-16 Unicode filename support | `alloc` |
+| `joliet` | Allocating Joliet encode/write helpers; allocation-free Joliet reading is part of `read` | `alloc` |
 
 `std` selects platform integration but does not select an I/O mode. The default
 configuration enables `sync`; custom configurations should select `sync`,
@@ -116,6 +119,29 @@ only under `sync`.
 [dependencies]
 hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
 ```
+
+The `read` feature exposes `IsoReader`, which opens and navigates ISO 9660 and
+Joliet trees without heap allocation. It performs nested path lookup, groups
+multi-extent files, and streams file contents into caller-owned buffers in
+both synchronous and asynchronous configurations:
+
+```rust
+use hadris_iso::read::IsoReader;
+
+let mut image = IsoReader::open(device)?;
+if let Some(entry) = image.find_path("BOOT/KERNEL.BIN")? {
+    let mut file = image.open_file(&entry)?;
+    while file.read_chunk(&mut scratch)? != 0 {
+        // Consume the initialized part of `scratch`.
+    }
+}
+# Ok::<(), hadris_iso::Error>(())
+```
+
+The reader prefers the highest recognized Joliet namespace. Use
+`primary_root()` with `find_path_in()` when raw ISO 9660 naming is required.
+Rock Ridge enrichment remains part of the allocation-backed `IsoImage` API;
+the allocation-free reader exposes raw system-use bytes for custom handling.
 
 ### For Kernels with Heap (no-std + alloc)
 
@@ -135,11 +161,11 @@ hadris-iso = "2.0.0-rc.1"  # Uses default features
 
 | Extension | Read | Write | Notes |
 |-----------|------|-------|-------|
-| ISO 9660 Level 1-3 | Yes | Yes | 8.3 to 31 character filenames, proper truncation handling |
+| ISO 9660 Level 1-3 | Yes | Yes | Allocation-free navigation and multi-extent streaming available |
 | ISO 9660:1999 | Yes | Yes | Long filenames up to 207 chars (Level 2/3 compliance) |
 | SUSP | Yes | Yes | System Use Sharing Protocol for extension framework |
-| Joliet | Yes | Yes | UTF-16 BE, up to 64 characters |
-| Rock Ridge (RRIP) | Yes | Yes | Read/write POSIX metadata, timestamps, symlinks, devices, and deep-directory relocation through SUSP/RRIP. |
+| Joliet | Yes | Yes | Allocation-free UTF-16BE lookup/decoding; owned helpers with `alloc` |
+| Rock Ridge (RRIP) | Yes | Yes | Allocation-backed metadata enrichment; raw system-use bytes remain available without `alloc` |
 | El-Torito | Yes | Yes | BIOS bootable images |
 | Hybrid Boot (MBR/GPT) | - | Yes | USB bootable images (MBR, GPT, or dual) |
 

--- a/crates/optical/hadris-iso/src/lib.rs
+++ b/crates/optical/hadris-iso/src/lib.rs
@@ -1,11 +1,12 @@
 //! # Hadris ISO
 //!
-//! A pure Rust ISO 9660 filesystem and disk-image library with support for
-//! Joliet, Rock Ridge (RRIP), El Torito booting, and `no_std` environments.
+//! A pure Rust ISO 9660 filesystem and disk-image library with allocation-free
+//! ISO 9660/Joliet reading, Rock Ridge (RRIP), El Torito booting, and `no_std`
+//! support.
 //!
 //! This crate provides both reading and writing capabilities for ISO 9660 images,
 //! making it suitable for:
-//! - **Bootloaders**: Minimal no-std + no-alloc read support
+//! - **Bootloaders**: Allocation-free path lookup and caller-buffered file streaming
 //! - **OS Kernels**: Read ISO filesystems with only a heap allocator
 //! - **Desktop Applications**: Full-featured ISO creation and extraction
 //! - **Build Systems**: Automated bootable ISO generation
@@ -132,11 +133,11 @@
 //!
 //! | Feature | Description | Dependencies |
 //! |---------|-------------|--------------|
-//! | `read` | Minimal read support (no-std, no-alloc) | None |
-//! | `alloc` | Heap allocation without full std | `alloc` crate |
+//! | `read` | Allocation-free ISO 9660/Joliet navigation and streaming | No heap allocator |
+//! | `alloc` | Owned collections, RRIP enrichment, and convenience reads | `alloc` crate |
 //! | `std` | Full standard library support | `std`, `alloc`, `thiserror`, `tracing`, `chrono` |
 //! | `write` | ISO creation/formatting | `std`, `alloc` |
-//! | `joliet` | UTF-16 Unicode filename support | `alloc` |
+//! | `joliet` | Allocating Joliet encode/write helpers (`read` already supports Joliet lookup) | `alloc` |
 //!
 //! ### Feature Combinations
 //!
@@ -312,7 +313,7 @@ pub mod types;
 /// - **Level 1**: Escape sequence `%/@`
 /// - **Level 2**: Escape sequence `%/C`
 /// - **Level 3**: Escape sequence `%/E` (recommended)
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "read", feature = "alloc"))]
 pub mod joliet;
 
 // ---------------------------------------------------------------------------
@@ -486,7 +487,21 @@ pub mod sync {
         /// }
         /// ```
         #[cfg(feature = "alloc")]
-        pub mod read;
+        #[path = "read/mod.rs"]
+        mod owned_read;
+
+        #[cfg(feature = "read")]
+        #[path = "read/basic.rs"]
+        mod basic_read;
+
+        /// ISO image reading APIs.
+        #[cfg(any(feature = "read", feature = "alloc"))]
+        pub mod read {
+            #[cfg(feature = "read")]
+            pub use super::basic_read::*;
+            #[cfg(feature = "alloc")]
+            pub use super::owned_read::*;
+        }
 
         /// ISO image creation and formatting.
         ///
@@ -589,16 +604,27 @@ pub mod r#async {
 
     #[path = "."]
     mod __inner {
+        #[cfg(feature = "read")]
+        #[path = "read/basic.rs"]
+        mod basic_read;
         pub mod boot;
         /// APIs for directory.
         pub mod directory;
         /// APIs for io.
         pub mod io;
+        #[cfg(feature = "alloc")]
+        #[path = "read/mod.rs"]
+        mod owned_read;
         /// APIs for path.
         pub mod path;
-        #[cfg(feature = "alloc")]
-        /// APIs for read.
-        pub mod read;
+        #[cfg(any(feature = "read", feature = "alloc"))]
+        /// APIs for reading ISO images.
+        pub mod read {
+            #[cfg(feature = "read")]
+            pub use super::basic_read::*;
+            #[cfg(feature = "alloc")]
+            pub use super::owned_read::*;
+        }
         #[cfg(feature = "alloc")]
         pub mod rrip;
         #[cfg(feature = "alloc")]

--- a/crates/optical/hadris-iso/src/read/basic.rs
+++ b/crates/optical/hadris-iso/src/read/basic.rs
@@ -1,0 +1,656 @@
+//! Allocation-free ISO 9660 reader.
+
+use core::char::decode_utf16;
+
+use super::directory::{DirectoryRecord, DirectoryRecordHeader, FileFlags};
+use super::io::{self, Read, Seek, SeekFrom};
+use super::volume::{
+    PrimaryVolumeDescriptor, SupplementaryVolumeDescriptor, VolumeDescriptor,
+    VolumeDescriptorHeader, VolumeDescriptorType,
+};
+use crate::joliet::JolietLevel;
+
+const DESCRIPTOR_SIZE: u64 = 2048;
+const FIRST_DESCRIPTOR: u64 = 16;
+const MIN_RECORD_SIZE: usize = core::mem::size_of::<DirectoryRecordHeader>() + 1;
+
+/// A filename namespace exposed by an ISO image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsoNamespace {
+    /// The primary ISO 9660 directory tree.
+    Primary,
+    /// A Joliet supplementary directory tree.
+    Joliet(JolietLevel),
+}
+
+/// A root directory and the namespace it represents.
+#[derive(Debug, Clone, Copy)]
+pub struct IsoRoot {
+    namespace: IsoNamespace,
+    extent: u32,
+    size: u32,
+    block_size: u16,
+}
+
+impl IsoRoot {
+    /// Returns the root's filename namespace.
+    pub const fn namespace(self) -> IsoNamespace {
+        self.namespace
+    }
+
+    /// Returns the root directory's byte length.
+    pub const fn size(self) -> u32 {
+        self.size
+    }
+
+    /// Returns the image logical-block size used by this tree.
+    pub const fn block_size(self) -> u16 {
+        self.block_size
+    }
+}
+
+/// An error produced while decoding an entry name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameError {
+    /// The on-disk name is not valid for its namespace.
+    InvalidEncoding,
+    /// The caller-provided UTF-8 buffer is too small.
+    BufferTooSmall,
+}
+
+impl core::fmt::Display for NameError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidEncoding => f.write_str("invalid ISO filename encoding"),
+            Self::BufferTooSmall => f.write_str("filename output buffer is too small"),
+        }
+    }
+}
+
+impl core::error::Error for NameError {}
+
+/// A borrowed, allocation-free view of an ISO directory-entry name.
+#[derive(Debug, Clone, Copy)]
+pub struct IsoName<'a> {
+    raw: &'a [u8],
+    namespace: IsoNamespace,
+}
+
+impl<'a> IsoName<'a> {
+    /// Returns the name exactly as stored in the directory record.
+    pub const fn raw(self) -> &'a [u8] {
+        self.raw
+    }
+
+    /// Returns the name's namespace and encoding.
+    pub const fn namespace(self) -> IsoNamespace {
+        self.namespace
+    }
+
+    /// Compares this name with a UTF-8 path component without allocating.
+    pub fn matches(self, candidate: &str) -> bool {
+        if self.raw == [0] {
+            return candidate == ".";
+        }
+        if self.raw == [1] {
+            return candidate == "..";
+        }
+        match self.namespace {
+            IsoNamespace::Primary => {
+                strip_primary_version(self.raw).eq_ignore_ascii_case(candidate.as_bytes())
+            }
+            IsoNamespace::Joliet(_) => joliet_matches(strip_joliet_version(self.raw), candidate),
+        }
+    }
+
+    /// Decodes the name as UTF-8 into `output` and returns the initialized text.
+    pub fn decode_into(self, output: &mut [u8]) -> Result<&str, NameError> {
+        if self.raw == [0] {
+            return write_special(output, b".");
+        }
+        if self.raw == [1] {
+            return write_special(output, b"..");
+        }
+        match self.namespace {
+            IsoNamespace::Primary => {
+                let raw = strip_primary_version(self.raw);
+                if !raw.is_ascii() {
+                    return Err(NameError::InvalidEncoding);
+                }
+                if raw.len() > output.len() {
+                    return Err(NameError::BufferTooSmall);
+                }
+                output[..raw.len()].copy_from_slice(raw);
+                core::str::from_utf8(&output[..raw.len()]).map_err(|_| NameError::InvalidEncoding)
+            }
+            IsoNamespace::Joliet(_) => decode_joliet_into(strip_joliet_version(self.raw), output),
+        }
+    }
+}
+
+fn write_special<'a>(output: &'a mut [u8], value: &[u8]) -> Result<&'a str, NameError> {
+    if value.len() > output.len() {
+        return Err(NameError::BufferTooSmall);
+    }
+    output[..value.len()].copy_from_slice(value);
+    core::str::from_utf8(&output[..value.len()]).map_err(|_| NameError::InvalidEncoding)
+}
+
+fn strip_primary_version(raw: &[u8]) -> &[u8] {
+    if let Some(pos) = raw.iter().rposition(|byte| *byte == b';')
+        && pos + 1 < raw.len()
+        && raw[pos + 1..].iter().all(u8::is_ascii_digit)
+    {
+        &raw[..pos]
+    } else {
+        raw
+    }
+}
+
+fn strip_joliet_version(raw: &[u8]) -> &[u8] {
+    if raw.len() % 2 != 0 {
+        return raw;
+    }
+    let mut pos = raw.len();
+    while pos >= 2 && raw[pos - 2] == 0 && raw[pos - 1].is_ascii_digit() {
+        pos -= 2;
+    }
+    if pos + 2 <= raw.len() && pos >= 2 && raw[pos - 2..pos] == [0, b';'] {
+        &raw[..pos - 2]
+    } else {
+        raw
+    }
+}
+
+fn joliet_matches(raw: &[u8], candidate: &str) -> bool {
+    if raw.len() % 2 != 0 {
+        return false;
+    }
+    let units = raw
+        .chunks_exact(2)
+        .map(|pair| u16::from_be_bytes([pair[0], pair[1]]));
+    let mut expected = candidate.chars();
+    for decoded in decode_utf16(units) {
+        let Ok(ch) = decoded else {
+            return false;
+        };
+        if expected.next() != Some(ch) {
+            return false;
+        }
+    }
+    expected.next().is_none()
+}
+
+fn decode_joliet_into<'a>(raw: &[u8], output: &'a mut [u8]) -> Result<&'a str, NameError> {
+    if raw.len() % 2 != 0 {
+        return Err(NameError::InvalidEncoding);
+    }
+    let units = raw
+        .chunks_exact(2)
+        .map(|pair| u16::from_be_bytes([pair[0], pair[1]]));
+    let mut written = 0;
+    for decoded in decode_utf16(units) {
+        let ch = decoded.map_err(|_| NameError::InvalidEncoding)?;
+        let needed = ch.len_utf8();
+        if written + needed > output.len() {
+            return Err(NameError::BufferTooSmall);
+        }
+        ch.encode_utf8(&mut output[written..written + needed]);
+        written += needed;
+    }
+    core::str::from_utf8(&output[..written]).map_err(|_| NameError::InvalidEncoding)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DirectoryLocation {
+    extent: u32,
+    size: u32,
+    block_size: u16,
+    namespace: IsoNamespace,
+}
+
+impl From<IsoRoot> for DirectoryLocation {
+    fn from(root: IsoRoot) -> Self {
+        Self {
+            extent: root.extent,
+            size: root.size,
+            block_size: root.block_size,
+            namespace: root.namespace,
+        }
+    }
+}
+
+/// An owned, fixed-size directory entry returned by the allocation-free reader.
+#[derive(Debug, Clone, Copy)]
+pub struct IsoDirEntry {
+    record: DirectoryRecord,
+    directory: DirectoryLocation,
+    continuation_offset: Option<u32>,
+    total_size: u64,
+}
+
+impl IsoDirEntry {
+    /// Returns the underlying ISO directory record.
+    pub const fn record(&self) -> &DirectoryRecord {
+        &self.record
+    }
+
+    /// Returns an allocation-free view of the filename.
+    pub fn name(&self) -> IsoName<'_> {
+        IsoName {
+            raw: self.record.name(),
+            namespace: self.directory.namespace,
+        }
+    }
+
+    /// Returns whether this entry is a directory.
+    pub fn is_directory(&self) -> bool {
+        self.record.is_directory()
+    }
+
+    /// Returns whether this entry is a regular file.
+    pub fn is_file(&self) -> bool {
+        !self.is_directory()
+    }
+
+    /// Returns whether the file uses multiple extents.
+    pub const fn is_multi_extent(&self) -> bool {
+        self.continuation_offset.is_some()
+    }
+
+    /// Returns the total data length across all file extents.
+    pub const fn total_size(&self) -> u64 {
+        self.total_size
+    }
+
+    /// Returns the raw system-use area.
+    pub fn system_use(&self) -> &[u8] {
+        self.record.system_use()
+    }
+}
+
+/// Allocation-free ISO 9660 image reader.
+#[derive(Debug)]
+pub struct IsoReader<R> {
+    source: R,
+    primary: IsoRoot,
+    joliet: Option<IsoRoot>,
+}
+
+impl<R> IsoReader<R> {
+    /// Consumes the reader and returns its underlying data source.
+    pub fn into_inner(self) -> R {
+        self.source
+    }
+
+    /// Returns the primary ISO 9660 root.
+    pub const fn primary_root(&self) -> IsoRoot {
+        self.primary
+    }
+
+    /// Returns the highest-level recognized Joliet root, when present.
+    pub const fn joliet_root(&self) -> Option<IsoRoot> {
+        self.joliet
+    }
+
+    /// Returns the preferred root, choosing Joliet over the primary namespace.
+    pub const fn preferred_root(&self) -> IsoRoot {
+        match self.joliet {
+            Some(root) => root,
+            None => self.primary,
+        }
+    }
+
+    /// Iterates over the primary root followed by the optional Joliet root.
+    pub fn roots(&self) -> impl Iterator<Item = IsoRoot> {
+        [Some(self.primary), self.joliet].into_iter().flatten()
+    }
+
+    /// Selects a root by namespace.
+    pub fn root(&self, namespace: IsoNamespace) -> Option<IsoRoot> {
+        match namespace {
+            IsoNamespace::Primary => Some(self.primary),
+            IsoNamespace::Joliet(level) => self
+                .joliet
+                .filter(|root| root.namespace == IsoNamespace::Joliet(level)),
+        }
+    }
+}
+
+io_transform! {
+impl<R: Read + Seek> IsoReader<R> {
+    /// Opens an ISO image without allocating.
+    pub async fn open(mut source: R) -> io::Result<Self> {
+        let mut primary = None;
+        let mut joliet = None;
+        let mut sector = FIRST_DESCRIPTOR;
+        loop {
+            source.seek(SeekFrom::Start(sector.checked_mul(DESCRIPTOR_SIZE).ok_or_else(overflow)?))
+                .await.map_err(io::Error::erase)?;
+            let mut bytes = [0_u8; DESCRIPTOR_SIZE as usize];
+            source.read_exact(&mut bytes).await?;
+            let header = VolumeDescriptorHeader::from_bytes(&bytes[..7]);
+            if !header.is_valid() {
+                return Err(invalid("invalid volume descriptor header"));
+            }
+            let ty = VolumeDescriptorType::from_u8(header.descriptor_type);
+            if ty == VolumeDescriptorType::VolumeSetTerminator { break; }
+            match VolumeDescriptor::new(bytes) {
+                VolumeDescriptor::Primary(descriptor) => primary = Some(root_from_primary(&descriptor)?),
+                VolumeDescriptor::Supplementary(descriptor) => {
+                    if let Some(root) = root_from_joliet(&descriptor)?
+                        && joliet.map(|old: IsoRoot| joliet_level(old) < joliet_level(root)).unwrap_or(true)
+                    { joliet = Some(root); }
+                }
+                _ => {}
+            }
+            sector = sector.checked_add(1).ok_or_else(overflow)?;
+        }
+        let primary = primary.ok_or_else(|| invalid("primary volume descriptor not found"))?;
+        Ok(Self { source, primary, joliet })
+    }
+
+    /// Opens an allocation-free directory reader.
+    pub fn open_dir(&mut self, root: IsoRoot) -> IsoDirReader<'_, R> {
+        IsoDirReader { image: self, directory: root.into(), offset: 0 }
+    }
+
+    /// Finds an entry using the preferred namespace.
+    pub async fn find_path(&mut self, path: &str) -> io::Result<Option<IsoDirEntry>> {
+        self.find_path_in(self.preferred_root(), path).await
+    }
+
+    /// Finds an entry in an explicitly selected directory tree.
+    pub async fn find_path_in(&mut self, root: IsoRoot, path: &str) -> io::Result<Option<IsoDirEntry>> {
+        let mut location = DirectoryLocation::from(root);
+        let mut components = hadris_path::VPath::with_separators(
+            path, hadris_path::Separators::SlashOrBackslash
+        ).components().filter_map(|component| match component {
+            hadris_path::Component::Root | hadris_path::Component::Current => None,
+            other => Some(other),
+        }).peekable();
+
+        while let Some(component) = components.next() {
+            let hadris_path::Component::Normal(name) = component else {
+                return Err(io::Error::new(io::ErrorKind::InvalidInput, "parent path components are not supported"));
+            };
+            let mut offset = 0;
+            let mut found = None;
+            while let Some(entry) = self.next_entry(location, &mut offset).await? {
+                let flags = FileFlags::from_bits_retain(entry.record.header().flags);
+                if !entry.record.is_special()
+                    && !flags.contains(FileFlags::ASSOCIATED_FILE)
+                    && entry.name().matches(name)
+                { found = Some(entry); break; }
+            }
+            let Some(entry) = found else { return Ok(None); };
+            if components.peek().is_none() { return Ok(Some(entry)); }
+            if !entry.is_directory() { return Ok(None); }
+            location = entry_directory(&entry)?;
+        }
+        Ok(None)
+    }
+
+    /// Opens a caller-buffered stream for a file entry.
+    pub fn open_file<'a>(&'a mut self, entry: &IsoDirEntry) -> io::Result<IsoFileReader<'a, R>> {
+        validate_file(entry)?;
+        Ok(IsoFileReader { image: self, entry: *entry, position: 0 })
+    }
+
+    async fn next_entry(&mut self, directory: DirectoryLocation, offset: &mut u32) -> io::Result<Option<IsoDirEntry>> {
+        let Some(record) = self.next_raw(directory, offset).await? else { return Ok(None); };
+        let first_flags = FileFlags::from_bits_retain(record.header().flags);
+        let continuation_offset = first_flags.contains(FileFlags::NOT_FINAL).then_some(*offset);
+        let mut total_size = record.header().data_len.read() as u64;
+        if continuation_offset.is_some() {
+            loop {
+                let continuation = self.next_raw(directory, offset).await?
+                    .ok_or_else(|| invalid("truncated multi-extent file"))?;
+                validate_continuation(&record, &continuation)?;
+                total_size = total_size.checked_add(continuation.header().data_len.read() as u64)
+                    .ok_or_else(overflow)?;
+                if !FileFlags::from_bits_retain(continuation.header().flags).contains(FileFlags::NOT_FINAL) { break; }
+            }
+        }
+        Ok(Some(IsoDirEntry { record, directory, continuation_offset, total_size }))
+    }
+
+    async fn next_raw(&mut self, directory: DirectoryLocation, offset: &mut u32) -> io::Result<Option<DirectoryRecord>> {
+        let block = directory.block_size as u32;
+        while *offset < directory.size {
+            let base = byte_offset(directory.extent, directory.block_size)?;
+            let absolute = base.checked_add(*offset as u64).ok_or_else(overflow)?;
+            self.source.seek(SeekFrom::Start(absolute)).await.map_err(io::Error::erase)?;
+            let mut len = [0_u8; 1];
+            self.source.read_exact(&mut len).await?;
+            if len[0] == 0 {
+                let next = ((*offset / block) + 1).checked_mul(block).ok_or_else(overflow)?;
+                if next <= *offset { return Err(invalid("directory offset did not advance")); }
+                *offset = next.min(directory.size);
+                continue;
+            }
+            let len = len[0] as usize;
+            if len < MIN_RECORD_SIZE || (*offset % block) as usize + len > block as usize {
+                return Err(invalid("invalid directory record length"));
+            }
+            self.source.seek(SeekFrom::Start(absolute)).await.map_err(io::Error::erase)?;
+            let mut header_bytes = [0_u8; core::mem::size_of::<DirectoryRecordHeader>()];
+            self.source.read_exact(&mut header_bytes).await?;
+            let header: DirectoryRecordHeader = bytemuck::pod_read_unaligned(&header_bytes);
+            let name_end = MIN_RECORD_SIZE - 1 + header.file_identifier_len as usize;
+            if name_end > len { return Err(invalid("directory identifier exceeds record")); }
+            self.source.seek(SeekFrom::Start(absolute)).await.map_err(io::Error::erase)?;
+            let record = DirectoryRecord::parse(&mut self.source).await?;
+            *offset = offset.checked_add(len as u32).ok_or_else(overflow)?;
+            return Ok(Some(record));
+        }
+        Ok(None)
+    }
+
+    async fn read_file_at(&mut self, entry: &IsoDirEntry, file_offset: u64, output: &mut [u8]) -> io::Result<usize> {
+        if file_offset >= entry.total_size || output.is_empty() { return Ok(0); }
+        validate_file(entry)?;
+        let wanted = output.len().min((entry.total_size - file_offset) as usize);
+        let mut written = 0;
+        let mut logical_start = 0_u64;
+        let mut record = entry.record;
+        let mut continuation_cursor = entry.continuation_offset;
+        loop {
+            let extent_len = record.header().data_len.read() as u64;
+            if file_offset < logical_start + extent_len && written < wanted {
+                let within = file_offset.saturating_sub(logical_start);
+                let available = (extent_len - within) as usize;
+                let take = available.min(wanted - written);
+                let xar = record.header().extended_attr_record as u64 * entry.directory.block_size as u64;
+                let absolute = byte_offset(record.header().extent.read(), entry.directory.block_size)?
+                    .checked_add(xar).and_then(|value| value.checked_add(within)).ok_or_else(overflow)?;
+                self.source.seek(SeekFrom::Start(absolute)).await.map_err(io::Error::erase)?;
+                self.source.read_exact(&mut output[written..written + take]).await?;
+                written += take;
+            }
+            logical_start = logical_start.checked_add(extent_len).ok_or_else(overflow)?;
+            if written == wanted { return Ok(written); }
+            let Some(ref mut cursor) = continuation_cursor else { return Ok(written); };
+            let Some(next) = self.next_raw(entry.directory, cursor).await? else {
+                return Err(invalid("truncated multi-extent file"));
+            };
+            validate_continuation(&entry.record, &next)?;
+            let more = FileFlags::from_bits_retain(next.header().flags).contains(FileFlags::NOT_FINAL);
+            record = next;
+            if !more { continuation_cursor = None; }
+        }
+    }
+}
+} // io_transform!
+
+/// Streaming allocation-free directory reader.
+pub struct IsoDirReader<'a, R> {
+    image: &'a mut IsoReader<R>,
+    directory: DirectoryLocation,
+    offset: u32,
+}
+
+io_transform! {
+impl<R: Read + Seek> IsoDirReader<'_, R> {
+    /// Reads the next logical directory entry.
+    pub async fn next_entry(&mut self) -> io::Result<Option<IsoDirEntry>> {
+        self.image.next_entry(self.directory, &mut self.offset).await
+    }
+}
+} // io_transform!
+
+sync_only! {
+impl<R: Read + Seek> Iterator for IsoDirReader<'_, R> {
+    type Item = io::Result<IsoDirEntry>;
+    fn next(&mut self) -> Option<Self::Item> { self.next_entry().transpose() }
+}
+}
+
+/// Caller-buffered file stream backed by an [`IsoReader`].
+pub struct IsoFileReader<'a, R> {
+    image: &'a mut IsoReader<R>,
+    entry: IsoDirEntry,
+    position: u64,
+}
+
+impl<R> IsoFileReader<'_, R> {
+    /// Returns the complete logical file length.
+    pub const fn len(&self) -> u64 {
+        self.entry.total_size
+    }
+
+    /// Returns whether the file contains no bytes.
+    pub const fn is_empty(&self) -> bool {
+        self.entry.total_size == 0
+    }
+
+    /// Returns the current logical read position.
+    pub const fn position(&self) -> u64 {
+        self.position
+    }
+}
+
+io_transform! {
+impl<R: Read + Seek> IsoFileReader<'_, R> {
+    /// Reads the next chunk into a caller-provided buffer.
+    pub async fn read_chunk(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        let read = self.image.read_file_at(&self.entry, self.position, output).await?;
+        self.position += read as u64;
+        Ok(read)
+    }
+}
+} // io_transform!
+
+fn root_from_primary(descriptor: &PrimaryVolumeDescriptor) -> io::Result<IsoRoot> {
+    make_root(
+        IsoNamespace::Primary,
+        descriptor.logical_block_size.read(),
+        descriptor.dir_record.header.extent.read(),
+        descriptor.dir_record.header.data_len.read(),
+        descriptor.dir_record.header.extended_attr_record,
+    )
+}
+
+fn root_from_joliet(descriptor: &SupplementaryVolumeDescriptor) -> io::Result<Option<IsoRoot>> {
+    let Some(level) = JolietLevel::from_escape_sequence(&descriptor.escape_sequences) else {
+        return Ok(None);
+    };
+    Ok(Some(make_root(
+        IsoNamespace::Joliet(level),
+        descriptor.logical_block_size.read(),
+        descriptor.dir_record.header.extent.read(),
+        descriptor.dir_record.header.data_len.read(),
+        descriptor.dir_record.header.extended_attr_record,
+    )?))
+}
+
+fn joliet_level(root: IsoRoot) -> JolietLevel {
+    match root.namespace {
+        IsoNamespace::Joliet(level) => level,
+        IsoNamespace::Primary => unreachable!("primary root used as Joliet root"),
+    }
+}
+
+fn make_root(
+    namespace: IsoNamespace,
+    block_size: u16,
+    extent: u32,
+    size: u32,
+    xar_blocks: u8,
+) -> io::Result<IsoRoot> {
+    if block_size < 512 || !block_size.is_power_of_two() {
+        return Err(invalid("invalid logical block size"));
+    }
+    let extent = extent.checked_add(xar_blocks as u32).ok_or_else(overflow)?;
+    byte_offset(extent, block_size)?;
+    Ok(IsoRoot {
+        namespace,
+        extent,
+        size,
+        block_size,
+    })
+}
+
+fn entry_directory(entry: &IsoDirEntry) -> io::Result<DirectoryLocation> {
+    if !entry.is_directory() {
+        return Err(invalid("entry is not a directory"));
+    }
+    Ok(DirectoryLocation {
+        extent: entry
+            .record
+            .header()
+            .extent
+            .read()
+            .checked_add(entry.record.header().extended_attr_record as u32)
+            .ok_or_else(overflow)?,
+        size: entry.record.header().data_len.read(),
+        block_size: entry.directory.block_size,
+        namespace: entry.directory.namespace,
+    })
+}
+
+fn validate_file(entry: &IsoDirEntry) -> io::Result<()> {
+    if entry.is_directory() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "entry is a directory",
+        ));
+    }
+    let header = entry.record.header();
+    if header.file_unit_size != 0 || header.interleave_gap_size != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "interleaved files are unsupported",
+        ));
+    }
+    if header.volume_sequence_number.read() != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "multi-volume files are unsupported",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_continuation(first: &DirectoryRecord, next: &DirectoryRecord) -> io::Result<()> {
+    if first.name() != next.name()
+        || next.is_directory()
+        || FileFlags::from_bits_retain(next.header().flags).contains(FileFlags::ASSOCIATED_FILE)
+    {
+        return Err(invalid("invalid multi-extent continuation"));
+    }
+    Ok(())
+}
+
+fn byte_offset(extent: u32, block_size: u16) -> io::Result<u64> {
+    (extent as u64)
+        .checked_mul(block_size as u64)
+        .ok_or_else(overflow)
+}
+
+fn invalid(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+fn overflow() -> io::Error {
+    invalid("ISO offset overflow")
+}

--- a/crates/optical/hadris-iso/src/read/basic.rs
+++ b/crates/optical/hadris-iso/src/read/basic.rs
@@ -394,7 +394,14 @@ impl<R: Read + Seek> IsoReader<R> {
     /// Opens a caller-buffered stream for a file entry.
     pub fn open_file<'a>(&'a mut self, entry: &IsoDirEntry) -> io::Result<IsoFileReader<'a, R>> {
         validate_file(entry)?;
-        Ok(IsoFileReader { image: self, entry: *entry, position: 0 })
+        Ok(IsoFileReader {
+            image: self,
+            entry: *entry,
+            current_record: entry.record,
+            current_extent_start: 0,
+            continuation_cursor: entry.continuation_offset,
+            position: 0,
+        })
     }
 
     async fn next_entry(&mut self, directory: DirectoryLocation, offset: &mut u32) -> io::Result<Option<IsoDirEntry>> {
@@ -433,9 +440,9 @@ impl<R: Read + Seek> IsoReader<R> {
             if len < MIN_RECORD_SIZE || (*offset % block) as usize + len > block as usize {
                 return Err(invalid("invalid directory record length"));
             }
-            self.source.seek(SeekFrom::Start(absolute)).await.map_err(io::Error::erase)?;
             let mut header_bytes = [0_u8; core::mem::size_of::<DirectoryRecordHeader>()];
-            self.source.read_exact(&mut header_bytes).await?;
+            header_bytes[0] = len as u8;
+            self.source.read_exact(&mut header_bytes[1..]).await?;
             let header: DirectoryRecordHeader = bytemuck::pod_read_unaligned(&header_bytes);
             let name_end = MIN_RECORD_SIZE - 1 + header.file_identifier_len as usize;
             if name_end > len { return Err(invalid("directory identifier exceeds record")); }
@@ -447,39 +454,6 @@ impl<R: Read + Seek> IsoReader<R> {
         Ok(None)
     }
 
-    async fn read_file_at(&mut self, entry: &IsoDirEntry, file_offset: u64, output: &mut [u8]) -> io::Result<usize> {
-        if file_offset >= entry.total_size || output.is_empty() { return Ok(0); }
-        validate_file(entry)?;
-        let wanted = output.len().min((entry.total_size - file_offset) as usize);
-        let mut written = 0;
-        let mut logical_start = 0_u64;
-        let mut record = entry.record;
-        let mut continuation_cursor = entry.continuation_offset;
-        loop {
-            let extent_len = record.header().data_len.read() as u64;
-            if file_offset < logical_start + extent_len && written < wanted {
-                let within = file_offset.saturating_sub(logical_start);
-                let available = (extent_len - within) as usize;
-                let take = available.min(wanted - written);
-                let xar = record.header().extended_attr_record as u64 * entry.directory.block_size as u64;
-                let absolute = byte_offset(record.header().extent.read(), entry.directory.block_size)?
-                    .checked_add(xar).and_then(|value| value.checked_add(within)).ok_or_else(overflow)?;
-                self.source.seek(SeekFrom::Start(absolute)).await.map_err(io::Error::erase)?;
-                self.source.read_exact(&mut output[written..written + take]).await?;
-                written += take;
-            }
-            logical_start = logical_start.checked_add(extent_len).ok_or_else(overflow)?;
-            if written == wanted { return Ok(written); }
-            let Some(ref mut cursor) = continuation_cursor else { return Ok(written); };
-            let Some(next) = self.next_raw(entry.directory, cursor).await? else {
-                return Err(invalid("truncated multi-extent file"));
-            };
-            validate_continuation(&entry.record, &next)?;
-            let more = FileFlags::from_bits_retain(next.header().flags).contains(FileFlags::NOT_FINAL);
-            record = next;
-            if !more { continuation_cursor = None; }
-        }
-    }
 }
 } // io_transform!
 
@@ -510,6 +484,9 @@ impl<R: Read + Seek> Iterator for IsoDirReader<'_, R> {
 pub struct IsoFileReader<'a, R> {
     image: &'a mut IsoReader<R>,
     entry: IsoDirEntry,
+    current_record: DirectoryRecord,
+    current_extent_start: u64,
+    continuation_cursor: Option<u32>,
     position: u64,
 }
 
@@ -534,9 +511,58 @@ io_transform! {
 impl<R: Read + Seek> IsoFileReader<'_, R> {
     /// Reads the next chunk into a caller-provided buffer.
     pub async fn read_chunk(&mut self, output: &mut [u8]) -> io::Result<usize> {
-        let read = self.image.read_file_at(&self.entry, self.position, output).await?;
-        self.position += read as u64;
-        Ok(read)
+        if self.position >= self.entry.total_size || output.is_empty() {
+            return Ok(0);
+        }
+
+        let wanted = output
+            .len()
+            .min((self.entry.total_size - self.position) as usize);
+        let mut written = 0;
+        while written < wanted {
+            let extent_len = self.current_record.header().data_len.read() as u64;
+            let within = self.position.checked_sub(self.current_extent_start)
+                .ok_or_else(|| invalid("file reader extent state is invalid"))?;
+            if within < extent_len {
+                let available = (extent_len - within) as usize;
+                let take = available.min(wanted - written);
+                let header = self.current_record.header();
+                let xar = header.extended_attr_record as u64
+                    * self.entry.directory.block_size as u64;
+                let absolute = byte_offset(header.extent.read(), self.entry.directory.block_size)?
+                    .checked_add(xar)
+                    .and_then(|value| value.checked_add(within))
+                    .ok_or_else(overflow)?;
+                self.image.source.seek(SeekFrom::Start(absolute)).await
+                    .map_err(io::Error::erase)?;
+                self.image.source.read_exact(&mut output[written..written + take]).await?;
+                written += take;
+                self.position += take as u64;
+            }
+
+            if written == wanted {
+                break;
+            }
+            self.advance_extent(extent_len).await?;
+        }
+        Ok(written)
+    }
+
+    async fn advance_extent(&mut self, extent_len: u64) -> io::Result<()> {
+        self.current_extent_start = self.current_extent_start
+            .checked_add(extent_len)
+            .ok_or_else(overflow)?;
+        let Some(ref mut cursor) = self.continuation_cursor else {
+            return Err(invalid("file extent chain ended before its declared size"));
+        };
+        let next = self.image.next_raw(self.entry.directory, cursor).await?
+            .ok_or_else(|| invalid("truncated multi-extent file"))?;
+        validate_continuation(&self.entry.record, &next)?;
+        if !FileFlags::from_bits_retain(next.header().flags).contains(FileFlags::NOT_FINAL) {
+            self.continuation_cursor = None;
+        }
+        self.current_record = next;
+        Ok(())
     }
 }
 } // io_transform!

--- a/crates/optical/hadris-iso/tests/no_alloc_reader.rs
+++ b/crates/optical/hadris-iso/tests/no_alloc_reader.rs
@@ -1,0 +1,179 @@
+#![cfg(all(feature = "std", feature = "sync", feature = "read"))]
+
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::Mutex;
+
+use bytemuck::Zeroable;
+use hadris_iso::directory::{DirectoryRecord, DirectoryRecordHeader, DirectoryRef, FileFlags};
+use hadris_iso::io::LogicalSector;
+use hadris_iso::joliet::JolietLevel;
+use hadris_iso::read::{IsoNamespace, IsoReader};
+use hadris_iso::types::{U16LsbMsb, U32LsbMsb};
+use hadris_iso::volume::{
+    PrimaryVolumeDescriptor, SupplementaryVolumeDescriptor, VolumeDescriptorHeader,
+    VolumeDescriptorSetTerminator, VolumeDescriptorType,
+};
+
+struct CountingAllocator;
+
+static COUNTING: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const BLOCK: usize = 2048;
+
+fn root_header(extent: u32) -> DirectoryRecordHeader {
+    DirectoryRecordHeader {
+        len: 34,
+        extended_attr_record: 0,
+        extent: U32LsbMsb::new(extent),
+        data_len: U32LsbMsb::new(BLOCK as u32),
+        flags: FileFlags::DIRECTORY.bits(),
+        volume_sequence_number: U16LsbMsb::new(1),
+        file_identifier_len: 1,
+        ..DirectoryRecordHeader::default()
+    }
+}
+
+fn put(image: &mut [u8], sector: usize, offset: usize, bytes: &[u8]) {
+    let start = sector * BLOCK + offset;
+    image[start..start + bytes.len()].copy_from_slice(bytes);
+}
+
+fn fixture() -> Vec<u8> {
+    let mut image = vec![0_u8; 32 * BLOCK];
+
+    let mut pvd = PrimaryVolumeDescriptor::new("NOALLOC", 32);
+    pvd.dir_record.header = root_header(20);
+    put(&mut image, 16, 0, bytemuck::bytes_of(&pvd));
+
+    let mut svd = SupplementaryVolumeDescriptor::zeroed();
+    svd.header = VolumeDescriptorHeader::new(VolumeDescriptorType::SupplementaryVolumeDescriptor);
+    svd.escape_sequences = JolietLevel::Level3.escape_sequence();
+    svd.logical_block_size = U16LsbMsb::new(BLOCK as u16);
+    svd.volume_sequence_number = U16LsbMsb::new(1);
+    svd.dir_record.header = root_header(23);
+    svd.file_structure_version = 1;
+    put(&mut image, 17, 0, bytemuck::bytes_of(&svd));
+    put(
+        &mut image,
+        18,
+        0,
+        VolumeDescriptorSetTerminator::new().to_bytes(),
+    );
+
+    let mut first = DirectoryRecord::new(
+        b"PAYLOAD.BIN;1",
+        &[],
+        DirectoryRef {
+            extent: LogicalSector(21),
+            size: 5,
+        },
+        FileFlags::NOT_FINAL,
+    );
+    first.header_mut().volume_sequence_number = U16LsbMsb::new(1);
+    let mut second = DirectoryRecord::new(
+        b"PAYLOAD.BIN;1",
+        &[],
+        DirectoryRef {
+            extent: LogicalSector(22),
+            size: 6,
+        },
+        FileFlags::empty(),
+    );
+    second.header_mut().volume_sequence_number = U16LsbMsb::new(1);
+    put(&mut image, 20, 0, first.to_bytes());
+    put(&mut image, 20, first.size(), second.to_bytes());
+    put(&mut image, 21, 0, b"hello");
+    put(&mut image, 22, 0, b" world");
+
+    let joliet_name = [
+        0x65, 0xe5, 0x67, 0x2c, 0x00, b'.', 0x00, b'T', 0x00, b'X', 0x00, b'T', 0x00, b';', 0x00,
+        b'1',
+    ];
+    let mut joliet = DirectoryRecord::new(
+        &joliet_name,
+        &[],
+        DirectoryRef {
+            extent: LogicalSector(24),
+            size: 7,
+        },
+        FileFlags::empty(),
+    );
+    joliet.header_mut().volume_sequence_number = U16LsbMsb::new(1);
+    put(&mut image, 23, 0, joliet.to_bytes());
+    put(&mut image, 24, 0, b"unicode");
+    image
+}
+
+#[test]
+fn navigation_and_streaming_allocate_nothing() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let image = fixture();
+    let mut primary_output = [0_u8; 11];
+    let mut joliet_output = [0_u8; 7];
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::SeqCst);
+
+    let mut reader = IsoReader::open(hadris_io::Cursor::new(image.as_slice())).unwrap();
+    assert_eq!(
+        reader.preferred_root().namespace(),
+        IsoNamespace::Joliet(JolietLevel::Level3)
+    );
+
+    let primary = reader.primary_root();
+    let entry = reader
+        .find_path_in(primary, "payload.bin")
+        .unwrap()
+        .unwrap();
+    assert!(entry.is_multi_extent());
+    assert_eq!(entry.total_size(), 11);
+    let mut file = reader.open_file(&entry).unwrap();
+    assert_eq!(file.read_chunk(&mut primary_output[..7]).unwrap(), 7);
+    assert_eq!(file.read_chunk(&mut primary_output[7..]).unwrap(), 4);
+
+    let entry = reader.find_path("日本.TXT").unwrap().unwrap();
+    let mut file = reader.open_file(&entry).unwrap();
+    assert_eq!(file.read_chunk(&mut joliet_output).unwrap(), 7);
+
+    COUNTING.store(false, Ordering::SeqCst);
+    assert_eq!(ALLOCATIONS.load(Ordering::Relaxed), 0);
+    assert_eq!(&primary_output, b"hello world");
+    assert_eq!(&joliet_output, b"unicode");
+}
+
+#[test]
+fn malformed_record_length_is_rejected() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let mut image = fixture();
+    image[20 * BLOCK] = 2;
+    let mut reader = IsoReader::open(hadris_io::Cursor::new(image.as_slice())).unwrap();
+    let error = reader
+        .find_path_in(reader.primary_root(), "PAYLOAD.BIN")
+        .unwrap_err();
+    assert_eq!(error.kind(), hadris_iso::ErrorKind::InvalidData);
+}

--- a/crates/optical/hadris-iso/tests/no_alloc_reader.rs
+++ b/crates/optical/hadris-iso/tests/no_alloc_reader.rs
@@ -153,8 +153,10 @@ fn navigation_and_streaming_allocate_nothing() {
     assert!(entry.is_multi_extent());
     assert_eq!(entry.total_size(), 11);
     let mut file = reader.open_file(&entry).unwrap();
-    assert_eq!(file.read_chunk(&mut primary_output[..7]).unwrap(), 7);
-    assert_eq!(file.read_chunk(&mut primary_output[7..]).unwrap(), 4);
+    for byte in &mut primary_output {
+        assert_eq!(file.read_chunk(core::slice::from_mut(byte)).unwrap(), 1);
+    }
+    assert_eq!(file.read_chunk(&mut primary_output[..1]).unwrap(), 0);
 
     let entry = reader.find_path("日本.TXT").unwrap().unwrap();
     let mut file = reader.open_file(&entry).unwrap();

--- a/crates/optical/hadris-iso/tests/no_alloc_reader.rs
+++ b/crates/optical/hadris-iso/tests/no_alloc_reader.rs
@@ -130,16 +130,12 @@ fn fixture() -> Vec<u8> {
     image
 }
 
-#[test]
-fn navigation_and_streaming_allocate_nothing() {
-    let _guard = TEST_LOCK.lock().unwrap();
-    let image = fixture();
-    let mut primary_output = [0_u8; 11];
-    let mut joliet_output = [0_u8; 7];
-    ALLOCATIONS.store(0, Ordering::Relaxed);
-    COUNTING.store(true, Ordering::SeqCst);
-
-    let mut reader = IsoReader::open(hadris_io::Cursor::new(image.as_slice())).unwrap();
+fn exercise_navigation_and_streaming(
+    image: &[u8],
+    primary_output: &mut [u8; 11],
+    joliet_output: &mut [u8; 7],
+) {
+    let mut reader = IsoReader::open(hadris_io::Cursor::new(image)).unwrap();
     assert_eq!(
         reader.preferred_root().namespace(),
         IsoNamespace::Joliet(JolietLevel::Level3)
@@ -153,14 +149,29 @@ fn navigation_and_streaming_allocate_nothing() {
     assert!(entry.is_multi_extent());
     assert_eq!(entry.total_size(), 11);
     let mut file = reader.open_file(&entry).unwrap();
-    for byte in &mut primary_output {
+    for byte in &mut *primary_output {
         assert_eq!(file.read_chunk(core::slice::from_mut(byte)).unwrap(), 1);
     }
     assert_eq!(file.read_chunk(&mut primary_output[..1]).unwrap(), 0);
 
     let entry = reader.find_path("日本.TXT").unwrap().unwrap();
     let mut file = reader.open_file(&entry).unwrap();
-    assert_eq!(file.read_chunk(&mut joliet_output).unwrap(), 7);
+    assert_eq!(file.read_chunk(joliet_output).unwrap(), 7);
+}
+
+#[test]
+fn navigation_and_streaming_allocate_nothing() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let image = fixture();
+    let mut warm_primary_output = [0_u8; 11];
+    let mut warm_joliet_output = [0_u8; 7];
+    exercise_navigation_and_streaming(&image, &mut warm_primary_output, &mut warm_joliet_output);
+
+    let mut primary_output = [0_u8; 11];
+    let mut joliet_output = [0_u8; 7];
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::SeqCst);
+    exercise_navigation_and_streaming(&image, &mut primary_output, &mut joliet_output);
 
     COUNTING.store(false, Ordering::SeqCst);
     assert_eq!(ALLOCATIONS.load(Ordering::Relaxed), 0);

--- a/docs/hadris-1-to-2-migration.md
+++ b/docs/hadris-1-to-2-migration.md
@@ -144,8 +144,17 @@ available. Use `checked_end_lba` when values originate from untrusted media.
 
 ### ISO 9660
 
-`IsoImage` remains the primary reader. Existing raw descriptor exports are not
+Choose `IsoReader` for allocation-free ISO 9660/Joliet navigation and streamed
+file reads, or `IsoImage` when owned collections, convenience reads, and Rock
+Ridge-enriched metadata are required. Existing raw descriptor exports are not
 being moved for 2.0.
+
+An allocation-free build selects `read` plus an I/O mode and does not require
+`alloc`:
+
+```toml
+hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+```
 
 Use `IsoDir::read_entries` for collection-oriented traversal in either mode,
 with `IsoDir::find` and `IsoImage::find_path` for lookup. Writing remains under

--- a/docs/hadris-2-api-audit.md
+++ b/docs/hadris-2-api-audit.md
@@ -93,7 +93,7 @@ validated opener without relying on the block facade.
 
 | Current surface | 2.0 direction |
 |---|---|
-| `IsoImage` | retain as primary read handle |
+| `IsoReader` / `IsoImage` | use `IsoReader` for allocation-free navigation and streaming; retain `IsoImage` for owned collections and RRIP-enriched reads |
 | root raw descriptors and high-level handles mixed | retain 1.x exports for 2.0; any future `raw` move must begin as additive aliases and receive a separate compatibility review |
 | writer constructors and modification APIs vary | canonical `create` returns the target; modifier `finish` returns the target; legacy methods deprecated |
 | sync-only writers beside async readers | keep capability explicit; do not synthesize async writers |
@@ -102,6 +102,12 @@ validated opener without relying on the block facade.
 Category-level detection reports ISO independently from UDF. ISO and UDF now
 provide recoverable ownership, and the optical facade implements policy-driven
 unified opening with matching sync and async surfaces.
+
+With `read` and no `alloc`, `IsoReader` opens primary and Joliet namespaces,
+performs allocation-free nested lookup, and streams single- or multi-extent
+files into caller buffers. It prefers the highest recognized Joliet root while
+allowing explicit primary-root selection. Rock Ridge enrichment remains on the
+allocation-backed `IsoImage` surface.
 
 `IsoDir::read_entries` is the collection-oriented traversal operation shared by
 both modes. `IsoDir::find` and `IsoImage::find_path` provide matching

--- a/docs/hadris-2-feature-model.md
+++ b/docs/hadris-2-feature-model.md
@@ -98,6 +98,12 @@ ISO now follows the same contract:
 - write, modification, and El-Torito writer APIs are exported only by `sync`;
 - both API modes can be documented and compiled in the same build.
 
+The `read` tier is independently useful without `alloc`: `IsoReader` supports
+primary ISO 9660 and Joliet namespace discovery, nested path lookup, directory
+iteration, and caller-buffered multi-extent file streaming in both I/O modes.
+Enabling `alloc` adds the owned `IsoImage` collections, convenience reads, and
+Rock Ridge metadata enrichment.
+
 ISO async reading now includes collection-oriented directory traversal and
 lookup through `IsoDir::read_entries`, `IsoDir::find`, and
 `IsoImage::find_path`. Direct leaf coverage exercises PVD and descriptor

--- a/docs/hadris-2.0.0-rc.1-release-notes.md
+++ b/docs/hadris-2.0.0-rc.1-release-notes.md
@@ -74,6 +74,9 @@ creation. exFAT is available only as a separately gated unstable preview.
 
 ### ISO 9660
 
+- The new `IsoReader` provides allocation-free sync/async ISO 9660 and Joliet
+  traversal, path lookup, and caller-buffered multi-extent file streaming for
+  bootloaders, firmware, and kernels.
 - Reading and writing cover ISO 9660 Levels 1-3, ISO 9660:1999, Joliet, SUSP,
   Rock Ridge, and El Torito workflows.
 - Rock Ridge writing now includes POSIX metadata, timestamps, symlinks, device


### PR DESCRIPTION
## Summary
- add a no-std, zero-heap IsoReader for sync and async ISO 9660 access
- support primary and Joliet namespaces, nested lookup, caller-buffered reads, and multi-extent streaming
- retain the allocation-backed IsoImage API for owned collections and Rock Ridge enrichment
- document the no-allocation feature tier across crate and workspace documentation

## Validation
- cargo test -p hadris-iso
- cargo test -p hadris-iso --doc
- cargo test -p hadris-iso --all-features --test async_read
- cargo test -p hadris-iso --all-features --test no_alloc_reader
- RUSTFLAGS=-D warnings cargo check -p hadris-iso --no-default-features --features read,sync
- RUSTFLAGS=-D warnings cargo check -p hadris-iso --no-default-features --features read,async
- RUSTFLAGS=-D warnings cargo check -p hadris-iso --all-features
- cargo clippy for the read,sync and read,async no-default-feature configurations

The counting-allocator integration test verifies zero allocations during open, primary and Joliet lookup, and multi-extent file streaming.