### PR TITLE
feat(fat,iso): spec-polish + interop qualification for 2.0.0-rc.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,11 +43,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       # cargo-public-api generates rustdoc JSON through nightly rustdoc even
       # though the project itself remains pinned to the stable MSRV above.
-      - uses: dtolnay/rust-toolchain@nightly
+      # Pin the nightly: rustdoc's rendering of blanket impls (e.g.
+      # `std::io::Read` vs `alloc::io::read::Read`) drifts between nightlies, so
+      # an unpinned toolchain makes the snapshot diff nondeterministic. Bump
+      # this date deliberately alongside a snapshot refresh.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-15
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-public-api
         run: cargo install cargo-public-api --version 0.52.0 --locked
       - name: Check all-feature public API snapshots
+        # cargo-public-api 0.52.0 has no --toolchain flag but honors
+        # RUSTUP_TOOLCHAIN when it names a nightly, so this drives rustdoc with
+        # the pinned dated nightly installed above.
+        env:
+          RUSTUP_TOOLCHAIN: nightly-2026-07-15
         run: scripts/check-public-api.sh
 
   check:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -405,13 +405,19 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - name: Install dosfstools
+      - name: Install dosfstools and mtools
         run: |
           sudo apt-get update
-          sudo apt-get install -y dosfstools
+          sudo apt-get install -y dosfstools mtools
       - name: Run FAT roundtrip tests
         run: |
           cargo test -p hadris-fat --features "write" --test fat_roundtrip -- --nocapture
+      # `mtools` (mdir/mtype) verifies filename and content fidelity that
+      # `fsck.fat` (structure only) does not — in particular the NT case bits
+      # for lowercase 8.3 names.
+      - name: Run FAT mtools fidelity tests
+        run: |
+          cargo test -p hadris-fat --features "write,std" --test mtools_fidelity -- --nocapture
       # `cache` is not a default feature, so the workspace `test` job never
       # exercises the FAT-sector cache, its routing on FatFs, or the
       # cache_integration suite. Run them explicitly here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,69 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+## [2.0.0-rc.2] - 2026-07-19
+
 ### Added
 
 - **hadris-iso:** Added a zero-allocation `IsoReader` for sync and async
   `no_std` builds, including ISO 9660/Joliet namespace selection, nested path
   lookup, caller-buffered reads, and multi-extent file streaming.
+- **hadris-fat:** Added `NtCaseFlags` and `FileEntry::nt_case` /
+  `ShortFileName::with_nt_case` so lowercase 8.3 short names round-trip in their
+  original case.
+- **hadris-iso:** `EmulationType` now names the El Torito boot media types
+  (1.2/1.44/2.88 MB floppy and hard-disk emulation) with an `is_emulated`
+  helper, so bootable images can request emulated media. Emulated boot entries
+  default their load size to one virtual sector.
+- **hadris-iso:** Rock Ridge `TF` timestamp entries now include the creation
+  time when the input entry carries one (new `RripBuilder::add_tf`), alongside
+  the existing modify and access times.
+- **hadris-fat:** `Fat12` and `Fat16` now expose `allocate_chain` and
+  `extend_chain`, matching `Fat32`, for callers doing manual multi-cluster
+  allocation.
+- **hadris-iso:** The allocation-free `IsoReader` can now resolve Rock Ridge
+  alternate names: `IsoDirEntry::rrip_name_into` decodes the `NM` field into a
+  caller buffer and `rrip_name_matches` compares it, both without allocating.
+  (Inline system-use areas only; `CE`-continued names are not followed.)
+
+### Removed
+
+- **hadris-iso:** Removed the unused, always-empty `read::SupportedFeatures`
+  bitflags stub.
+
+### Fixed
+
+- **hadris-iso:** `IsoImage::open` now rejects images that declare a logical
+  block size other than 2048 with a clear `Unsupported` error, instead of
+  silently misreading their extents. (The allocation-free `IsoReader` honors the
+  declared block size; full non-2048 support in `IsoImage` remains future work.)
+- **hadris-iso:** Joliet file identifiers are now encoded as conformant UCS-2:
+  characters outside the Basic Multilingual Plane are substituted with `_`
+  instead of leaking UTF-16 surrogate pairs into the field, and names are capped
+  at the Joliet 64-character limit (previously up to 103). `encode_joliet_name`
+  is likewise BMP-safe.
+- **hadris-iso:** Directory records are now written in ascending File Identifier
+  order (ECMA-119 9.3) instead of input/tree order, so images validate against
+  strict readers.
+- **hadris-iso:** Writing a file larger than 4 GiB now fails with a clear error
+  instead of silently truncating its length to 32 bits. Multi-extent records
+  (which would lift the limit) are not yet emitted.
+- **hadris-fat:** Lowercase 8.3 names (e.g. `readme.txt`) are now stored as a
+  single short entry with the Windows NT `DIR_NTRes` case flags and read back in
+  their original case, instead of being uppercased on read or spending a
+  long-file-name entry. `rename` now records case flags for the new name rather
+  than carrying over the source entry's.
 
 ### Documentation
 
+- Expanded the `@hadris-spec` compliance annotations and `docs/spec-coverage.md`
+  to cover more ISO volume descriptors, path tables, and El Torito section
+  entries, the FAT FSInfo sector, and a new `hadris-part` (MBR/GPT) section.
+- Completed the in-repo ISO 9660 specification notes (volume descriptors, path
+  table, directory record, and an extensions index) and documented the ISO
+  writer's known limitations.
+- Added `docs/hadris-2-perf-notes.md` recording the caching/performance findings
+  deferred out of 2.0.
 - Added a Docusaurus documentation site with getting-started, crate-selection,
   migration, release-candidate, and task-oriented FAT, partition, ISO, CPIO,
   and `no_std` guides.
@@ -183,7 +238,8 @@ Each published package owns its version and may be released independently.
 Baseline for this changelog. See the git history for changes at and before this
 tag.
 
-[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.1...HEAD
+[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.2...HEAD
+[2.0.0-rc.2]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/hxyulin/hadris/compare/v1.2.1...v2.0.0-rc.1
 [1.2.1]: https://github.com/hxyulin/hadris/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/hxyulin/hadris/compare/v1.1.0...v1.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "hadris"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "hadris-archive",
  "hadris-block",
@@ -468,14 +468,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-archive"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "hadris-cpio",
 ]
 
 [[package]]
 name = "hadris-block"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "hadris-fat",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "hadris-io",
  "hadris-iso",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "clap",
  "hadris-cd",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "hadris-common",
  "hadris-io",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -607,14 +607,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "hadris-io"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "clap",
  "hadris-iso",
@@ -655,14 +655,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-optical"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "hadris-cd",
  "hadris-io",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-part"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "crc",
@@ -684,11 +684,11 @@ dependencies = [
 
 [[package]]
 name = "hadris-path"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 
 [[package]]
 name = "hadris-storage"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "embedded-io",
  "hadris-io",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "clap",
  "hadris-udf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,18 +43,18 @@ clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 
 # Internal crates
-hadris-macros = { version = "2.0.0-rc.1", path = "crates/core/hadris-macros" }
-hadris-io = { version = "2.0.0-rc.1", path = "crates/core/hadris-io", default-features = false }
-hadris-fixed = { version = "2.0.0-rc.1", path = "crates/core/hadris-fixed", default-features = false }
-hadris-path = { version = "2.0.0-rc.1", path = "crates/core/hadris-path", default-features = false }
-hadris-common = { version = "2.0.0-rc.1", path = "crates/core/hadris-common", default-features = false }
-hadris-storage = { version = "2.0.0-rc.1", path = "crates/core/hadris-storage", default-features = false }
-hadris-block = { version = "2.0.0-rc.1", path = "crates/block/hadris-block", default-features = false }
-hadris-fat = { version = "2.0.0-rc.1", path = "crates/block/hadris-fat", default-features = false }
-hadris-part = { version = "2.0.0-rc.1", path = "crates/block/hadris-part", default-features = false }
-hadris-optical = { version = "2.0.0-rc.1", path = "crates/optical/hadris-optical", default-features = false }
-hadris-iso = { version = "2.0.0-rc.1", path = "crates/optical/hadris-iso", default-features = false }
-hadris-udf = { version = "2.0.0-rc.1", path = "crates/optical/hadris-udf", default-features = false }
-hadris-cd = { version = "2.0.0-rc.1", path = "crates/optical/hadris-cd", default-features = false }
-hadris-archive = { version = "2.0.0-rc.1", path = "crates/archive/hadris-archive", default-features = false }
-hadris-cpio = { version = "2.0.0-rc.1", path = "crates/archive/hadris-cpio", default-features = false }
+hadris-macros = { version = "2.0.0-rc.2", path = "crates/core/hadris-macros" }
+hadris-io = { version = "2.0.0-rc.2", path = "crates/core/hadris-io", default-features = false }
+hadris-fixed = { version = "2.0.0-rc.2", path = "crates/core/hadris-fixed", default-features = false }
+hadris-path = { version = "2.0.0-rc.2", path = "crates/core/hadris-path", default-features = false }
+hadris-common = { version = "2.0.0-rc.2", path = "crates/core/hadris-common", default-features = false }
+hadris-storage = { version = "2.0.0-rc.2", path = "crates/core/hadris-storage", default-features = false }
+hadris-block = { version = "2.0.0-rc.2", path = "crates/block/hadris-block", default-features = false }
+hadris-fat = { version = "2.0.0-rc.2", path = "crates/block/hadris-fat", default-features = false }
+hadris-part = { version = "2.0.0-rc.2", path = "crates/block/hadris-part", default-features = false }
+hadris-optical = { version = "2.0.0-rc.2", path = "crates/optical/hadris-optical", default-features = false }
+hadris-iso = { version = "2.0.0-rc.2", path = "crates/optical/hadris-iso", default-features = false }
+hadris-udf = { version = "2.0.0-rc.2", path = "crates/optical/hadris-udf", default-features = false }
+hadris-cd = { version = "2.0.0-rc.2", path = "crates/optical/hadris-cd", default-features = false }
+hadris-archive = { version = "2.0.0-rc.2", path = "crates/archive/hadris-archive", default-features = false }
+hadris-cpio = { version = "2.0.0-rc.2", path = "crates/archive/hadris-cpio", default-features = false }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ layers coherent without hiding format-specific capabilities.
 ## Stability and Versioning
 
 Hadris follows [Semantic Versioning](https://semver.org/). The
-`2.0.0-rc.1` prerelease marks the V2 feature and public-API freeze: until the
+`2.0.0-rc.1` prerelease marked the V2 feature and public-API freeze, which the
+`2.0.0-rc.2` candidate continues: until the
 final `2.0.0` release, changes are limited to correctness fixes,
 interoperability qualification, documentation, and release engineering.
 Breaking changes to the frozen public API require explicit review and a new
@@ -145,10 +146,10 @@ Choose the narrowest entry point that fits the application:
 ```toml
 [dependencies]
 # One filesystem:
-hadris-fat = "2.0.0-rc.1"
+hadris-fat = "2.0.0-rc.2"
 
 # Or the unified storage ecosystem:
-hadris = { version = "2.0.0-rc.1", features = ["block", "optical"] }
+hadris = { version = "2.0.0-rc.2", features = ["block", "optical"] }
 ```
 
 The umbrella crate re-exports the same underlying format crates through
@@ -156,15 +157,15 @@ The umbrella crate re-exports the same underlying format crates through
 grow into partition detection or additional disk-image formats without
 replacing their filesystem implementation.
 
-Each package now owns its version; all current packages target **2.0.0-rc.1**:
+Each package now owns its version; all current packages target **2.0.0-rc.2**:
 
 ```toml
 [dependencies]
-hadris-iso = "2.0.0-rc.1"
-hadris-fat = "2.0.0-rc.1"
-hadris-part = { version = "2.0.0-rc.1", features = ["read"] }
-hadris-fixed = "2.0.0-rc.1"
-hadris-path = "2.0.0-rc.1"
+hadris-iso = "2.0.0-rc.2"
+hadris-fat = "2.0.0-rc.2"
+hadris-part = { version = "2.0.0-rc.2", features = ["read"] }
+hadris-fixed = "2.0.0-rc.2"
+hadris-path = "2.0.0-rc.2"
 ```
 
 For allocation-free `no_std` ISO reading:
@@ -172,8 +173,8 @@ For allocation-free `no_std` ISO reading:
 ```toml
 [dependencies]
 # No heap allocator: ISO 9660/Joliet lookup and streamed file reads.
-hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
-hadris-fat = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
 ```
 
 Add the `alloc` feature to `hadris-iso` when owned collections, convenience
@@ -196,7 +197,7 @@ See [CLAUDE.md](CLAUDE.md) for detailed build instructions and architecture note
 Users upgrading from Hadris 1.x should read the
 [2.0 migration guide](docs/hadris-1-to-2-migration.md). Prerelease testers
 should also review the
-[`2.0.0-rc.1` release notes](docs/hadris-2.0.0-rc.1-release-notes.md).
+[`2.0.0-rc.2` release notes](docs/hadris-2.0.0-rc.2-release-notes.md).
 The Docusaurus source for the task-oriented documentation site lives in
 [`website/`](website/); it includes getting-started, crate-selection, and
 FAT, partition, ISO, CPIO, and `no_std` use-case guides.

--- a/api-snapshots/hadris-fat.txt
+++ b/api-snapshots/hadris-fat.txt
@@ -49,6 +49,7 @@ pub fn hadris_fat::async::dir::FileEntry::len(&self) -> u64
 pub fn hadris_fat::async::dir::FileEntry::long_name(&self) -> core::option::Option<&hadris_fat::file::LongFileName>
 pub fn hadris_fat::async::dir::FileEntry::modified(&self) -> hadris_fat::time::FatDateTime
 pub fn hadris_fat::async::dir::FileEntry::name(&self) -> alloc::borrow::Cow<'_, str>
+pub fn hadris_fat::async::dir::FileEntry::nt_case(&self) -> hadris_fat::NtCaseFlags
 pub fn hadris_fat::async::dir::FileEntry::short_name(&self) -> &hadris_fat::file::ShortFileName
 pub fn hadris_fat::async::dir::FileEntry::size(&self) -> usize
 pub struct hadris_fat::async::dir::FileSystemErrors(_)
@@ -228,7 +229,9 @@ impl core::fmt::Display for hadris_fat::async::fat_table::FatType
 pub fn hadris_fat::async::fat_table::FatType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_fat::async::fat_table::Fat12
 impl hadris_fat::async::fat_table::Fat12
+pub async fn hadris_fat::async::fat_table::Fat12::allocate_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat12::allocate_cluster<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub async fn hadris_fat::async::fat_table::Fat12::extend_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat12::free_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub async fn hadris_fat::async::fat_table::Fat12::mark_bad<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::async::fat_table::Fat12::max_cluster(&self) -> u16
@@ -238,7 +241,9 @@ pub async fn hadris_fat::async::fat_table::Fat12::truncate_chain<T: hadris_io::a
 pub async fn hadris_fat::async::fat_table::Fat12::write_clus<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<()>
 pub struct hadris_fat::async::fat_table::Fat16
 impl hadris_fat::async::fat_table::Fat16
+pub async fn hadris_fat::async::fat_table::Fat16::allocate_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat16::allocate_cluster<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub async fn hadris_fat::async::fat_table::Fat16::extend_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat16::free_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub async fn hadris_fat::async::fat_table::Fat16::mark_bad<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::async::fat_table::Fat16::max_cluster(&self) -> u16
@@ -541,7 +546,9 @@ impl core::fmt::Display for hadris_fat::async::fat_table::FatType
 pub fn hadris_fat::async::fat_table::FatType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_fat::async::Fat12
 impl hadris_fat::async::fat_table::Fat12
+pub async fn hadris_fat::async::fat_table::Fat12::allocate_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat12::allocate_cluster<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub async fn hadris_fat::async::fat_table::Fat12::extend_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat12::free_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub async fn hadris_fat::async::fat_table::Fat12::mark_bad<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::async::fat_table::Fat12::max_cluster(&self) -> u16
@@ -551,7 +558,9 @@ pub async fn hadris_fat::async::fat_table::Fat12::truncate_chain<T: hadris_io::a
 pub async fn hadris_fat::async::fat_table::Fat12::write_clus<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<()>
 pub struct hadris_fat::async::Fat16
 impl hadris_fat::async::fat_table::Fat16
+pub async fn hadris_fat::async::fat_table::Fat16::allocate_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat16::allocate_cluster<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub async fn hadris_fat::async::fat_table::Fat16::extend_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub async fn hadris_fat::async::fat_table::Fat16::free_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub async fn hadris_fat::async::fat_table::Fat16::mark_bad<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::async::fat_table::Fat16::max_cluster(&self) -> u16
@@ -701,6 +710,7 @@ pub fn hadris_fat::async::dir::FileEntry::len(&self) -> u64
 pub fn hadris_fat::async::dir::FileEntry::long_name(&self) -> core::option::Option<&hadris_fat::file::LongFileName>
 pub fn hadris_fat::async::dir::FileEntry::modified(&self) -> hadris_fat::time::FatDateTime
 pub fn hadris_fat::async::dir::FileEntry::name(&self) -> alloc::borrow::Cow<'_, str>
+pub fn hadris_fat::async::dir::FileEntry::nt_case(&self) -> hadris_fat::NtCaseFlags
 pub fn hadris_fat::async::dir::FileEntry::short_name(&self) -> &hadris_fat::file::ShortFileName
 pub fn hadris_fat::async::dir::FileEntry::size(&self) -> usize
 pub trait hadris_fat::async::FatFsReadExt<DATA: hadris_io::async_api::Read + hadris_io::async_api::Seek>
@@ -790,6 +800,7 @@ pub fn hadris_fat::dir::FileEntry::len(&self) -> u64
 pub fn hadris_fat::dir::FileEntry::long_name(&self) -> core::option::Option<&hadris_fat::file::LongFileName>
 pub fn hadris_fat::dir::FileEntry::modified(&self) -> hadris_fat::time::FatDateTime
 pub fn hadris_fat::dir::FileEntry::name(&self) -> alloc::borrow::Cow<'_, str>
+pub fn hadris_fat::dir::FileEntry::nt_case(&self) -> hadris_fat::NtCaseFlags
 pub fn hadris_fat::dir::FileEntry::short_name(&self) -> &hadris_fat::file::ShortFileName
 pub fn hadris_fat::dir::FileEntry::size(&self) -> usize
 pub struct hadris_fat::dir::FileSystemErrors(_)
@@ -1025,7 +1036,9 @@ impl core::fmt::Display for hadris_fat::fat_table::FatType
 pub fn hadris_fat::fat_table::FatType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_fat::fat_table::Fat12
 impl hadris_fat::fat_table::Fat12
+pub fn hadris_fat::fat_table::Fat12::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat12::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat12::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat12::max_cluster(&self) -> u16
@@ -1037,7 +1050,9 @@ impl hadris_fat::fat_table::Fat12
 pub fn hadris_fat::fat_table::Fat12::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u16>
 pub struct hadris_fat::fat_table::Fat16
 impl hadris_fat::fat_table::Fat16
+pub fn hadris_fat::fat_table::Fat16::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat16::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat16::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat16::max_cluster(&self) -> u16
@@ -1111,6 +1126,7 @@ pub fn hadris_fat::file::ShortFileName::matches(&self, &str) -> bool
 pub fn hadris_fat::file::ShortFileName::new([u8; 11]) -> core::result::Result<Self, hadris_fat::file::CreateShortFileNameError>
 pub fn hadris_fat::file::ShortFileName::raw_bytes(&self) -> [u8; 11]
 pub fn hadris_fat::file::ShortFileName::to_raw_bytes(&self) -> [u8; 11]
+pub fn hadris_fat::file::ShortFileName::with_nt_case(&self, hadris_fat::NtCaseFlags) -> hadris_fat::file::ShortFileName
 impl core::fmt::Debug for hadris_fat::file::ShortFileName
 pub fn hadris_fat::file::ShortFileName::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub const hadris_fat::file::LFN_MAX_UTF16_UNITS: usize
@@ -1457,6 +1473,82 @@ pub fn hadris_fat::DirEntryAttrFlags::bitxor_assign(&mut self, Self)
 impl core::ops::bit::Not for hadris_fat::DirEntryAttrFlags
 pub type hadris_fat::DirEntryAttrFlags::Output = hadris_fat::DirEntryAttrFlags
 pub fn hadris_fat::DirEntryAttrFlags::not(self) -> Self
+pub struct hadris_fat::raw::NtCaseFlags(_)
+impl hadris_fat::NtCaseFlags
+pub const hadris_fat::NtCaseFlags::LOWER_BASE: Self
+pub const hadris_fat::NtCaseFlags::LOWER_EXT: Self
+impl hadris_fat::NtCaseFlags
+pub const fn hadris_fat::NtCaseFlags::all() -> Self
+pub const fn hadris_fat::NtCaseFlags::bits(&self) -> u8
+pub const fn hadris_fat::NtCaseFlags::complement(self) -> Self
+pub const fn hadris_fat::NtCaseFlags::contains(&self, Self) -> bool
+pub const fn hadris_fat::NtCaseFlags::difference(self, Self) -> Self
+pub const fn hadris_fat::NtCaseFlags::empty() -> Self
+pub const fn hadris_fat::NtCaseFlags::from_bits(u8) -> core::option::Option<Self>
+pub const fn hadris_fat::NtCaseFlags::from_bits_retain(u8) -> Self
+pub const fn hadris_fat::NtCaseFlags::from_bits_truncate(u8) -> Self
+pub fn hadris_fat::NtCaseFlags::from_name(&str) -> core::option::Option<Self>
+pub fn hadris_fat::NtCaseFlags::insert(&mut self, Self)
+pub const fn hadris_fat::NtCaseFlags::intersection(self, Self) -> Self
+pub const fn hadris_fat::NtCaseFlags::intersects(&self, Self) -> bool
+pub const fn hadris_fat::NtCaseFlags::is_all(&self) -> bool
+pub const fn hadris_fat::NtCaseFlags::is_empty(&self) -> bool
+pub fn hadris_fat::NtCaseFlags::remove(&mut self, Self)
+pub fn hadris_fat::NtCaseFlags::set(&mut self, Self, bool)
+pub const fn hadris_fat::NtCaseFlags::symmetric_difference(self, Self) -> Self
+pub fn hadris_fat::NtCaseFlags::toggle(&mut self, Self)
+pub const fn hadris_fat::NtCaseFlags::union(self, Self) -> Self
+impl hadris_fat::NtCaseFlags
+pub const fn hadris_fat::NtCaseFlags::iter(&self) -> bitflags::iter::Iter<hadris_fat::NtCaseFlags>
+pub const fn hadris_fat::NtCaseFlags::iter_names(&self) -> bitflags::iter::IterNames<hadris_fat::NtCaseFlags>
+impl bitflags::traits::Flags for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Bits = u8
+pub const hadris_fat::NtCaseFlags::FLAGS: &'static [bitflags::traits::Flag<hadris_fat::NtCaseFlags>]
+pub fn hadris_fat::NtCaseFlags::all_named() -> hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bits(&self) -> u8
+pub fn hadris_fat::NtCaseFlags::from_bits_retain(u8) -> hadris_fat::NtCaseFlags
+impl bitflags::traits::PublicFlags for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Internal = InternalBitFlags
+pub type hadris_fat::NtCaseFlags::Primitive = u8
+impl core::fmt::Binary for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::LowerHex for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Octal for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::UpperHex for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::Extend<hadris_fat::NtCaseFlags> for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, T)
+impl core::iter::traits::collect::FromIterator<hadris_fat::NtCaseFlags> for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(T) -> Self
+impl core::iter::traits::collect::IntoIterator for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::IntoIter = bitflags::iter::Iter<hadris_fat::NtCaseFlags>
+pub type hadris_fat::NtCaseFlags::Item = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::into_iter(self) -> Self::IntoIter
+impl core::ops::arith::Sub for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::sub(self, Self) -> Self
+impl core::ops::arith::SubAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::sub_assign(&mut self, Self)
+impl core::ops::bit::BitAnd for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitand(self, Self) -> Self
+impl core::ops::bit::BitAndAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitand_assign(&mut self, Self)
+impl core::ops::bit::BitOr for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitor(self, hadris_fat::NtCaseFlags) -> Self
+impl core::ops::bit::BitOrAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitor_assign(&mut self, Self)
+impl core::ops::bit::BitXor for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitxor(self, Self) -> Self
+impl core::ops::bit::BitXorAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitxor_assign(&mut self, Self)
+impl core::ops::bit::Not for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::not(self) -> Self
 #[repr(C)] pub struct hadris_fat::raw::RawBpb
 pub hadris_fat::raw::RawBpb::bytes_per_sector: hadris_common::types::number::U16<hadris_common::types::endian::LittleEndian>
 pub hadris_fat::raw::RawBpb::fat_count: u8
@@ -1629,6 +1721,7 @@ pub fn hadris_fat::dir::FileEntry::len(&self) -> u64
 pub fn hadris_fat::dir::FileEntry::long_name(&self) -> core::option::Option<&hadris_fat::file::LongFileName>
 pub fn hadris_fat::dir::FileEntry::modified(&self) -> hadris_fat::time::FatDateTime
 pub fn hadris_fat::dir::FileEntry::name(&self) -> alloc::borrow::Cow<'_, str>
+pub fn hadris_fat::dir::FileEntry::nt_case(&self) -> hadris_fat::NtCaseFlags
 pub fn hadris_fat::dir::FileEntry::short_name(&self) -> &hadris_fat::file::ShortFileName
 pub fn hadris_fat::dir::FileEntry::size(&self) -> usize
 pub struct hadris_fat::sync::dir::FileSystemErrors(_)
@@ -1808,7 +1901,9 @@ impl core::fmt::Display for hadris_fat::fat_table::FatType
 pub fn hadris_fat::fat_table::FatType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_fat::sync::fat_table::Fat12
 impl hadris_fat::fat_table::Fat12
+pub fn hadris_fat::fat_table::Fat12::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat12::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat12::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat12::max_cluster(&self) -> u16
@@ -1820,7 +1915,9 @@ impl hadris_fat::fat_table::Fat12
 pub fn hadris_fat::fat_table::Fat12::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u16>
 pub struct hadris_fat::sync::fat_table::Fat16
 impl hadris_fat::fat_table::Fat16
+pub fn hadris_fat::fat_table::Fat16::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat16::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat16::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat16::max_cluster(&self) -> u16
@@ -2305,7 +2402,9 @@ impl core::fmt::Display for hadris_fat::fat_table::FatType
 pub fn hadris_fat::fat_table::FatType::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_fat::sync::Fat12
 impl hadris_fat::fat_table::Fat12
+pub fn hadris_fat::fat_table::Fat12::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat12::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat12::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat12::max_cluster(&self) -> u16
@@ -2317,7 +2416,9 @@ impl hadris_fat::fat_table::Fat12
 pub fn hadris_fat::fat_table::Fat12::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u16>
 pub struct hadris_fat::sync::Fat16
 impl hadris_fat::fat_table::Fat16
+pub fn hadris_fat::fat_table::Fat16::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat16::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat16::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat16::max_cluster(&self) -> u16
@@ -2497,6 +2598,7 @@ pub fn hadris_fat::dir::FileEntry::len(&self) -> u64
 pub fn hadris_fat::dir::FileEntry::long_name(&self) -> core::option::Option<&hadris_fat::file::LongFileName>
 pub fn hadris_fat::dir::FileEntry::modified(&self) -> hadris_fat::time::FatDateTime
 pub fn hadris_fat::dir::FileEntry::name(&self) -> alloc::borrow::Cow<'_, str>
+pub fn hadris_fat::dir::FileEntry::nt_case(&self) -> hadris_fat::NtCaseFlags
 pub fn hadris_fat::dir::FileEntry::short_name(&self) -> &hadris_fat::file::ShortFileName
 pub fn hadris_fat::dir::FileEntry::size(&self) -> usize
 pub trait hadris_fat::sync::FatAnalysisExt<DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
@@ -2932,7 +3034,9 @@ pub type hadris_fat::DirEntryAttrFlags::Output = hadris_fat::DirEntryAttrFlags
 pub fn hadris_fat::DirEntryAttrFlags::not(self) -> Self
 pub struct hadris_fat::Fat12
 impl hadris_fat::fat_table::Fat12
+pub fn hadris_fat::fat_table::Fat12::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat12::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat12::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat12::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat12::max_cluster(&self) -> u16
@@ -2944,7 +3048,9 @@ impl hadris_fat::fat_table::Fat12
 pub fn hadris_fat::fat_table::Fat12::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u16>
 pub struct hadris_fat::Fat16
 impl hadris_fat::fat_table::Fat16
+pub fn hadris_fat::fat_table::Fat16::allocate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::allocate_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u16>
+pub fn hadris_fat::fat_table::Fat16::extend_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16, usize, u16) -> hadris_fat::error::Result<u16>
 pub fn hadris_fat::fat_table::Fat16::free_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<u32>
 pub fn hadris_fat::fat_table::Fat16::mark_bad<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u16) -> hadris_fat::error::Result<()>
 pub fn hadris_fat::fat_table::Fat16::max_cluster(&self) -> u16
@@ -3124,8 +3230,85 @@ pub fn hadris_fat::dir::FileEntry::len(&self) -> u64
 pub fn hadris_fat::dir::FileEntry::long_name(&self) -> core::option::Option<&hadris_fat::file::LongFileName>
 pub fn hadris_fat::dir::FileEntry::modified(&self) -> hadris_fat::time::FatDateTime
 pub fn hadris_fat::dir::FileEntry::name(&self) -> alloc::borrow::Cow<'_, str>
+pub fn hadris_fat::dir::FileEntry::nt_case(&self) -> hadris_fat::NtCaseFlags
 pub fn hadris_fat::dir::FileEntry::short_name(&self) -> &hadris_fat::file::ShortFileName
 pub fn hadris_fat::dir::FileEntry::size(&self) -> usize
+pub struct hadris_fat::NtCaseFlags(_)
+impl hadris_fat::NtCaseFlags
+pub const hadris_fat::NtCaseFlags::LOWER_BASE: Self
+pub const hadris_fat::NtCaseFlags::LOWER_EXT: Self
+impl hadris_fat::NtCaseFlags
+pub const fn hadris_fat::NtCaseFlags::all() -> Self
+pub const fn hadris_fat::NtCaseFlags::bits(&self) -> u8
+pub const fn hadris_fat::NtCaseFlags::complement(self) -> Self
+pub const fn hadris_fat::NtCaseFlags::contains(&self, Self) -> bool
+pub const fn hadris_fat::NtCaseFlags::difference(self, Self) -> Self
+pub const fn hadris_fat::NtCaseFlags::empty() -> Self
+pub const fn hadris_fat::NtCaseFlags::from_bits(u8) -> core::option::Option<Self>
+pub const fn hadris_fat::NtCaseFlags::from_bits_retain(u8) -> Self
+pub const fn hadris_fat::NtCaseFlags::from_bits_truncate(u8) -> Self
+pub fn hadris_fat::NtCaseFlags::from_name(&str) -> core::option::Option<Self>
+pub fn hadris_fat::NtCaseFlags::insert(&mut self, Self)
+pub const fn hadris_fat::NtCaseFlags::intersection(self, Self) -> Self
+pub const fn hadris_fat::NtCaseFlags::intersects(&self, Self) -> bool
+pub const fn hadris_fat::NtCaseFlags::is_all(&self) -> bool
+pub const fn hadris_fat::NtCaseFlags::is_empty(&self) -> bool
+pub fn hadris_fat::NtCaseFlags::remove(&mut self, Self)
+pub fn hadris_fat::NtCaseFlags::set(&mut self, Self, bool)
+pub const fn hadris_fat::NtCaseFlags::symmetric_difference(self, Self) -> Self
+pub fn hadris_fat::NtCaseFlags::toggle(&mut self, Self)
+pub const fn hadris_fat::NtCaseFlags::union(self, Self) -> Self
+impl hadris_fat::NtCaseFlags
+pub const fn hadris_fat::NtCaseFlags::iter(&self) -> bitflags::iter::Iter<hadris_fat::NtCaseFlags>
+pub const fn hadris_fat::NtCaseFlags::iter_names(&self) -> bitflags::iter::IterNames<hadris_fat::NtCaseFlags>
+impl bitflags::traits::Flags for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Bits = u8
+pub const hadris_fat::NtCaseFlags::FLAGS: &'static [bitflags::traits::Flag<hadris_fat::NtCaseFlags>]
+pub fn hadris_fat::NtCaseFlags::all_named() -> hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bits(&self) -> u8
+pub fn hadris_fat::NtCaseFlags::from_bits_retain(u8) -> hadris_fat::NtCaseFlags
+impl bitflags::traits::PublicFlags for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Internal = InternalBitFlags
+pub type hadris_fat::NtCaseFlags::Primitive = u8
+impl core::fmt::Binary for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::LowerHex for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Octal for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::UpperHex for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::Extend<hadris_fat::NtCaseFlags> for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, T)
+impl core::iter::traits::collect::FromIterator<hadris_fat::NtCaseFlags> for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(T) -> Self
+impl core::iter::traits::collect::IntoIterator for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::IntoIter = bitflags::iter::Iter<hadris_fat::NtCaseFlags>
+pub type hadris_fat::NtCaseFlags::Item = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::into_iter(self) -> Self::IntoIter
+impl core::ops::arith::Sub for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::sub(self, Self) -> Self
+impl core::ops::arith::SubAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::sub_assign(&mut self, Self)
+impl core::ops::bit::BitAnd for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitand(self, Self) -> Self
+impl core::ops::bit::BitAndAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitand_assign(&mut self, Self)
+impl core::ops::bit::BitOr for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitor(self, hadris_fat::NtCaseFlags) -> Self
+impl core::ops::bit::BitOrAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitor_assign(&mut self, Self)
+impl core::ops::bit::BitXor for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitxor(self, Self) -> Self
+impl core::ops::bit::BitXorAssign for hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::bitxor_assign(&mut self, Self)
+impl core::ops::bit::Not for hadris_fat::NtCaseFlags
+pub type hadris_fat::NtCaseFlags::Output = hadris_fat::NtCaseFlags
+pub fn hadris_fat::NtCaseFlags::not(self) -> Self
 #[repr(C)] pub struct hadris_fat::RawBpb
 pub hadris_fat::RawBpb::bytes_per_sector: hadris_common::types::number::U16<hadris_common::types::endian::LittleEndian>
 pub hadris_fat::RawBpb::fat_count: u8

--- a/api-snapshots/hadris-iso.txt
+++ b/api-snapshots/hadris-iso.txt
@@ -58,10 +58,15 @@ impl core::error::Error for hadris_iso::async::boot::BootError
 impl core::fmt::Display for hadris_iso::async::boot::BootError
 pub fn hadris_iso::async::boot::BootError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum hadris_iso::async::boot::EmulationType
+pub hadris_iso::async::boot::EmulationType::Floppy1_2
+pub hadris_iso::async::boot::EmulationType::Floppy1_44
+pub hadris_iso::async::boot::EmulationType::Floppy2_88
+pub hadris_iso::async::boot::EmulationType::HardDisk
 pub hadris_iso::async::boot::EmulationType::NoEmulation
 pub hadris_iso::async::boot::EmulationType::Unknown(u8)
 impl hadris_iso::async::boot::EmulationType
 pub fn hadris_iso::async::boot::EmulationType::from_u8(u8) -> Self
+pub fn hadris_iso::async::boot::EmulationType::is_emulated(self) -> bool
 pub fn hadris_iso::async::boot::EmulationType::to_u8(self) -> u8
 pub enum hadris_iso::async::boot::PlatformId
 pub hadris_iso::async::boot::PlatformId::Macintosh
@@ -437,6 +442,8 @@ pub fn hadris_iso::async::read::IsoDirEntry::is_file(&self) -> bool
 pub const fn hadris_iso::async::read::IsoDirEntry::is_multi_extent(&self) -> bool
 pub fn hadris_iso::async::read::IsoDirEntry::name(&self) -> hadris_iso::async::read::IsoName<'_>
 pub const fn hadris_iso::async::read::IsoDirEntry::record(&self) -> &hadris_iso::async::directory::DirectoryRecord
+pub fn hadris_iso::async::read::IsoDirEntry::rrip_name_into<'b>(&self, &'b mut [u8]) -> core::option::Option<core::result::Result<&'b str, hadris_iso::async::read::NameError>>
+pub fn hadris_iso::async::read::IsoDirEntry::rrip_name_matches(&self, &str) -> bool
 pub fn hadris_iso::async::read::IsoDirEntry::system_use(&self) -> &[u8]
 pub const fn hadris_iso::async::read::IsoDirEntry::total_size(&self) -> u64
 pub struct hadris_iso::async::read::IsoDirReader<'a, R>
@@ -538,79 +545,6 @@ pub hadris_iso::async::read::RripTimestamps::creation: core::option::Option<hadr
 pub hadris_iso::async::read::RripTimestamps::effective: core::option::Option<hadris_iso::async::read::RripDateTime>
 pub hadris_iso::async::read::RripTimestamps::expiration: core::option::Option<hadris_iso::async::read::RripDateTime>
 pub hadris_iso::async::read::RripTimestamps::modify: core::option::Option<hadris_iso::async::read::RripDateTime>
-pub struct hadris_iso::async::read::SupportedFeatures(_)
-impl hadris_iso::async::read::SupportedFeatures
-pub const fn hadris_iso::async::read::SupportedFeatures::all() -> Self
-pub const fn hadris_iso::async::read::SupportedFeatures::bits(&self) -> u64
-pub const fn hadris_iso::async::read::SupportedFeatures::complement(self) -> Self
-pub const fn hadris_iso::async::read::SupportedFeatures::contains(&self, Self) -> bool
-pub const fn hadris_iso::async::read::SupportedFeatures::difference(self, Self) -> Self
-pub const fn hadris_iso::async::read::SupportedFeatures::empty() -> Self
-pub const fn hadris_iso::async::read::SupportedFeatures::from_bits(u64) -> core::option::Option<Self>
-pub const fn hadris_iso::async::read::SupportedFeatures::from_bits_retain(u64) -> Self
-pub const fn hadris_iso::async::read::SupportedFeatures::from_bits_truncate(u64) -> Self
-pub fn hadris_iso::async::read::SupportedFeatures::from_name(&str) -> core::option::Option<Self>
-pub fn hadris_iso::async::read::SupportedFeatures::insert(&mut self, Self)
-pub const fn hadris_iso::async::read::SupportedFeatures::intersection(self, Self) -> Self
-pub const fn hadris_iso::async::read::SupportedFeatures::intersects(&self, Self) -> bool
-pub const fn hadris_iso::async::read::SupportedFeatures::is_all(&self) -> bool
-pub const fn hadris_iso::async::read::SupportedFeatures::is_empty(&self) -> bool
-pub fn hadris_iso::async::read::SupportedFeatures::remove(&mut self, Self)
-pub fn hadris_iso::async::read::SupportedFeatures::set(&mut self, Self, bool)
-pub const fn hadris_iso::async::read::SupportedFeatures::symmetric_difference(self, Self) -> Self
-pub fn hadris_iso::async::read::SupportedFeatures::toggle(&mut self, Self)
-pub const fn hadris_iso::async::read::SupportedFeatures::union(self, Self) -> Self
-impl hadris_iso::async::read::SupportedFeatures
-pub const fn hadris_iso::async::read::SupportedFeatures::iter(&self) -> bitflags::iter::Iter<hadris_iso::async::read::SupportedFeatures>
-pub const fn hadris_iso::async::read::SupportedFeatures::iter_names(&self) -> bitflags::iter::IterNames<hadris_iso::async::read::SupportedFeatures>
-impl bitflags::traits::Flags for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Bits = u64
-pub const hadris_iso::async::read::SupportedFeatures::FLAGS: &'static [bitflags::traits::Flag<hadris_iso::async::read::SupportedFeatures>]
-pub fn hadris_iso::async::read::SupportedFeatures::all_named() -> hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bits(&self) -> u64
-pub fn hadris_iso::async::read::SupportedFeatures::from_bits_retain(u64) -> hadris_iso::async::read::SupportedFeatures
-impl bitflags::traits::PublicFlags for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Internal = InternalBitFlags
-pub type hadris_iso::async::read::SupportedFeatures::Primitive = u64
-impl core::fmt::Binary for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::LowerHex for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Octal for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::UpperHex for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::iter::traits::collect::Extend<hadris_iso::async::read::SupportedFeatures> for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, T)
-impl core::iter::traits::collect::FromIterator<hadris_iso::async::read::SupportedFeatures> for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(T) -> Self
-impl core::iter::traits::collect::IntoIterator for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::IntoIter = bitflags::iter::Iter<hadris_iso::async::read::SupportedFeatures>
-pub type hadris_iso::async::read::SupportedFeatures::Item = hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::into_iter(self) -> Self::IntoIter
-impl core::ops::arith::Sub for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Output = hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::sub(self, Self) -> Self
-impl core::ops::arith::SubAssign for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::sub_assign(&mut self, Self)
-impl core::ops::bit::BitAnd for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Output = hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bitand(self, Self) -> Self
-impl core::ops::bit::BitAndAssign for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bitand_assign(&mut self, Self)
-impl core::ops::bit::BitOr for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Output = hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bitor(self, hadris_iso::async::read::SupportedFeatures) -> Self
-impl core::ops::bit::BitOrAssign for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bitor_assign(&mut self, Self)
-impl core::ops::bit::BitXor for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Output = hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bitxor(self, Self) -> Self
-impl core::ops::bit::BitXorAssign for hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::bitxor_assign(&mut self, Self)
-impl core::ops::bit::Not for hadris_iso::async::read::SupportedFeatures
-pub type hadris_iso::async::read::SupportedFeatures::Output = hadris_iso::async::read::SupportedFeatures
-pub fn hadris_iso::async::read::SupportedFeatures::not(self) -> Self
 pub struct hadris_iso::async::read::VolumeDescriptorIter<'ctx, DATA: hadris_io::async_api::Read + hadris_io::async_api::Seek>
 impl<DATA: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_iso::async::read::VolumeDescriptorIter<'_, DATA>
 pub async fn hadris_iso::async::read::VolumeDescriptorIter<'_, DATA>::next_descriptor(&mut self) -> hadris_io::error::Result<core::option::Option<hadris_iso::async::volume::VolumeDescriptor>>
@@ -893,6 +827,7 @@ pub fn hadris_iso::async::rrip::RripBuilder::add_rrip_er(&mut self) -> &mut Self
 pub fn hadris_iso::async::rrip::RripBuilder::add_sl(&mut self, &str) -> &mut Self
 pub fn hadris_iso::async::rrip::RripBuilder::add_sp(&mut self, u8) -> &mut Self
 pub fn hadris_iso::async::rrip::RripBuilder::add_st(&mut self) -> &mut Self
+pub fn hadris_iso::async::rrip::RripBuilder::add_tf(&mut self, core::option::Option<&[u8; 7]>, &[u8; 7], &[u8; 7]) -> &mut Self
 pub fn hadris_iso::async::rrip::RripBuilder::add_tf_short(&mut self, &[u8; 7], &[u8; 7]) -> &mut Self
 pub fn hadris_iso::async::rrip::RripBuilder::build(&self) -> alloc::vec::Vec<u8>
 pub fn hadris_iso::async::rrip::RripBuilder::build_split(&self, usize) -> hadris_iso::async::susp::SplitSu
@@ -1444,10 +1379,15 @@ impl core::error::Error for hadris_iso::boot::BootError
 impl core::fmt::Display for hadris_iso::boot::BootError
 pub fn hadris_iso::boot::BootError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum hadris_iso::boot::EmulationType
+pub hadris_iso::boot::EmulationType::Floppy1_2
+pub hadris_iso::boot::EmulationType::Floppy1_44
+pub hadris_iso::boot::EmulationType::Floppy2_88
+pub hadris_iso::boot::EmulationType::HardDisk
 pub hadris_iso::boot::EmulationType::NoEmulation
 pub hadris_iso::boot::EmulationType::Unknown(u8)
 impl hadris_iso::boot::EmulationType
 pub fn hadris_iso::boot::EmulationType::from_u8(u8) -> Self
+pub fn hadris_iso::boot::EmulationType::is_emulated(self) -> bool
 pub fn hadris_iso::boot::EmulationType::to_u8(self) -> u8
 pub enum hadris_iso::boot::PlatformId
 pub hadris_iso::boot::PlatformId::Macintosh
@@ -1729,6 +1669,7 @@ impl core::convert::From<hadris_iso::write::options::BaseIsoLevel> for hadris_is
 pub fn hadris_iso::file::EntryType::from(hadris_iso::write::options::BaseIsoLevel) -> Self
 impl core::default::Default for hadris_iso::file::EntryType
 pub fn hadris_iso::file::EntryType::default() -> Self
+pub const hadris_iso::file::JOLIET_MAX_NAME_CHARS: usize
 pub fn hadris_iso::file::convert_joliet3(&str) -> hadris_fixed::FixedBytes<207>
 pub fn hadris_iso::file::convert_l1(&str, bool) -> hadris_fixed::FixedBytes<14>
 pub fn hadris_iso::file::convert_l2(&str, bool) -> hadris_iso::file::FilenameL2
@@ -1945,6 +1886,8 @@ pub fn hadris_iso::read::IsoDirEntry::is_file(&self) -> bool
 pub const fn hadris_iso::read::IsoDirEntry::is_multi_extent(&self) -> bool
 pub fn hadris_iso::read::IsoDirEntry::name(&self) -> hadris_iso::read::IsoName<'_>
 pub const fn hadris_iso::read::IsoDirEntry::record(&self) -> &hadris_iso::directory::DirectoryRecord
+pub fn hadris_iso::read::IsoDirEntry::rrip_name_into<'b>(&self, &'b mut [u8]) -> core::option::Option<core::result::Result<&'b str, hadris_iso::read::NameError>>
+pub fn hadris_iso::read::IsoDirEntry::rrip_name_matches(&self, &str) -> bool
 pub fn hadris_iso::read::IsoDirEntry::system_use(&self) -> &[u8]
 pub const fn hadris_iso::read::IsoDirEntry::total_size(&self) -> u64
 pub struct hadris_iso::read::IsoDirIter<'a, T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
@@ -2061,79 +2004,6 @@ pub hadris_iso::read::RripTimestamps::creation: core::option::Option<hadris_iso:
 pub hadris_iso::read::RripTimestamps::effective: core::option::Option<hadris_iso::read::RripDateTime>
 pub hadris_iso::read::RripTimestamps::expiration: core::option::Option<hadris_iso::read::RripDateTime>
 pub hadris_iso::read::RripTimestamps::modify: core::option::Option<hadris_iso::read::RripDateTime>
-pub struct hadris_iso::read::SupportedFeatures(_)
-impl hadris_iso::read::SupportedFeatures
-pub const fn hadris_iso::read::SupportedFeatures::all() -> Self
-pub const fn hadris_iso::read::SupportedFeatures::bits(&self) -> u64
-pub const fn hadris_iso::read::SupportedFeatures::complement(self) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::contains(&self, Self) -> bool
-pub const fn hadris_iso::read::SupportedFeatures::difference(self, Self) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::empty() -> Self
-pub const fn hadris_iso::read::SupportedFeatures::from_bits(u64) -> core::option::Option<Self>
-pub const fn hadris_iso::read::SupportedFeatures::from_bits_retain(u64) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::from_bits_truncate(u64) -> Self
-pub fn hadris_iso::read::SupportedFeatures::from_name(&str) -> core::option::Option<Self>
-pub fn hadris_iso::read::SupportedFeatures::insert(&mut self, Self)
-pub const fn hadris_iso::read::SupportedFeatures::intersection(self, Self) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::intersects(&self, Self) -> bool
-pub const fn hadris_iso::read::SupportedFeatures::is_all(&self) -> bool
-pub const fn hadris_iso::read::SupportedFeatures::is_empty(&self) -> bool
-pub fn hadris_iso::read::SupportedFeatures::remove(&mut self, Self)
-pub fn hadris_iso::read::SupportedFeatures::set(&mut self, Self, bool)
-pub const fn hadris_iso::read::SupportedFeatures::symmetric_difference(self, Self) -> Self
-pub fn hadris_iso::read::SupportedFeatures::toggle(&mut self, Self)
-pub const fn hadris_iso::read::SupportedFeatures::union(self, Self) -> Self
-impl hadris_iso::read::SupportedFeatures
-pub const fn hadris_iso::read::SupportedFeatures::iter(&self) -> bitflags::iter::Iter<hadris_iso::read::SupportedFeatures>
-pub const fn hadris_iso::read::SupportedFeatures::iter_names(&self) -> bitflags::iter::IterNames<hadris_iso::read::SupportedFeatures>
-impl bitflags::traits::Flags for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Bits = u64
-pub const hadris_iso::read::SupportedFeatures::FLAGS: &'static [bitflags::traits::Flag<hadris_iso::read::SupportedFeatures>]
-pub fn hadris_iso::read::SupportedFeatures::all_named() -> hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bits(&self) -> u64
-pub fn hadris_iso::read::SupportedFeatures::from_bits_retain(u64) -> hadris_iso::read::SupportedFeatures
-impl bitflags::traits::PublicFlags for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Internal = InternalBitFlags
-pub type hadris_iso::read::SupportedFeatures::Primitive = u64
-impl core::fmt::Binary for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::LowerHex for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Octal for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::UpperHex for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::iter::traits::collect::Extend<hadris_iso::read::SupportedFeatures> for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, T)
-impl core::iter::traits::collect::FromIterator<hadris_iso::read::SupportedFeatures> for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(T) -> Self
-impl core::iter::traits::collect::IntoIterator for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::IntoIter = bitflags::iter::Iter<hadris_iso::read::SupportedFeatures>
-pub type hadris_iso::read::SupportedFeatures::Item = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::into_iter(self) -> Self::IntoIter
-impl core::ops::arith::Sub for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::sub(self, Self) -> Self
-impl core::ops::arith::SubAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::sub_assign(&mut self, Self)
-impl core::ops::bit::BitAnd for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitand(self, Self) -> Self
-impl core::ops::bit::BitAndAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitand_assign(&mut self, Self)
-impl core::ops::bit::BitOr for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitor(self, hadris_iso::read::SupportedFeatures) -> Self
-impl core::ops::bit::BitOrAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitor_assign(&mut self, Self)
-impl core::ops::bit::BitXor for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitxor(self, Self) -> Self
-impl core::ops::bit::BitXorAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitxor_assign(&mut self, Self)
-impl core::ops::bit::Not for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::not(self) -> Self
 pub struct hadris_iso::read::VolumeDescriptorIter<'ctx, DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::VolumeDescriptorIter<'_, DATA>
 pub fn hadris_iso::read::VolumeDescriptorIter<'_, DATA>::next_descriptor(&mut self) -> hadris_io::error::Result<core::option::Option<hadris_iso::volume::VolumeDescriptor>>
@@ -2419,6 +2289,7 @@ pub fn hadris_iso::rrip::RripBuilder::add_rrip_er(&mut self) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_sl(&mut self, &str) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_sp(&mut self, u8) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_st(&mut self) -> &mut Self
+pub fn hadris_iso::rrip::RripBuilder::add_tf(&mut self, core::option::Option<&[u8; 7]>, &[u8; 7], &[u8; 7]) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_tf_short(&mut self, &[u8; 7], &[u8; 7]) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::build(&self) -> alloc::vec::Vec<u8>
 pub fn hadris_iso::rrip::RripBuilder::build_split(&self, usize) -> hadris_iso::susp::SplitSu
@@ -2796,10 +2667,15 @@ impl core::error::Error for hadris_iso::boot::BootError
 impl core::fmt::Display for hadris_iso::boot::BootError
 pub fn hadris_iso::boot::BootError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum hadris_iso::sync::boot::EmulationType
+pub hadris_iso::sync::boot::EmulationType::Floppy1_2
+pub hadris_iso::sync::boot::EmulationType::Floppy1_44
+pub hadris_iso::sync::boot::EmulationType::Floppy2_88
+pub hadris_iso::sync::boot::EmulationType::HardDisk
 pub hadris_iso::sync::boot::EmulationType::NoEmulation
 pub hadris_iso::sync::boot::EmulationType::Unknown(u8)
 impl hadris_iso::boot::EmulationType
 pub fn hadris_iso::boot::EmulationType::from_u8(u8) -> Self
+pub fn hadris_iso::boot::EmulationType::is_emulated(self) -> bool
 pub fn hadris_iso::boot::EmulationType::to_u8(self) -> u8
 pub enum hadris_iso::sync::boot::PlatformId
 pub hadris_iso::sync::boot::PlatformId::Macintosh
@@ -3240,6 +3116,8 @@ pub fn hadris_iso::read::IsoDirEntry::is_file(&self) -> bool
 pub const fn hadris_iso::read::IsoDirEntry::is_multi_extent(&self) -> bool
 pub fn hadris_iso::read::IsoDirEntry::name(&self) -> hadris_iso::read::IsoName<'_>
 pub const fn hadris_iso::read::IsoDirEntry::record(&self) -> &hadris_iso::directory::DirectoryRecord
+pub fn hadris_iso::read::IsoDirEntry::rrip_name_into<'b>(&self, &'b mut [u8]) -> core::option::Option<core::result::Result<&'b str, hadris_iso::read::NameError>>
+pub fn hadris_iso::read::IsoDirEntry::rrip_name_matches(&self, &str) -> bool
 pub fn hadris_iso::read::IsoDirEntry::system_use(&self) -> &[u8]
 pub const fn hadris_iso::read::IsoDirEntry::total_size(&self) -> u64
 pub struct hadris_iso::sync::read::IsoDirIter<'a, T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
@@ -3356,79 +3234,6 @@ pub hadris_iso::sync::read::RripTimestamps::creation: core::option::Option<hadri
 pub hadris_iso::sync::read::RripTimestamps::effective: core::option::Option<hadris_iso::read::RripDateTime>
 pub hadris_iso::sync::read::RripTimestamps::expiration: core::option::Option<hadris_iso::read::RripDateTime>
 pub hadris_iso::sync::read::RripTimestamps::modify: core::option::Option<hadris_iso::read::RripDateTime>
-pub struct hadris_iso::sync::read::SupportedFeatures(_)
-impl hadris_iso::read::SupportedFeatures
-pub const fn hadris_iso::read::SupportedFeatures::all() -> Self
-pub const fn hadris_iso::read::SupportedFeatures::bits(&self) -> u64
-pub const fn hadris_iso::read::SupportedFeatures::complement(self) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::contains(&self, Self) -> bool
-pub const fn hadris_iso::read::SupportedFeatures::difference(self, Self) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::empty() -> Self
-pub const fn hadris_iso::read::SupportedFeatures::from_bits(u64) -> core::option::Option<Self>
-pub const fn hadris_iso::read::SupportedFeatures::from_bits_retain(u64) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::from_bits_truncate(u64) -> Self
-pub fn hadris_iso::read::SupportedFeatures::from_name(&str) -> core::option::Option<Self>
-pub fn hadris_iso::read::SupportedFeatures::insert(&mut self, Self)
-pub const fn hadris_iso::read::SupportedFeatures::intersection(self, Self) -> Self
-pub const fn hadris_iso::read::SupportedFeatures::intersects(&self, Self) -> bool
-pub const fn hadris_iso::read::SupportedFeatures::is_all(&self) -> bool
-pub const fn hadris_iso::read::SupportedFeatures::is_empty(&self) -> bool
-pub fn hadris_iso::read::SupportedFeatures::remove(&mut self, Self)
-pub fn hadris_iso::read::SupportedFeatures::set(&mut self, Self, bool)
-pub const fn hadris_iso::read::SupportedFeatures::symmetric_difference(self, Self) -> Self
-pub fn hadris_iso::read::SupportedFeatures::toggle(&mut self, Self)
-pub const fn hadris_iso::read::SupportedFeatures::union(self, Self) -> Self
-impl hadris_iso::read::SupportedFeatures
-pub const fn hadris_iso::read::SupportedFeatures::iter(&self) -> bitflags::iter::Iter<hadris_iso::read::SupportedFeatures>
-pub const fn hadris_iso::read::SupportedFeatures::iter_names(&self) -> bitflags::iter::IterNames<hadris_iso::read::SupportedFeatures>
-impl bitflags::traits::Flags for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Bits = u64
-pub const hadris_iso::read::SupportedFeatures::FLAGS: &'static [bitflags::traits::Flag<hadris_iso::read::SupportedFeatures>]
-pub fn hadris_iso::read::SupportedFeatures::all_named() -> hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bits(&self) -> u64
-pub fn hadris_iso::read::SupportedFeatures::from_bits_retain(u64) -> hadris_iso::read::SupportedFeatures
-impl bitflags::traits::PublicFlags for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Internal = InternalBitFlags
-pub type hadris_iso::read::SupportedFeatures::Primitive = u64
-impl core::fmt::Binary for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::LowerHex for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Octal for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::UpperHex for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::iter::traits::collect::Extend<hadris_iso::read::SupportedFeatures> for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, T)
-impl core::iter::traits::collect::FromIterator<hadris_iso::read::SupportedFeatures> for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(T) -> Self
-impl core::iter::traits::collect::IntoIterator for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::IntoIter = bitflags::iter::Iter<hadris_iso::read::SupportedFeatures>
-pub type hadris_iso::read::SupportedFeatures::Item = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::into_iter(self) -> Self::IntoIter
-impl core::ops::arith::Sub for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::sub(self, Self) -> Self
-impl core::ops::arith::SubAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::sub_assign(&mut self, Self)
-impl core::ops::bit::BitAnd for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitand(self, Self) -> Self
-impl core::ops::bit::BitAndAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitand_assign(&mut self, Self)
-impl core::ops::bit::BitOr for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitor(self, hadris_iso::read::SupportedFeatures) -> Self
-impl core::ops::bit::BitOrAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitor_assign(&mut self, Self)
-impl core::ops::bit::BitXor for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitxor(self, Self) -> Self
-impl core::ops::bit::BitXorAssign for hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::bitxor_assign(&mut self, Self)
-impl core::ops::bit::Not for hadris_iso::read::SupportedFeatures
-pub type hadris_iso::read::SupportedFeatures::Output = hadris_iso::read::SupportedFeatures
-pub fn hadris_iso::read::SupportedFeatures::not(self) -> Self
 pub struct hadris_iso::sync::read::VolumeDescriptorIter<'ctx, DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_iso::read::VolumeDescriptorIter<'_, DATA>
 pub fn hadris_iso::read::VolumeDescriptorIter<'_, DATA>::next_descriptor(&mut self) -> hadris_io::error::Result<core::option::Option<hadris_iso::volume::VolumeDescriptor>>
@@ -3714,6 +3519,7 @@ pub fn hadris_iso::rrip::RripBuilder::add_rrip_er(&mut self) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_sl(&mut self, &str) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_sp(&mut self, u8) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_st(&mut self) -> &mut Self
+pub fn hadris_iso::rrip::RripBuilder::add_tf(&mut self, core::option::Option<&[u8; 7]>, &[u8; 7], &[u8; 7]) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::add_tf_short(&mut self, &[u8; 7], &[u8; 7]) -> &mut Self
 pub fn hadris_iso::rrip::RripBuilder::build(&self) -> alloc::vec::Vec<u8>
 pub fn hadris_iso::rrip::RripBuilder::build_split(&self, usize) -> hadris_iso::susp::SplitSu

--- a/crates/archive/hadris-archive/Cargo.toml
+++ b/crates/archive/hadris-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-archive"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-cpio/Cargo.toml
+++ b/crates/archive/hadris-cpio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-cpio/README.md
+++ b/crates/archive/hadris-cpio/README.md
@@ -76,21 +76,21 @@ configurations should enable `sync`, `async`, or both explicitly.
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+hadris-cpio = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Kernels with Heap (no-std + alloc)
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.0.0-rc.1", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-cpio = { version = "2.0.0-rc.2", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-cpio = "2.0.0-rc.1"  # Uses default features
+hadris-cpio = "2.0.0-rc.2"  # Uses default features
 ```
 
 ## Archive Format

--- a/crates/block/hadris-block/Cargo.toml
+++ b/crates/block/hadris-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-block"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-fat/Cargo.toml
+++ b/crates/block/hadris-fat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fat"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 description = "Rust FAT12/FAT16/FAT32 filesystem library for disk images, embedded devices, and no-std"
 readme = "README.md"
 keywords = ["fat", "fat32", "vfat", "filesystem", "no-std"]

--- a/crates/block/hadris-fat/README.md
+++ b/crates/block/hadris-fat/README.md
@@ -146,21 +146,21 @@ Automatic FAT type selection follows Microsoft recommendations:
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Embedded Systems with Heap
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.0.0-rc.1", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
+hadris-fat = { version = "2.0.0-rc.2", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-fat = "2.0.0-rc.1"  # Uses default features
+hadris-fat = "2.0.0-rc.2"  # Uses default features
 ```
 
 ## FAT Variant Support

--- a/crates/block/hadris-fat/src/dir.rs
+++ b/crates/block/hadris-fat/src/dir.rs
@@ -8,13 +8,45 @@ use crate::error::{FatError, Result};
 use crate::file::ShortFileName;
 #[cfg(feature = "lfn")]
 use crate::file::{LfnBuilder, LongFileName};
-use crate::raw::{DirEntryAttrFlags, RawDirectoryEntry};
+use crate::raw::{DirEntryAttrFlags, NtCaseFlags, RawDirectoryEntry};
 use crate::time::FatDateTime;
 use super::fs::FatFs;
 #[cfg(not(feature = "alloc"))]
 use super::io::ReadExt;
 use super::io::{Cluster, ClusterLike, Read, Seek, SeekFrom};
 use super::read::FileReader;
+
+/// Formats a stored 8.3 short name as its human-facing filename: the NT case
+/// flags are applied, trailing space padding is trimmed from the base and
+/// extension, and the `.` separator is dropped when there is no extension.
+///
+/// [`ShortFileName::as_str`] returns the padded on-disk field (`README  .TXT`);
+/// this returns the logical name (`readme.txt`).
+#[cfg(feature = "alloc")]
+fn short_name_display(short: &ShortFileName, flags: NtCaseFlags) -> alloc::string::String {
+    use alloc::string::ToString;
+
+    // The "." and ".." directory entries are stored without 8.3 padding and
+    // carry no case flags; the base/extension split below would corrupt them.
+    let raw = short.as_str();
+    if raw == "." || raw == ".." {
+        return raw.to_string();
+    }
+
+    let cased = short.with_nt_case(flags);
+    let raw = cased.as_str();
+    let (base, ext) = match raw.find('.') {
+        Some(dot) => (raw[..dot].trim_end(), raw[dot + 1..].trim_end()),
+        None => (raw.trim_end(), ""),
+    };
+    let mut name = alloc::string::String::with_capacity(base.len() + 1 + ext.len());
+    name.push_str(base);
+    if !ext.is_empty() {
+        name.push('.');
+        name.push_str(ext);
+    }
+    name
+}
 
 /// A directory within a mounted FAT filesystem.
 pub struct FatDir<'a, DATA: Read + Seek> {
@@ -381,6 +413,7 @@ impl<DATA: Read + Seek> FatDirIter<'_, DATA> {
 
             return Some(Ok(DirectoryEntry::Entry(FileEntry {
                 short_name,
+                nt_case: NtCaseFlags::from_bits_truncate(file_entry.reserved),
                 #[cfg(feature = "lfn")]
                 long_name,
                 attr,
@@ -456,6 +489,9 @@ bitflags::bitflags! {
 /// Metadata for a file or subdirectory entry.
 pub struct FileEntry {
     pub(crate) short_name: ShortFileName,
+    /// Windows NT 8.3 name case flags (`DIR_NTRes`); applied to the display
+    /// name when no long name is present.
+    pub(crate) nt_case: NtCaseFlags,
     #[cfg(feature = "lfn")]
     pub(crate) long_name: Option<LongFileName>,
     pub(crate) attr: DirEntryAttrFlags,
@@ -498,12 +534,23 @@ impl FileEntry {
                 return alloc::borrow::Cow::Owned(lfn.to_string());
             }
         }
-        alloc::borrow::Cow::Borrowed(self.short_name.as_str())
+        alloc::borrow::Cow::Owned(short_name_display(&self.short_name, self.nt_case))
     }
 
-    /// Get the short (8.3) filename
+    /// Get the short (8.3) filename, in its canonical on-disk (uppercase) form.
+    ///
+    /// Use [`Self::nt_case`] with [`ShortFileName::with_nt_case`] to recover the
+    /// original lowercase presentation without allocating.
     pub fn short_name(&self) -> &ShortFileName {
         &self.short_name
+    }
+
+    /// Windows NT 8.3 name case flags (`DIR_NTRes`) for this entry.
+    ///
+    /// Records whether the short name's base and/or extension were originally
+    /// lowercase. Meaningful only when the entry has no long file name.
+    pub fn nt_case(&self) -> NtCaseFlags {
+        self.nt_case
     }
 
     /// Get the long filename, if available
@@ -789,6 +836,7 @@ impl<DATA: Read + Seek> Iterator for FatDirIter<'_, DATA> {
 
             return Some(Ok(DirectoryEntry::Entry(FileEntry {
                 short_name,
+                nt_case: NtCaseFlags::from_bits_truncate(file_entry.reserved),
                 #[cfg(feature = "lfn")]
                 long_name,
                 attr,

--- a/crates/block/hadris-fat/src/fat_table.rs
+++ b/crates/block/hadris-fat/src/fat_table.rs
@@ -645,6 +645,52 @@ impl Fat12 {
         Err(FatError::NoFreeSpace)
     }
 
+    /// Allocate a linked chain of `count` clusters, returning the first cluster.
+    ///
+    /// Each cluster is allocated from a rolling hint (near the previous one) and
+    /// linked to its successor; the last is marked end-of-chain. Mirrors
+    /// [`Fat32::allocate_chain`]. On partial failure the already-allocated
+    /// clusters are not rolled back (matching the FAT32 behavior).
+    #[cfg(feature = "write")]
+    pub async fn allocate_chain<T: Read + Write + Seek>(
+        &self,
+        rw: &mut T,
+        count: usize,
+        hint: u16,
+    ) -> Result<u16> {
+        if count == 0 {
+            return Err(FatError::NoFreeSpace);
+        }
+        let first = self.allocate_cluster(rw, hint).await?;
+        let mut prev = first;
+        for _ in 1..count {
+            let next = self.allocate_cluster(rw, prev + 1).await?;
+            self.write_clus(rw, prev as usize, next).await?;
+            prev = next;
+        }
+        Ok(first)
+    }
+
+    /// Extend the chain whose current last cluster is `last` by `count`
+    /// clusters, returning the first newly allocated cluster. If `count` is 0,
+    /// no clusters are allocated and `last` is returned unchanged. Mirrors
+    /// [`Fat32::extend_chain`].
+    #[cfg(feature = "write")]
+    pub async fn extend_chain<T: Read + Write + Seek>(
+        &self,
+        rw: &mut T,
+        last: u16,
+        count: usize,
+        hint: u16,
+    ) -> Result<u16> {
+        if count == 0 {
+            return Ok(last);
+        }
+        let first_new = self.allocate_chain(rw, count, hint).await?;
+        self.write_clus(rw, last as usize, first_new).await?;
+        Ok(first_new)
+    }
+
     /// Free a cluster chain starting at `start`, returns count of freed clusters.
     #[cfg(feature = "write")]
     pub async fn free_chain<T: Read + Write + Seek>(&self, rw: &mut T, start: u16) -> Result<u32> {
@@ -882,6 +928,52 @@ impl Fat16 {
         }
 
         Err(FatError::NoFreeSpace)
+    }
+
+    /// Allocate a linked chain of `count` clusters, returning the first cluster.
+    ///
+    /// Each cluster is allocated from a rolling hint (near the previous one) and
+    /// linked to its successor; the last is marked end-of-chain. Mirrors
+    /// [`Fat32::allocate_chain`]. On partial failure the already-allocated
+    /// clusters are not rolled back (matching the FAT32 behavior).
+    #[cfg(feature = "write")]
+    pub async fn allocate_chain<T: Read + Write + Seek>(
+        &self,
+        rw: &mut T,
+        count: usize,
+        hint: u16,
+    ) -> Result<u16> {
+        if count == 0 {
+            return Err(FatError::NoFreeSpace);
+        }
+        let first = self.allocate_cluster(rw, hint).await?;
+        let mut prev = first;
+        for _ in 1..count {
+            let next = self.allocate_cluster(rw, prev + 1).await?;
+            self.write_clus(rw, prev as usize, next).await?;
+            prev = next;
+        }
+        Ok(first)
+    }
+
+    /// Extend the chain whose current last cluster is `last` by `count`
+    /// clusters, returning the first newly allocated cluster. If `count` is 0,
+    /// no clusters are allocated and `last` is returned unchanged. Mirrors
+    /// [`Fat32::extend_chain`].
+    #[cfg(feature = "write")]
+    pub async fn extend_chain<T: Read + Write + Seek>(
+        &self,
+        rw: &mut T,
+        last: u16,
+        count: usize,
+        hint: u16,
+    ) -> Result<u16> {
+        if count == 0 {
+            return Ok(last);
+        }
+        let first_new = self.allocate_chain(rw, count, hint).await?;
+        self.write_clus(rw, last as usize, first_new).await?;
+        Ok(first_new)
     }
 
     /// Free a cluster chain starting at `start`, returns count of freed clusters.

--- a/crates/block/hadris-fat/src/file.rs
+++ b/crates/block/hadris-fat/src/file.rs
@@ -92,6 +92,48 @@ impl ShortFileName {
         self.0.as_str()
     }
 
+    /// Returns a copy of this 8.3 name with the base and/or extension
+    /// lowercased according to the Windows NT `DIR_NTRes` case flags.
+    ///
+    /// FAT stores 8.3 names uppercase on disk; the case flags (see
+    /// [`NtCaseFlags`](crate::raw::NtCaseFlags)) record that the name was
+    /// originally entered lowercase so it can be presented that way without a
+    /// long-file-name entry. Only ASCII letters are re-cased; any other bytes
+    /// (OEM high bytes, digits, symbols, the `.` separator) pass through
+    /// unchanged.
+    pub fn with_nt_case(&self, flags: crate::raw::NtCaseFlags) -> ShortFileName {
+        use crate::raw::NtCaseFlags;
+
+        fn push_maybe_lower(out: &mut FixedBytes<12>, part: &[u8], lower: bool) {
+            for &byte in part {
+                out.push_byte(if lower {
+                    byte.to_ascii_lowercase()
+                } else {
+                    byte
+                });
+            }
+        }
+
+        let bytes = self.0.as_bytes();
+        let dot = bytes.iter().position(|&b| b == b'.');
+        let base_end = dot.unwrap_or(bytes.len());
+        let mut out = FixedBytes::<12>::empty();
+        push_maybe_lower(
+            &mut out,
+            &bytes[..base_end],
+            flags.contains(NtCaseFlags::LOWER_BASE),
+        );
+        if let Some(dot) = dot {
+            out.push_byte(b'.');
+            push_maybe_lower(
+                &mut out,
+                &bytes[dot + 1..],
+                flags.contains(NtCaseFlags::LOWER_EXT),
+            );
+        }
+        ShortFileName(out)
+    }
+
     /// Check if this short filename matches a given name (case-insensitive).
     /// Handles both padded ("TEST    .TXT") and unpadded ("TEST.TXT") formats.
     pub fn matches(&self, name: &str) -> bool {

--- a/crates/block/hadris-fat/src/raw.rs
+++ b/crates/block/hadris-fat/src/raw.rs
@@ -213,9 +213,15 @@ unsafe impl bytemuck::AnyBitPattern for RawBpbExt32 {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BpbExt32Flags(u16);
 
+/// Raw 32-byte FAT short-name file or directory entry.
+///
+/// @hadris-spec FAT:DirEntry
+/// @hadris-compliance partial
+/// @hadris-note Name/attributes/timestamps/cluster/size and NT case flags (`DIR_NTRes`) are read and written; extended access-time granularity is not modeled.
+/// @hadris-tests test_write::test_lowercase_short_name_uses_nt_case_flags
+/// @hadris-fuzz fat_read
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
-/// Raw 32-byte FAT short-name file or directory entry.
 pub struct RawFileEntry {
     /// DIR_Name
     ///
@@ -233,7 +239,10 @@ pub struct RawFileEntry {
     pub attributes: u8,
     /// DIR_NTRes
     ///
-    /// Reserved for use by Windows NT
+    /// Reserved for use by Windows NT. In practice Windows stores 8.3 name
+    /// case information here: bit 3 (`0x08`) marks the base name as originally
+    /// lowercase and bit 4 (`0x10`) marks the extension as originally
+    /// lowercase. See [`NtCaseFlags`].
     pub reserved: u8,
     /// DIR_CrtTimeTenth
     ///
@@ -366,9 +375,14 @@ unsafe impl bytemuck::NoUninit for RawDirectoryEntry {}
 unsafe impl bytemuck::Zeroable for RawDirectoryEntry {}
 unsafe impl bytemuck::AnyBitPattern for RawDirectoryEntry {}
 
+/// Raw FAT32 FSInfo sector.
+///
+/// @hadris-spec FAT:FSInfo
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_fat::test_fsinfo_free_cluster_unknown
+/// @hadris-fuzz fat_read
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
-/// Raw FAT32 FSInfo sector.
 pub struct RawFsInfo {
     /// FSI_LeadSig
     ///
@@ -419,6 +433,22 @@ bitflags::bitflags! {
         const DIRECTORY = 1 << 4;
         /// Entry has the archive bit set.
         const ARCHIVE = 1 << 5;
+    }
+}
+
+bitflags::bitflags! {
+    /// Windows NT 8.3 name case flags stored in the `DIR_NTRes` byte.
+    ///
+    /// FAT stores 8.3 short names uppercase on disk. Windows records in this
+    /// byte whether the base name and/or extension were originally lowercase
+    /// so an all-lowercase (or lowercase-base / lowercase-ext) 8.3 name can be
+    /// presented in its original case without spending a long-file-name entry.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NtCaseFlags: u8 {
+        /// The base name (characters before the dot) was originally lowercase.
+        const LOWER_BASE = 0x08;
+        /// The extension (characters after the dot) was originally lowercase.
+        const LOWER_EXT = 0x10;
     }
 }
 

--- a/crates/block/hadris-fat/src/write.rs
+++ b/crates/block/hadris-fat/src/write.rs
@@ -546,26 +546,72 @@ fn kanji_short_name_fixup(name: &mut [u8; 11]) {
 #[cfg(all(feature = "write", feature = "lfn"))]
 pub(crate) const MAX_LFN_ENTRIES: usize = 20;
 
-/// Decide whether `name` requires LFN entries to round-trip losslessly.
+/// Decide whether `name` can be stored as a single short (8.3) directory entry
+/// using the Windows NT `DIR_NTRes` case flags, and if so which flags to set.
 ///
-/// Returns `true` for any name that wouldn't survive the 8.3 short-name
-/// conversion: lowercase letters, multiple dots, spaces, length over 8.3,
-/// or non-ASCII characters. Returns `false` for already-conforming names —
-/// those write as a single short entry, the same as before LFN-write existed.
-#[cfg(all(feature = "write", feature = "lfn"))]
-fn name_requires_lfn(name: &str) -> bool {
+/// Returns `Some(bits)` when the name fits 8.3 with at most a per-part *uniform*
+/// case difference — `bits` carries `LOWER_BASE` (0x08) and/or `LOWER_EXT`
+/// (0x10) so a lowercase name round-trips without a long-file-name entry. An
+/// already-uppercase 8.3 name returns `Some(0)`. Returns `None` when the name
+/// needs LFN entries to round-trip: too long, spaces, multiple dots, mixed case
+/// within the base or extension, or characters not representable in the 8.3
+/// character set.
+///
+/// This replaces the older "does this need an LFN?" predicate — a `None` result
+/// is exactly the set of names that previously required LFN entries.
+#[cfg(feature = "write")]
+fn short_name_case_bits(name: &str) -> Option<u8> {
+    const LOWER_BASE: u8 = 0x08;
+    const LOWER_EXT: u8 = 0x10;
+
     let (base, ext) = match name.rfind('.') {
         Some(pos) if pos > 0 => (&name[..pos], &name[pos + 1..]),
         _ => (name, ""),
     };
-    if base.chars().count() > 8 || ext.chars().count() > 3 {
-        return true;
+    if base.is_empty() || base.chars().count() > 8 || ext.chars().count() > 3 {
+        return None;
     }
     if name.matches('.').count() > 1 {
-        return true;
+        return None;
     }
-    name.chars()
-        .any(|c| !c.is_ascii() || c.is_ascii_lowercase() || c == ' ')
+
+    // Returns `Some(true)` for an all-lowercase part, `Some(false)` for an
+    // all-uppercase (or caseless) part, and `None` when the part is not 8.3
+    // representable (invalid character or mixed case).
+    fn part_is_lower(part: &str) -> Option<bool> {
+        let mut seen_lower = false;
+        let mut seen_upper = false;
+        for c in part.chars() {
+            if !c.is_ascii() {
+                return None;
+            }
+            let upper = (c as u8).to_ascii_uppercase();
+            let representable = upper.is_ascii_uppercase()
+                || upper.is_ascii_digit()
+                || ShortFileName::ALLOWED_SYMBOLS.contains(&upper);
+            if !representable {
+                return None;
+            }
+            if c.is_ascii_lowercase() {
+                seen_lower = true;
+            } else if c.is_ascii_uppercase() {
+                seen_upper = true;
+            }
+        }
+        if seen_lower && seen_upper {
+            return None;
+        }
+        Some(seen_lower)
+    }
+
+    let mut bits = 0;
+    if part_is_lower(base)? {
+        bits |= LOWER_BASE;
+    }
+    if part_is_lower(ext)? {
+        bits |= LOWER_EXT;
+    }
+    Some(bits)
 }
 
 /// Maximum number of LFN entries we'll walk backward when cleaning up
@@ -1092,19 +1138,23 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
         let short_name = ShortFileName::from_long_name_with(name, 0, self.oem_converter())
             .map_err(|_| FatError::InvalidFilename)?;
 
-        // Build LFN entries if the long name doesn't fit 8.3 cleanly, into
-        // a stack buffer. When the lfn feature is off, we never emit LFN.
+        // A name that fits 8.3 apart from per-part case is stored as a single
+        // short entry with the NT case byte set; otherwise it needs LFN entries.
+        // When the lfn feature is off, we never emit LFN.
+        let case_bits = short_name_case_bits(name);
         #[cfg(feature = "lfn")]
         let mut lfn_buf: [RawDirectoryEntry; MAX_LFN_ENTRIES] = unsafe { core::mem::zeroed() };
         #[cfg(feature = "lfn")]
-        let lfn_count = if name_requires_lfn(name) {
-            build_lfn_entries(name, short_name.lfn_checksum(), &mut lfn_buf)
-                .ok_or(FatError::InvalidFilename)?
-        } else {
-            0
+        let (lfn_count, nt_res) = match case_bits {
+            Some(bits) => (0usize, bits),
+            None => (
+                build_lfn_entries(name, short_name.lfn_checksum(), &mut lfn_buf)
+                    .ok_or(FatError::InvalidFilename)?,
+                0u8,
+            ),
         };
         #[cfg(not(feature = "lfn"))]
-        let lfn_count = 0usize;
+        let (lfn_count, nt_res) = (0usize, case_bits.unwrap_or(0));
 
         // Find a free run sized for the LFN preamble + the short entry.
         let total_slots = lfn_count + 1;
@@ -1120,7 +1170,7 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
         let entry = RawFileEntry {
             name: raw_name,
             attributes: DirEntryAttrFlags::ARCHIVE.bits(),
-            reserved: 0,
+            reserved: nt_res,
             creation_time_tenth: time_tenth,
             creation_time: time.to_le_bytes(),
             creation_date: date.to_le_bytes(),
@@ -1159,6 +1209,7 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
 
         Ok(FileEntry {
             short_name,
+            nt_case: crate::raw::NtCaseFlags::from_bits_truncate(nt_res),
             #[cfg(feature = "lfn")]
             long_name: if lfn_count > 0 {
                 crate::file::LongFileName::from_str_utf16(name)
@@ -1201,19 +1252,23 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
         self.decrement_free_count();
         self.update_next_free_hint(new_cluster);
 
-        // Build LFN entries if the long name doesn't fit 8.3 cleanly. When
-        // the lfn feature is off, we never emit LFN.
+        // A name that fits 8.3 apart from per-part case is stored as a single
+        // short entry with the NT case byte set; otherwise it needs LFN entries.
+        // When the lfn feature is off, we never emit LFN.
+        let case_bits = short_name_case_bits(name);
         #[cfg(feature = "lfn")]
         let mut lfn_buf: [RawDirectoryEntry; MAX_LFN_ENTRIES] = unsafe { core::mem::zeroed() };
         #[cfg(feature = "lfn")]
-        let lfn_count = if name_requires_lfn(name) {
-            build_lfn_entries(name, short_name.lfn_checksum(), &mut lfn_buf)
-                .ok_or(FatError::InvalidFilename)?
-        } else {
-            0
+        let (lfn_count, nt_res) = match case_bits {
+            Some(bits) => (0usize, bits),
+            None => (
+                build_lfn_entries(name, short_name.lfn_checksum(), &mut lfn_buf)
+                    .ok_or(FatError::InvalidFilename)?,
+                0u8,
+            ),
         };
         #[cfg(not(feature = "lfn"))]
-        let lfn_count = 0usize;
+        let (lfn_count, nt_res) = (0usize, case_bits.unwrap_or(0));
 
         // Allocate `lfn_count + 1` consecutive slots.
         let total_slots = lfn_count + 1;
@@ -1235,7 +1290,7 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
         let entry = RawFileEntry {
             name: raw_name,
             attributes: DirEntryAttrFlags::DIRECTORY.bits(),
-            reserved: 0,
+            reserved: nt_res,
             creation_time_tenth: time_tenth,
             creation_time: time.to_le_bytes(),
             creation_date: date.to_le_bytes(),
@@ -1416,19 +1471,23 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
         let short_name = ShortFileName::from_long_name_with(new_name, 0, self.oem_converter())
             .map_err(|_| FatError::InvalidFilename)?;
 
-        // Build LFN entries for the new name if it doesn't fit 8.3 cleanly.
-        // When the lfn feature is off, we never emit LFN.
+        // The new name is stored as a single short entry (with NT case bits)
+        // when it fits 8.3 apart from case, otherwise via LFN entries. When the
+        // lfn feature is off, we never emit LFN.
+        let case_bits = short_name_case_bits(new_name);
         #[cfg(feature = "lfn")]
         let mut lfn_buf: [RawDirectoryEntry; MAX_LFN_ENTRIES] = unsafe { core::mem::zeroed() };
         #[cfg(feature = "lfn")]
-        let lfn_count = if name_requires_lfn(new_name) {
-            build_lfn_entries(new_name, short_name.lfn_checksum(), &mut lfn_buf)
-                .ok_or(FatError::InvalidFilename)?
-        } else {
-            0
+        let (lfn_count, nt_res) = match case_bits {
+            Some(bits) => (0usize, bits),
+            None => (
+                build_lfn_entries(new_name, short_name.lfn_checksum(), &mut lfn_buf)
+                    .ok_or(FatError::InvalidFilename)?,
+                0u8,
+            ),
         };
         #[cfg(not(feature = "lfn"))]
-        let lfn_count = 0usize;
+        let (lfn_count, nt_res) = (0usize, case_bits.unwrap_or(0));
 
         // Find a contiguous run sized for LFN entries plus the short entry.
         let total_slots = lfn_count + 1;
@@ -1479,8 +1538,9 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
         let now = self.time_provider().now();
         let new_entry = RawFileEntry {
             name: raw_name,
+            // Case bits follow the new name, not the original entry's.
+            reserved: nt_res,
             attributes: original_file.attributes,
-            reserved: original_file.reserved,
             creation_time_tenth: original_file.creation_time_tenth,
             creation_time: original_file.creation_time,
             creation_date: original_file.creation_date,
@@ -1542,6 +1602,7 @@ impl<DATA: Read + Write + Seek> FatFs<DATA> {
 
         Ok(FileEntry {
             short_name,
+            nt_case: crate::raw::NtCaseFlags::from_bits_truncate(nt_res),
             #[cfg(feature = "lfn")]
             long_name: if lfn_count > 0 {
                 crate::file::LongFileName::from_str_utf16(new_name)

--- a/crates/block/hadris-fat/tests/mtools_fidelity.rs
+++ b/crates/block/hadris-fat/tests/mtools_fidelity.rs
@@ -1,0 +1,101 @@
+//! External-tool fidelity checks against `mtools`.
+//!
+//! `fsck.fat` validates structure but not filename/content fidelity. These
+//! tests write an image with hadris and read it back with `mdir`/`mtype` so a
+//! reference FAT driver confirms what hadris produced — in particular that a
+//! lowercase 8.3 name (stored via the NT `DIR_NTRes` case bits) is presented in
+//! its original case.
+//!
+//! All tests skip cleanly when `mtools` is not installed, so they are inert
+//! locally and only assert in CI where the tool is present.
+
+#![cfg(feature = "write")]
+
+use std::io::Seek;
+use std::path::Path;
+use std::process::Command;
+
+use hadris_fat::format::{FatTypeSelection, FatVolumeFormatter, FormatOptions};
+use hadris_fat::{FatFs, FatFsWriteExt};
+
+fn mtools_available() -> bool {
+    Command::new("mdir")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// hadris writes the image; the closure is invoked to populate it.
+fn make_image_with(path: &Path, size: u64, files: &[(&str, &[u8])]) {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .expect("create image");
+    file.set_len(size).expect("set length");
+    let options = FormatOptions::new(size)
+        .volume_label("MTOOLS")
+        .fat_type(FatTypeSelection::Fat16);
+    drop(FatVolumeFormatter::format(file, options).expect("format"));
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("reopen image");
+    file.seek(std::io::SeekFrom::Start(0)).unwrap();
+    let fs = FatFs::open(file).expect("open FAT");
+    for (name, contents) in files {
+        let entry = fs.create_file(&fs.root_dir(), name).expect("create_file");
+        let mut writer = fs.write_file(&entry).expect("write_file");
+        writer.write(contents).expect("write");
+        writer.finish().expect("finish");
+    }
+    // Dropping `fs` flushes its underlying File handle.
+    drop(fs);
+}
+
+/// `-i <image>` drives mtools against a raw FAT image, using `::` as the drive.
+fn mtools(image: &Path, args: &[&str]) -> String {
+    let mut command = Command::new(args[0]);
+    command.arg("-i").arg(image);
+    command.args(&args[1..]);
+    let output = command.output().expect("run mtools");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn mtools_reads_lowercase_short_name_in_original_case() {
+    if !mtools_available() {
+        eprintln!("note: mtools not available, skipping external validation");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let img = tmp.path().join("case.img");
+    // FAT16 requires at least 4 MiB; give some headroom above the minimum.
+    make_image_with(&img, 8 * 1024 * 1024, &[("readme.txt", b"hadris")]);
+
+    // `mdir ::` lists the root directory. mtools prints 8.3 short names in
+    // column form ("readme   txt", no dot) and honors the NT case bits, so the
+    // base and extension must appear lowercased — and specifically not as the
+    // uppercase on-disk form a driver ignoring the case bits would show.
+    let listing = mtools(&img, &["mdir", "::"]);
+    assert!(
+        listing.contains("readme") && listing.contains("txt"),
+        "mtools should list the short name lowercased; got:\n{listing}"
+    );
+    assert!(
+        !listing.contains("README"),
+        "mtools should honor the NT case bits and not uppercase the name; got:\n{listing}"
+    );
+
+    // `mtype ::readme.txt` prints the file's contents.
+    let body = mtools(&img, &["mtype", "::readme.txt"]);
+    assert!(
+        body.contains("hadris"),
+        "mtools should read back the file contents; got:\n{body}"
+    );
+}

--- a/crates/block/hadris-fat/tests/test_write.rs
+++ b/crates/block/hadris-fat/tests/test_write.rs
@@ -1800,6 +1800,130 @@ mod corrupt_image_tests {
         );
     }
 
+    /// A lowercase 8.3 name must round-trip in its original case without
+    /// spending a long-file-name entry: it is stored uppercase on disk with the
+    /// Windows NT `DIR_NTRes` case flags set. Regression for T0.1 — previously
+    /// `readme.txt` either read back as `README.TXT` (case byte ignored) or
+    /// wasted an LFN slot.
+    #[cfg(feature = "lfn")]
+    #[test]
+    fn test_lowercase_short_name_uses_nt_case_flags() {
+        use hadris_fat::raw::NtCaseFlags;
+
+        // The 8.3 display name carries internal space padding ("readme  .txt");
+        // strip it per-component to compare the logical name and its case.
+        fn normalize_8_3(name: &str) -> String {
+            match name.split_once('.') {
+                Some((base, ext)) => {
+                    let base = base.trim_end_matches(' ');
+                    let ext = ext.trim_end_matches(' ');
+                    if ext.is_empty() {
+                        base.to_string()
+                    } else {
+                        format!("{base}.{ext}")
+                    }
+                }
+                None => name.trim_end_matches(' ').to_string(),
+            }
+        }
+
+        let image = create_fat32_image();
+        let fs = FatFs::open(image).expect("open");
+
+        // base + ext both lowercase, base lowercase / ext uppercase, and a
+        // lowercase name with no extension.
+        for (name, expect_flags) in [
+            (
+                "readme.txt",
+                NtCaseFlags::LOWER_BASE | NtCaseFlags::LOWER_EXT,
+            ),
+            ("kernel.C", NtCaseFlags::LOWER_BASE),
+            ("makefile", NtCaseFlags::LOWER_BASE),
+            ("BOOT.BIN", NtCaseFlags::empty()),
+        ] {
+            fs.create_file(&fs.root_dir(), name).expect("create");
+
+            let entry = fs
+                .root_dir()
+                .find(name)
+                .expect("find")
+                .expect("entry present");
+
+            assert!(
+                entry.long_name().is_none(),
+                "{name}: case-only differences must not spend an LFN entry"
+            );
+            assert_eq!(entry.nt_case(), expect_flags, "{name}: NT case flags");
+            assert_eq!(
+                normalize_8_3(&entry.name()),
+                name,
+                "{name}: display name round-trips case"
+            );
+        }
+    }
+
+    /// FAT16 gains `allocate_chain`/`extend_chain` (previously FAT32-only): a
+    /// freshly allocated chain must be linked cluster-to-cluster and terminate,
+    /// and extending it must splice the new run onto the old tail. Regression
+    /// for T1.5 (FAT12/16 chain-allocator parity).
+    #[test]
+    fn test_fat16_allocate_and_extend_chain_links_clusters() {
+        use hadris_fat::Fat16;
+        use std::io::Cursor;
+
+        // A 512-byte FAT16 region (256 entries), all clusters free.
+        let mut rw = Cursor::new(vec![0u8; 512]);
+        let fat = Fat16::new(0, 512, 1, 32);
+
+        let first = fat.allocate_chain(&mut rw, 3, 2).expect("allocate_chain");
+        assert_eq!(first, 2, "first cluster starts at the hint");
+        assert_eq!(fat.next_cluster(&mut rw, 2).unwrap(), Some(3));
+        assert_eq!(fat.next_cluster(&mut rw, 3).unwrap(), Some(4));
+        assert_eq!(
+            fat.next_cluster(&mut rw, 4).unwrap(),
+            None,
+            "chain terminates"
+        );
+
+        // Extend from the current tail (cluster 4) by two more clusters.
+        let new_first = fat.extend_chain(&mut rw, 4, 2, 5).expect("extend_chain");
+        assert_eq!(
+            fat.next_cluster(&mut rw, 4).unwrap(),
+            Some(new_first as u32),
+            "old tail now links to the extension"
+        );
+
+        // Full walk from the head should now visit five clusters.
+        let mut count = 1;
+        let mut cur = first as u32;
+        while let Some(next) = fat.next_cluster(&mut rw, cur as usize).unwrap() {
+            count += 1;
+            cur = next;
+        }
+        assert_eq!(count, 5, "chain length after extend");
+    }
+
+    /// A mixed-case 8.3 name (e.g. `ReadMe.txt`) cannot be represented by the
+    /// per-part case flags and must fall back to a long-file-name entry.
+    #[cfg(feature = "lfn")]
+    #[test]
+    fn test_mixed_case_short_name_falls_back_to_lfn() {
+        let image = create_fat32_image();
+        let fs = FatFs::open(image).expect("open");
+
+        fs.create_file(&fs.root_dir(), "ReadMe.txt")
+            .expect("create");
+        let entry = fs
+            .root_dir()
+            .find("ReadMe.txt")
+            .expect("find")
+            .expect("entry");
+
+        let lfn = entry.long_name().expect("mixed case requires an LFN");
+        assert!(lfn.eq_str("ReadMe.txt"));
+        assert_eq!(&*entry.name(), "ReadMe.txt");
+    }
+
     /// Mounting via `FatFsBuilder::with_fat_cache` should install the cache
     /// without changing observable read/write behaviour. Compares writing
     /// the same file with cache on vs off and asserts both files round-trip

--- a/crates/block/hadris-fat/tests/v2_api.rs
+++ b/crates/block/hadris-fat/tests/v2_api.rs
@@ -8,9 +8,9 @@ fn canonical_v2_names_open_a_formatted_volume() {
         .volume_label("HADRIS")
         .fat_type(FatTypeSelection::Fat12)
         .volume_id(42);
-    let formatted =
-        FatVolumeFormatter::format(std::io::Cursor::new(&mut image[..]), options).unwrap();
-    drop(formatted);
+    // Bind to `_` so the formatter (which mutably borrows `image`) is dropped
+    // at the end of this statement, releasing the borrow before the read below.
+    let _ = FatVolumeFormatter::format(std::io::Cursor::new(&mut image[..]), options).unwrap();
 
     let volume: FatVolume<_> = FatVolumeBuilder::new(std::io::Cursor::new(&image[..]))
         .open()

--- a/crates/block/hadris-part/Cargo.toml
+++ b/crates/block/hadris-part/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-part"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-part/README.md
+++ b/crates/block/hadris-part/README.md
@@ -114,16 +114,16 @@ for (idx, entry) in gpt.partitions() {
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+hadris-part = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Desktop Applications
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.0.0-rc.1", features = ["write"] }  # read is already default
+hadris-part = { version = "2.0.0-rc.2", features = ["write"] }  # read is already default
 # Optional GPT CRC verification:
-# hadris-part = { version = "2.0.0-rc.1", features = ["write", "crc"] }
+# hadris-part = { version = "2.0.0-rc.2", features = ["write", "crc"] }
 ```
 
 ## Partition Types

--- a/crates/block/hadris-part/src/gpt.rs
+++ b/crates/block/hadris-part/src/gpt.rs
@@ -665,6 +665,10 @@ impl GptPartitionName {
 ///
 /// Numeric fields use [`Le`] so their on-disk little-endian layout is explicit.
 /// Use `to_raw` / `from_raw` or the I/O extension traits for serialization.
+///
+/// @hadris-spec UEFI:GPT-Header
+/// @hadris-compliance full
+/// @hadris-tests io_roundtrip::gpt_scheme_sync_write_open_and_detect_roundtrip
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct GptHeader {
@@ -849,6 +853,10 @@ impl GptHeader {
 }
 
 /// GPT partition entry (128 bytes by default).
+///
+/// @hadris-spec UEFI:GPT-Entry
+/// @hadris-compliance full
+/// @hadris-tests roundtrip::gpt_partition_entry_roundtrip
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct GptPartitionEntry {

--- a/crates/block/hadris-part/src/mbr.rs
+++ b/crates/block/hadris-part/src/mbr.rs
@@ -415,6 +415,10 @@ impl IndexMut<usize> for MbrPartitionTable {
 }
 
 /// The complete Master Boot Record structure (512 bytes).
+///
+/// @hadris-spec MBR:layout
+/// @hadris-compliance full
+/// @hadris-tests roundtrip::mbr_write_read_roundtrip
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub struct MasterBootRecord {

--- a/crates/block/hadris-part/tests/io_roundtrip.rs
+++ b/crates/block/hadris-part/tests/io_roundtrip.rs
@@ -1,4 +1,10 @@
 //! I/O roundtrip tests for partition table extension traits.
+//!
+//! These exercise the sync write extension traits and GPT CRC helpers, so the
+//! whole module is gated on the features that provide them. Without them (e.g.
+//! a plain `cargo test -p hadris-part` on default features) it compiles to
+//! nothing rather than failing to build; CI runs it via `--all-features`.
+#![cfg(all(feature = "sync", feature = "write", feature = "crc"))]
 
 use hadris_io::Cursor;
 use hadris_io::ErrorKind;

--- a/crates/core/hadris-common/Cargo.toml
+++ b/crates/core/hadris-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-common"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-common/README.md
+++ b/crates/core/hadris-common/README.md
@@ -55,14 +55,14 @@ assert_eq!(hadris_common::BOOT_SECTOR_BIN[511], 0xAA);
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "bytemuck"] }
+hadris-common = { version = "2.0.0-rc.2", default-features = false, features = ["alloc", "bytemuck"] }
 ```
 
 ### Minimal (No Heap)
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.0.0-rc.1", default-features = false, features = ["bytemuck"] }
+hadris-common = { version = "2.0.0-rc.2", default-features = false, features = ["bytemuck"] }
 ```
 
 ## License

--- a/crates/core/hadris-common/boot_sector/Cargo.toml
+++ b/crates/core/hadris-common/boot_sector/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "boot_sector"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/hadris-fixed/Cargo.toml
+++ b/crates/core/hadris-fixed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fixed"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/Cargo.toml
+++ b/crates/core/hadris-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-io"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/README.md
+++ b/crates/core/hadris-io/README.md
@@ -32,14 +32,14 @@ When the `std` feature is enabled, traits re-export from `std::io`. In `no_std` 
 
 ```toml
 [dependencies]
-hadris-io = "2.0.0-rc.1"
+hadris-io = "2.0.0-rc.2"
 ```
 
 ### No-std
 
 ```toml
 [dependencies]
-hadris-io = { version = "2.0.0-rc.1", default-features = false, features = ["sync"] }
+hadris-io = { version = "2.0.0-rc.2", default-features = false, features = ["sync"] }
 ```
 
 ## Quick Start

--- a/crates/core/hadris-macros/Cargo.toml
+++ b/crates/core/hadris-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-macros"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-path/Cargo.toml
+++ b/crates/core/hadris-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-path"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-storage/Cargo.toml
+++ b/crates/core/hadris-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-storage"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris/Cargo.toml
+++ b/crates/core/hadris/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-cd/Cargo.toml
+++ b/crates/optical/hadris-cd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-iso"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -117,7 +117,7 @@ only under `sync`.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
 ```
 
 The `read` feature exposes `IsoReader`, which opens and navigates ISO 9660 and
@@ -147,14 +147,14 @@ the allocation-free reader exposes raw system-use bytes for custom handling.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-iso = "2.0.0-rc.1"  # Uses default features
+hadris-iso = "2.0.0-rc.2"  # Uses default features
 ```
 
 ## Extension Support

--- a/crates/optical/hadris-iso/spec/Specification.md
+++ b/crates/optical/hadris-iso/spec/Specification.md
@@ -94,12 +94,52 @@ Each ISO-9660 image contains a list of volume descriptors starting at LBA 16.
 The first descriptor must be the primary volume descriptor, which is the only descriptor that is required to be present.
 There can be any number of other volume descriptors, which can be used to store additional information about the filesystem, and ends with an Volume Set Terminator descriptor, padded to the entire sector.
 
-The following table describes the structure of the primary volume descriptor:
+The following table describes the structure of the primary volume descriptor
+(ECMA-119 8.4; `@hadris-spec ECMA-119:8.4`, implemented by `PrimaryVolumeDescriptor`):
+
 | Offset | Size | Type | Description |
 | --- | --- | --- | --- |
-| 0 | 1 | u8 | Descriptor type |
+| 0 | 1 | u8 | Descriptor type (1) |
+| 1 | 5 | u8[5] | Standard identifier ("CD001") |
+| 6 | 1 | u8 | Version (1) |
+| 8 | 32 | strA | System identifier |
+| 40 | 32 | strD | Volume identifier |
+| 80 | 8 | u32lsbmsb | Volume space size (logical blocks) |
+| 120 | 4 | u16lsbmsb | Volume set size |
+| 124 | 4 | u16lsbmsb | Volume sequence number |
+| 128 | 4 | u16lsbmsb | Logical block size (bytes; 2048) |
+| 132 | 8 | u32lsbmsb | Path table size (bytes) |
+| 140 | 4 | u32lsb | Location of Type-L path table |
+| 144 | 4 | u32lsb | Location of optional Type-L path table |
+| 148 | 4 | u32msb | Location of Type-M path table |
+| 152 | 4 | u32msb | Location of optional Type-M path table |
+| 156 | 34 | — | Root directory record (see [Directory Record](#directory-record)) |
+| 190 | 128 | strD | Volume set identifier |
+| 318 | 128 | strA | Publisher identifier |
+| 446 | 128 | strA | Data preparer identifier |
+| 574 | 128 | strA | Application identifier |
+| 702 | 37 | strD | Copyright file identifier |
+| 739 | 37 | strD | Abstract file identifier |
+| 776 | 37 | strD | Bibliographic file identifier |
+| 813 | 17 | dec-datetime | Volume creation date/time |
+| 830 | 17 | dec-datetime | Volume modification date/time |
+| 847 | 17 | dec-datetime | Volume expiration date/time |
+| 864 | 17 | dec-datetime | Volume effective date/time |
+| 881 | 1 | u8 | File structure version (1) |
+| 883 | 512 | — | Application use |
 
-(WIP)
+The **Supplementary Volume Descriptor** (ECMA-119 8.5; `@hadris-spec ECMA-119:8.5`,
+`SupplementaryVolumeDescriptor`) shares this layout; Hadris uses it for the Joliet
+namespace, distinguished by an escape sequence in the "Escape Sequences" field
+(offset 88) selecting UCS-2 Level 1/2/3.
+
+The **Boot Record Volume Descriptor** (ECMA-119 8.2; `@hadris-spec ECMA-119:8.2`,
+`BootRecordVolumeDescriptor`) carries the boot system identifier
+`"EL TORITO SPECIFICATION"` and a pointer to the El Torito boot catalog.
+
+The **Volume Descriptor Set Terminator** (ECMA-119 8.3; `@hadris-spec ECMA-119:8.3`,
+`VolumeDescriptorSetTerminator`) is a header-only descriptor (type `0xFF`) padded to
+2048 bytes that ends the descriptor sequence.
 
 #### Volume Descriptor Type
 
@@ -117,6 +157,72 @@ The volume descriptor type is an enum, which can be one of the following values:
 
 The standard identifier is a 5-byte ASCII string, which is used to identify the standard that the volume descriptor follows.
 It is the string "CD001".
+
+### Path Table
+
+The path table (ECMA-119 9.4; `@hadris-spec ECMA-119:9.4`, implemented by
+`PathTableEntryHeader` / `PathTableEntry`) is a flat, breadth-first index of every
+directory in the image, allowing a reader to locate a directory without walking the
+tree. Each record is:
+
+| Offset | Size | Type | Description |
+| --- | --- | --- | --- |
+| 0 | 1 | u8 | Length of directory identifier (LEN_DI) |
+| 1 | 1 | u8 | Extended attribute record length |
+| 2 | 4 | u32 | Location of extent (logical block) |
+| 6 | 2 | u16 | Directory number of parent |
+| 8 | LEN_DI | strD | Directory identifier |
+| 8+LEN_DI | 0/1 | u8 | Padding to an even boundary |
+
+Two copies are written: the **Type-L** table stores the extent location little-endian,
+the **Type-M** table big-endian. Hadris writes both; the optional secondary path-table
+pointers in the PVD are left zero.
+
+### Directory Record
+
+A directory record (ECMA-119 9.1; `@hadris-spec ECMA-119:9.1`, implemented by
+`DirectoryRecordHeader` / `DirectoryRecord`) describes one file or directory:
+
+| Offset | Size | Type | Description |
+| --- | --- | --- | --- |
+| 0 | 1 | u8 | Length of directory record (LEN_DR) |
+| 1 | 1 | u8 | Extended attribute record length |
+| 2 | 8 | u32lsbmsb | Location of extent (logical block) |
+| 10 | 8 | u32lsbmsb | Data length (bytes) |
+| 18 | 7 | datetime | Recording date and time |
+| 25 | 1 | u8 | File flags (see below) |
+| 26 | 1 | u8 | File unit size (interleaved mode) |
+| 27 | 1 | u8 | Interleave gap size |
+| 28 | 4 | u16lsbmsb | Volume sequence number |
+| 32 | 1 | u8 | Length of file identifier (LEN_FI) |
+| 33 | LEN_FI | strD | File identifier |
+| 33+LEN_FI | 0/1 | u8 | Padding to an even boundary |
+| … | … | — | System use area (SUSP / Rock Ridge) |
+
+File flags (offset 25): bit 0 Hidden, bit 1 Directory, bit 2 Associated file,
+bit 3 Record format in EAR, bit 4 Permissions in EAR, bit 7 Not-final (multi-extent).
+The special identifiers `0x00` ("." — self) and `0x01` (".." — parent) are the first
+two records of every directory. Hadris writes records in ascending File Identifier
+order (ECMA-119 9.3).
+
+## Extensions
+
+Hadris implements the following on top of base ISO 9660. Each is indexed by its
+`@hadris-spec` id in [`docs/spec-coverage.md`](../../../docs/spec-coverage.md).
+
+- **Joliet** — a Supplementary Volume Descriptor whose names are UCS-2 (BMP only),
+  giving long, case-preserving, Unicode filenames. `@hadris-spec ECMA-119:8.5`.
+- **Rock Ridge / SUSP (RRIP)** — System-use entries in each directory record carrying
+  POSIX metadata: `PX` (mode/uid/gid/inode), `NM` (long name), `SL` (symlink),
+  `TF` (timestamps, incl. creation), `CL`/`PL`/`RE` (deep-directory relocation),
+  `SP`/`CE`/`ER`/`ST` (SUSP framing).
+- **El Torito** — a boot catalog referenced by the Boot Record Volume Descriptor:
+  a validation entry, a default/initial entry, and optional platform section
+  headers/entries. Media emulation types: none, 1.2/1.44/2.88 MB floppy, hard disk.
+  `@hadris-spec El-Torito:validation`, `El-Torito:section-header`,
+  `El-Torito:section-entry`.
+- **Hybrid MBR/GPT** — a partition table embedded so the image also boots as a USB
+  disk (via `hadris-part`).
 
 ## References
 

--- a/crates/optical/hadris-iso/src/boot.rs
+++ b/crates/optical/hadris-iso/src/boot.rs
@@ -347,9 +347,15 @@ impl BootValidationEntry {
     }
 }
 
+/// El Torito section header entry (0x90/0x91) introducing a platform's boot
+/// entries.
+///
+/// @hadris-spec El-Torito:section-header
+/// @hadris-compliance full
+/// @hadris-tests xorriso_boot::test_hadris_multisection_boot_catalog
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy)]
-/// Represents BootSectionHeaderEntry.
 pub struct BootSectionHeaderEntry {
     /// 0x90 = Header, more headers follow
     /// 0x91 = Final header
@@ -379,12 +385,21 @@ impl Debug for BootSectionHeaderEntry {
 unsafe impl bytemuck::Zeroable for BootSectionHeaderEntry {}
 unsafe impl bytemuck::Pod for BootSectionHeaderEntry {}
 
-#[derive(Debug, Clone, Copy)]
-/// Identifies a EmulationType value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// El Torito boot-media emulation type (the low nibble of the boot media type
+/// byte, ECMA "El Torito" §2.x).
 pub enum EmulationType {
-    /// 0x00 = No emulation
+    /// 0x00 = No emulation. The firmware loads `sector_count` 512-byte sectors.
     NoEmulation,
-    /// The `Unknown` variant.
+    /// 0x01 = 1.2 MB diskette emulation.
+    Floppy1_2,
+    /// 0x02 = 1.44 MB diskette emulation.
+    Floppy1_44,
+    /// 0x03 = 2.88 MB diskette emulation.
+    Floppy2_88,
+    /// 0x04 = Hard-disk emulation (drive 0x80).
+    HardDisk,
+    /// Any other (or flag-decorated) media type byte, preserved verbatim.
     Unknown(u8),
 }
 
@@ -393,6 +408,10 @@ impl EmulationType {
     pub fn from_u8(value: u8) -> Self {
         match value {
             0x00 => Self::NoEmulation,
+            0x01 => Self::Floppy1_2,
+            0x02 => Self::Floppy1_44,
+            0x03 => Self::Floppy2_88,
+            0x04 => Self::HardDisk,
             value => Self::Unknown(value),
         }
     }
@@ -401,14 +420,36 @@ impl EmulationType {
     pub fn to_u8(self) -> u8 {
         match self {
             Self::NoEmulation => 0x00,
+            Self::Floppy1_2 => 0x01,
+            Self::Floppy1_44 => 0x02,
+            Self::Floppy2_88 => 0x03,
+            Self::HardDisk => 0x04,
             Self::Unknown(value) => value,
         }
     }
+
+    /// Returns `true` for any emulated media (floppy or hard disk), i.e. not
+    /// [`NoEmulation`](Self::NoEmulation). Emulated entries load a single
+    /// virtual boot sector; the firmware then services the emulated medium.
+    ///
+    /// Only the media-type nibble (low 4 bits) is examined, matching the El
+    /// Torito layout where the upper bits are flags (continuation, contains
+    /// ATAPI driver). A flag-decorated byte whose low nibble is `0x0` — a
+    /// no-emulation entry — is therefore correctly reported as not emulated.
+    pub fn is_emulated(self) -> bool {
+        (self.to_u8() & 0x0F) != 0
+    }
 }
 
+/// El Torito section/initial entry: the bootable image reference and its
+/// emulation media type.
+///
+/// @hadris-spec El-Torito:section-entry
+/// @hadris-compliance full
+/// @hadris-tests xorriso_boot::test_floppy_emulation_media_type_and_default_load_size
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy)]
-/// Represents BootSectionEntry.
 pub struct BootSectionEntry {
     /// 0x88 = Bootable, 0x00 = Not bootable
     pub boot_indicator: u8,
@@ -910,15 +951,22 @@ mod tests {
 
     #[test]
     fn test_emulation_type_roundtrip() {
-        let no_emul = EmulationType::NoEmulation;
-        assert_eq!(no_emul.to_u8(), 0x00);
-        assert!(matches!(
-            EmulationType::from_u8(0x00),
-            EmulationType::NoEmulation
-        ));
-
-        let unknown = EmulationType::Unknown(0x42);
-        assert_eq!(unknown.to_u8(), 0x42);
+        for (byte, ty, emulated) in [
+            (0x00u8, EmulationType::NoEmulation, false),
+            (0x01, EmulationType::Floppy1_2, true),
+            (0x02, EmulationType::Floppy1_44, true),
+            (0x03, EmulationType::Floppy2_88, true),
+            (0x04, EmulationType::HardDisk, true),
+            // Flag-decorated byte with a non-zero media nibble (0x2 = 1.44 MB).
+            (0x42, EmulationType::Unknown(0x42), true),
+            // Continuation flag set on a no-emulation entry: the low nibble is
+            // 0x0, so this must NOT be treated as emulated.
+            (0x20, EmulationType::Unknown(0x20), false),
+        ] {
+            assert_eq!(ty.to_u8(), byte, "{ty:?} to_u8");
+            assert_eq!(EmulationType::from_u8(byte), ty, "from_u8({byte:#x})");
+            assert_eq!(ty.is_emulated(), emulated, "{ty:?} is_emulated");
+        }
     }
 }
 }

--- a/crates/optical/hadris-iso/src/file.rs
+++ b/crates/optical/hadris-iso/src/file.rs
@@ -305,18 +305,69 @@ pub fn convert_l3(name: &str, supports_lowercase: bool) -> FilenameL3 {
     l3
 }
 
+/// Maximum number of characters in a Joliet file identifier.
+///
+/// The Joliet specification limits a file identifier to 64 UCS-2 characters.
+/// (A 255-byte directory record could physically hold up to 103, but 64 is the
+/// conformant limit produced by default by reference tools.)
 #[cfg(feature = "write")]
-/// Performs the `convert_joliet3` operation.
+pub const JOLIET_MAX_NAME_CHARS: usize = 64;
+
+#[cfg(feature = "write")]
+/// Encode `name` as a big-endian UCS-2 Joliet file identifier.
+///
+/// Joliet identifiers are UCS-2 (Basic Multilingual Plane only), not UTF-16:
+/// a character outside the BMP cannot be represented as a single UCS-2 code
+/// unit, so it is substituted with `_` rather than emitting a surrogate pair
+/// into the field. The identifier is limited to [`JOLIET_MAX_NAME_CHARS`]
+/// characters; longer names are truncated.
 pub fn convert_joliet3(name: &str) -> FixedBytes<207> {
     let mut j1 = FixedBytes::empty();
-    for (written, c) in name.encode_utf16().enumerate() {
-        if written >= 206 / 2 {
-            // We reached the maximum we can write
-            break;
-        }
-        let bytes = c.to_be_bytes();
-        j1.push_slice(&bytes);
+    for c in name.chars().take(JOLIET_MAX_NAME_CHARS) {
+        let unit = if (c as u32) <= 0xFFFF {
+            c as u16
+        } else {
+            b'_' as u16
+        };
+        j1.push_slice(&unit.to_be_bytes());
     }
 
     j1
+}
+
+#[cfg(all(test, feature = "write", feature = "alloc"))]
+mod joliet_tests {
+    use super::*;
+    use crate::joliet::decode_joliet_name;
+
+    #[test]
+    fn joliet_name_is_truncated_to_the_conformant_limit() {
+        let long = "a".repeat(200);
+        let encoded = convert_joliet3(&long);
+        // Two bytes per UCS-2 unit, capped at 64 characters.
+        assert_eq!(encoded.as_bytes().len(), JOLIET_MAX_NAME_CHARS * 2);
+        assert_eq!(decode_joliet_name(encoded.as_bytes()).chars().count(), 64);
+    }
+
+    #[test]
+    fn joliet_substitutes_non_bmp_instead_of_emitting_surrogates() {
+        // U+1F600 GRINNING FACE is outside the BMP and cannot be UCS-2 encoded.
+        let encoded = convert_joliet3("a\u{1F600}b.txt");
+        let decoded = decode_joliet_name(encoded.as_bytes());
+        assert_eq!(decoded, "a_b.txt");
+        // No byte pair may fall in the UTF-16 surrogate range 0xD800..=0xDFFF.
+        for pair in encoded.as_bytes().chunks_exact(2) {
+            let unit = u16::from_be_bytes([pair[0], pair[1]]);
+            assert!(
+                !(0xD800..=0xDFFF).contains(&unit),
+                "surrogate leaked into UCS-2"
+            );
+        }
+    }
+
+    #[test]
+    fn joliet_preserves_bmp_unicode() {
+        let encoded = convert_joliet3("日本語.txt");
+        assert_eq!(decode_joliet_name(encoded.as_bytes()), "日本語.txt");
+    }
 }

--- a/crates/optical/hadris-iso/src/joliet.rs
+++ b/crates/optical/hadris-iso/src/joliet.rs
@@ -90,12 +90,21 @@ fn strip_version_suffix(bytes: &[u8]) -> &[u8] {
     bytes
 }
 
-/// Encode a string as a Joliet filename (UTF-16 Big Endian)
+/// Encode a string as a Joliet filename (big-endian UCS-2).
+///
+/// Joliet uses UCS-2, which covers only the Basic Multilingual Plane. A
+/// character outside the BMP cannot be represented as a single UCS-2 code unit,
+/// so it is substituted with `_` rather than emitting a UTF-16 surrogate pair.
 #[cfg(feature = "alloc")]
 pub fn encode_joliet_name(name: &str) -> alloc::vec::Vec<u8> {
-    let mut result = alloc::vec::Vec::with_capacity(name.len() * 2);
-    for c in name.encode_utf16() {
-        result.extend_from_slice(&c.to_be_bytes());
+    let mut result = alloc::vec::Vec::with_capacity(name.chars().count() * 2);
+    for c in name.chars() {
+        let unit = if (c as u32) <= 0xFFFF {
+            c as u16
+        } else {
+            b'_' as u16
+        };
+        result.extend_from_slice(&unit.to_be_bytes());
     }
     result
 }

--- a/crates/optical/hadris-iso/src/lib.rs
+++ b/crates/optical/hadris-iso/src/lib.rs
@@ -267,6 +267,16 @@
 //!   writer does not synthesize a filesystem inside them.
 //! - **High-level `IsoImage`:** Requires the `alloc` feature. `read` alone
 //!   exposes low-level modules suitable for no-alloc bootloaders.
+//! - **Not supported (writer rejects or does not emit):** files larger than
+//!   4 GiB / multi-extent write; Extended Attribute Record contents; the Volume
+//!   Partition Descriptor body; interleaved files; associated-file write; the
+//!   optional secondary path tables; RRIP `SF` (sparse) and `RR` (legacy
+//!   presence) entries; zisofs compression; and the Apple Partition Map.
+//! - **Non-2048 logical block size:** `IsoImage` requires a 2048-byte logical
+//!   block and rejects other sizes; the allocation-free `IsoReader` honors the
+//!   declared block size.
+//! - **Hybrid GPT backup:** the embedded GPT writes the primary header/entries
+//!   only; a spec-valid backup GPT at end-of-disk is not written.
 
 #![no_std]
 #![deny(missing_docs)]

--- a/crates/optical/hadris-iso/src/path.rs
+++ b/crates/optical/hadris-iso/src/path.rs
@@ -14,9 +14,14 @@ use super::io::{Seek, SeekFrom};
 use super::read::IsoImage;
 }
 
+/// Path Table record header (ECMA-119 9.4).
+///
+/// @hadris-spec ECMA-119:9.4
+/// @hadris-compliance partial
+/// @hadris-note Both L- and M-type path tables are written and read; the optional secondary path tables are not populated.
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-/// Represents PathTableEntryHeader.
 pub struct PathTableEntryHeader {
     /// The `len` field.
     pub len: u8,

--- a/crates/optical/hadris-iso/src/read/basic.rs
+++ b/crates/optical/hadris-iso/src/read/basic.rs
@@ -181,6 +181,52 @@ fn joliet_matches(raw: &[u8], candidate: &str) -> bool {
     expected.next().is_none()
 }
 
+/// Copies the Rock Ridge alternate name (SUSP `NM` entries) out of an inline
+/// system-use area into `out`, concatenating a `CONTINUE`-flagged run. Returns
+/// the number of bytes written, or `None` when there is no usable `NM` entry.
+///
+/// Only the inline system-use area is parsed; a name continued into a SUSP `CE`
+/// continuation area is not followed, which keeps this allocation- and I/O-free.
+/// The `CURRENT`/`PARENT` NM aliases (the "." and ".." names) yield `None`.
+fn rrip_nm_into(su: &[u8], out: &mut [u8]) -> Option<usize> {
+    const NM_CONTINUE: u8 = 0x01;
+    const NM_CURRENT: u8 = 0x02;
+    const NM_PARENT: u8 = 0x04;
+
+    let mut written = 0usize;
+    let mut found = false;
+    let mut i = 0usize;
+    // Each SUSP entry is [SIG0, SIG1, LEN, VER, ...]; LEN covers the whole entry.
+    while i + 4 <= su.len() {
+        let len = su[i + 2] as usize;
+        if len < 4 || i + len > su.len() {
+            break;
+        }
+        if &su[i..i + 2] == b"ST" {
+            break; // SUSP terminator
+        }
+        if &su[i..i + 2] == b"NM" && len >= 5 {
+            let flags = su[i + 4];
+            if flags & (NM_CURRENT | NM_PARENT) != 0 {
+                return None;
+            }
+            let content = &su[i + 5..i + len];
+            if written + content.len() > out.len() {
+                return None; // caller buffer too small for the full name
+            }
+            out[written..written + content.len()].copy_from_slice(content);
+            written += content.len();
+            found = true;
+            if flags & NM_CONTINUE == 0 {
+                break;
+            }
+        }
+        i += len;
+    }
+
+    found.then_some(written)
+}
+
 fn decode_joliet_into<'a>(raw: &[u8], output: &'a mut [u8]) -> Result<&'a str, NameError> {
     if raw.len() % 2 != 0 {
         return Err(NameError::InvalidEncoding);
@@ -266,6 +312,31 @@ impl IsoDirEntry {
     /// Returns the raw system-use area.
     pub fn system_use(&self) -> &[u8] {
         self.record.system_use()
+    }
+
+    /// Resolves the Rock Ridge alternate name (SUSP `NM`) into `output`, without
+    /// allocating.
+    ///
+    /// Returns `None` when the entry carries no usable `NM` field — a plain
+    /// ISO 9660/Joliet image, or a "."/".." alias — in which case
+    /// [`Self::name`] is the name to use. Otherwise the RRIP name is validated
+    /// as UTF-8 and written into `output`. Only the inline system-use area is
+    /// parsed; a name continued into a SUSP `CE` area is not followed.
+    pub fn rrip_name_into<'b>(&self, output: &'b mut [u8]) -> Option<Result<&'b str, NameError>> {
+        let len = rrip_nm_into(self.system_use(), output)?;
+        Some(core::str::from_utf8(&output[..len]).map_err(|_| NameError::InvalidEncoding))
+    }
+
+    /// Returns `true` if this entry's Rock Ridge name equals `candidate`.
+    ///
+    /// Returns `false` when the entry has no `NM` field or the name does not
+    /// fit POSIX `NAME_MAX` (255 bytes). Allocation-free.
+    pub fn rrip_name_matches(&self, candidate: &str) -> bool {
+        let mut buffer = [0u8; 255];
+        match rrip_nm_into(self.system_use(), &mut buffer) {
+            Some(len) => &buffer[..len] == candidate.as_bytes(),
+            None => false,
+        }
     }
 }
 

--- a/crates/optical/hadris-iso/src/read/mod.rs
+++ b/crates/optical/hadris-iso/src/read/mod.rs
@@ -153,14 +153,6 @@ impl RootDir {
     }
 }
 
-bitflags::bitflags! {
-    /// Extension features supported by an ISO image reader.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct SupportedFeatures: u64 {
-
-    }
-}
-
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Identifies a PathSeparator value.
@@ -205,6 +197,16 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
         let volume_descriptors = VolumeDescriptorList::parse(&mut data).await?;
         let pvd = volume_descriptors.primary();
         let block_size = pvd.logical_block_size.read() as usize;
+        // IsoImage's extent→byte math assumes a 2048-byte logical block. Rather
+        // than silently misread an image that declares a different block size,
+        // reject it. (The allocation-free `IsoReader` honors the PVD block size;
+        // full non-2048 support in `IsoImage` is future work.)
+        if block_size != 2048 {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "ISO logical block size other than 2048 is not supported by IsoImage",
+            ));
+        }
         let root_extent = LogicalSector(pvd.dir_record.header.extent.read() as usize);
         let root_size = pvd.dir_record.header.data_len.read() as usize;
         let root_dir = DirectoryRef {

--- a/crates/optical/hadris-iso/src/rrip.rs
+++ b/crates/optical/hadris-iso/src/rrip.rs
@@ -886,15 +886,41 @@ impl RripBuilder {
         self
     }
 
-    /// Add a TF entry for timestamps
+    /// Add a short-form TF entry carrying modify and access timestamps.
     pub fn add_tf_short(&mut self, mtime: &[u8; 7], atime: &[u8; 7]) -> &mut Self {
-        let mut buf = alloc::vec![0u8; 19]; // 5 + 7 + 7
+        self.add_tf(None, mtime, atime)
+    }
+
+    /// Add a short-form (7-byte) TF timestamp entry.
+    ///
+    /// Emits the creation timestamp when provided (RRIP `CREATION` flag, 0x01),
+    /// followed by modify (0x02) and access (0x04). Timestamps are written in
+    /// ascending flag-bit order, as required by RRIP.
+    pub fn add_tf(
+        &mut self,
+        creation: Option<&[u8; 7]>,
+        mtime: &[u8; 7],
+        atime: &[u8; 7],
+    ) -> &mut Self {
+        // CREATION | MODIFY | ACCESS, short form (no LONG_FORM bit).
+        let mut flags = 0x06u8; // MODIFY | ACCESS
+        let mut len = 5 + 7 + 7;
+        if creation.is_some() {
+            flags |= 0x01; // CREATION
+            len += 7;
+        }
+        let mut buf = alloc::vec![0u8; len];
         buf[0..2].copy_from_slice(b"TF");
-        buf[2] = 19;
+        buf[2] = len as u8;
         buf[3] = 1;
-        buf[4] = 0x06; // MODIFY | ACCESS flags
-        buf[5..12].copy_from_slice(mtime);
-        buf[12..19].copy_from_slice(atime);
+        buf[4] = flags;
+        let mut off = 5;
+        if let Some(ctime) = creation {
+            buf[off..off + 7].copy_from_slice(ctime);
+            off += 7;
+        }
+        buf[off..off + 7].copy_from_slice(mtime);
+        buf[off + 7..off + 14].copy_from_slice(atime);
         self.builder.add_raw(buf);
         self
     }

--- a/crates/optical/hadris-iso/src/volume.rs
+++ b/crates/optical/hadris-iso/src/volume.rs
@@ -520,9 +520,15 @@ impl PrimaryVolumeDescriptor {
 unsafe impl bytemuck::Zeroable for PrimaryVolumeDescriptor {}
 unsafe impl bytemuck::Pod for PrimaryVolumeDescriptor {}
 
+/// Boot Record Volume Descriptor (ECMA-119 8.2), locating the El Torito boot
+/// catalog.
+///
+/// @hadris-spec ECMA-119:8.2
+/// @hadris-compliance full
+/// @hadris-tests xorriso_boot::test_hadris_multisection_boot_catalog
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy)]
-/// Represents BootRecordVolumeDescriptor.
 pub struct BootRecordVolumeDescriptor {
     /// The `header` field.
     pub header: VolumeDescriptorHeader,
@@ -564,9 +570,15 @@ impl Debug for BootRecordVolumeDescriptor {
 unsafe impl bytemuck::Zeroable for BootRecordVolumeDescriptor {}
 unsafe impl bytemuck::Pod for BootRecordVolumeDescriptor {}
 
+/// Supplementary / Enhanced Volume Descriptor (ECMA-119 8.5), used here for the
+/// Joliet namespace.
+///
+/// @hadris-spec ECMA-119:8.5
+/// @hadris-compliance partial
+/// @hadris-note Joliet SVD is read/written (UCS-2, BMP only); the version-2 "enhanced" form is repurposed as a UDF-bridge signal rather than a conformant ISO 9660:1999 secondary descriptor.
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy)]
-/// Represents SupplementaryVolumeDescriptor.
 pub struct SupplementaryVolumeDescriptor {
     /// The `header` field.
     pub header: VolumeDescriptorHeader,
@@ -791,9 +803,14 @@ impl Debug for SupplementaryVolumeDescriptor {
     }
 }
 
+/// Volume Descriptor Set Terminator (ECMA-119 8.3).
+///
+/// @hadris-spec ECMA-119:8.3
+/// @hadris-compliance full
+/// @hadris-tests comprehensive_iso::test_pvd_standard_identifier
+/// @hadris-fuzz iso_read
 #[repr(C)]
 #[derive(Clone, Copy)]
-/// Represents VolumeDescriptorSetTerminator.
 pub struct VolumeDescriptorSetTerminator {
     header: VolumeDescriptorHeader,
     padding: [u8; 2041],

--- a/crates/optical/hadris-iso/src/write/mod.rs
+++ b/crates/optical/hadris-iso/src/write/mod.rs
@@ -460,13 +460,27 @@ fn validate_input_tree(tree: &InputTree, rrip: Option<&RripOptions>) -> io::Resu
                         ));
                     }
                 }
-                InputEntryKind::File(_) => {}
+                InputEntryKind::File(contents) => {
+                    if contents.len() as u64 > MAX_SINGLE_EXTENT_FILE_LEN {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "file exceeds 4 GiB; the ISO writer stores each file in a single \
+                             extent and cannot yet emit multi-extent records",
+                        ));
+                    }
+                }
             }
         }
         Ok(())
     }
     visit(&tree.entries, rrip, 1, 0)
 }
+
+/// Largest file size a single ISO 9660 (ECMA-119 9.1) directory record can
+/// address through its 32-bit `data_len` field. Larger files require
+/// multi-extent records, which the writer does not yet emit — attempting to
+/// write one is rejected up front rather than silently truncated to `u32`.
+pub(crate) const MAX_SINGLE_EXTENT_FILE_LEN: u64 = u32::MAX as u64;
 
 fn relocate_deep_directories(files: &mut WrittenFiles) {
     fn visit(
@@ -645,7 +659,12 @@ fn build_rrip_entries(
         if options.preserve_timestamps {
             let modified = rrip_datetime(metadata.modified, fallback_time);
             let accessed = rrip_datetime(metadata.accessed, fallback_time);
-            builder.add_tf_short(&modified, &accessed);
+            // Emit the creation timestamp when the input carries one; in-memory
+            // entries without a creation time keep the modify/access-only form.
+            let created = metadata
+                .created
+                .map(|created| rrip_datetime(Some(created), fallback_time));
+            builder.add_tf(created.as_ref(), &modified, &accessed);
         }
     };
 
@@ -996,10 +1015,18 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                             "boot image file not found",
                         )
                     })?;
-                let load_size = entry
-                    .load_size
-                    .map(core::num::NonZeroU16::get)
-                    .unwrap_or_else(|| dir_ref.size.div_ceil(512) as u16);
+                let load_size = entry.load_size.map(core::num::NonZeroU16::get).unwrap_or_else(
+                    || {
+                        // Emulated media load a single virtual boot sector; the
+                        // firmware then services the emulated disk. No-emulation
+                        // entries load the whole image as 512-byte sectors.
+                        if entry.emulation.is_emulated() {
+                            1
+                        } else {
+                            dir_ref.size.div_ceil(512) as u16
+                        }
+                    },
+                );
                 let boot_image_lba = dir_ref.extent.0 as u32;
                 let boot_entry =
                     BootSectionEntry::new(entry.emulation, 0, load_size, boot_image_lba);
@@ -2075,6 +2102,16 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             }
         }
 
+        // ── Phase 1.75: Order records by File Identifier (ECMA-119 9.3) ──
+        // Directory records must be written in ascending File Identifier order.
+        // "." and ".." (identifiers 0x00 / 0x01) sort first; the remaining
+        // entries follow in identifier order. A byte-wise comparison reproduces
+        // the standard's space-padded ordering because the pad byte (0x20) sorts
+        // below every character valid in an ISO 9660 identifier, so a shorter
+        // identifier that is a prefix of a longer one still sorts first. Sorting
+        // after dedup keeps the assigned suffixes intact.
+        records.sort_by(|a, b| a.name.cmp(&b.name));
+
         // ── Phase 2: Write continuation area if any records have overflow ──
 
         let has_overflow = records.iter().any(|r| r.split.has_overflow());
@@ -2180,6 +2217,22 @@ impl<'a> Iterator for FileTreeWalker<'a> {
 mod tests {
     use super::*; // Import items from the outer module
     use alloc::vec;
+
+    /// The single-extent ceiling is exactly the 32-bit `data_len` range, and
+    /// ordinary files validate. The >4 GiB rejection path itself cannot be
+    /// exercised in a unit test without allocating a >4 GiB buffer (files are
+    /// held in memory as `Vec<u8>`); it is guarded by inspection and the
+    /// constant below.
+    #[test]
+    fn single_extent_ceiling_and_normal_files_validate() {
+        assert_eq!(MAX_SINGLE_EXTENT_FILE_LEN, u32::MAX as u64);
+
+        let tree = InputTree::new(
+            PathSeparator::ForwardSlash,
+            vec![InputEntry::file("hello.txt", vec![0u8; 4096])],
+        );
+        assert!(validate_input_tree(&tree, None).is_ok());
+    }
 
     #[test]
     fn test_depth_first_tree_walk_iterator() {

--- a/crates/optical/hadris-iso/src/write/writer.rs
+++ b/crates/optical/hadris-iso/src/write/writer.rs
@@ -444,16 +444,11 @@ mod tests {
 
     #[test]
     fn test_convert_joliet3_long_name_truncation() {
-        // 207 bytes / 2 = 103 UTF-16 code units max
+        // Joliet identifiers are capped at the conformant 64-character limit.
         let long_name = "a".repeat(150);
         let converted = convert_joliet3(&long_name);
-        // 103 code units * 2 bytes = 206 bytes
-        assert!(
-            converted.len() <= 207,
-            "Joliet overflow: {}",
-            converted.len()
-        );
-        assert_eq!(converted.len(), 206);
+        // 64 UCS-2 code units * 2 bytes = 128 bytes.
+        assert_eq!(converted.len(), 128);
     }
 
     #[test]

--- a/crates/optical/hadris-iso/tests/comprehensive_iso.rs
+++ b/crates/optical/hadris-iso/tests/comprehensive_iso.rs
@@ -254,6 +254,24 @@ mod volume_descriptor_tests {
     }
 
     #[test]
+    fn test_non_2048_block_size_is_rejected() {
+        // An image declaring a logical block size other than 2048 would be
+        // silently misread by IsoImage (extents are in logical-block units);
+        // opening it must fail cleanly instead. Regression for T0.5.
+        let mut iso = create_minimal_iso("TEST");
+        let pvd_offset = 16 * 2048;
+        // Logical block size field (both-endian) at PVD offset 128.
+        iso[pvd_offset + 128..pvd_offset + 130].copy_from_slice(&512u16.to_le_bytes());
+        iso[pvd_offset + 130..pvd_offset + 132].copy_from_slice(&512u16.to_be_bytes());
+
+        let result = IsoImage::open(Cursor::new(iso));
+        assert!(
+            result.is_err(),
+            "IsoImage must reject a non-2048 logical block size"
+        );
+    }
+
+    #[test]
     fn test_volume_id_extraction() {
         let iso = create_minimal_iso("MY_VOLUME");
         let cursor = Cursor::new(iso);

--- a/crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs
+++ b/crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs
@@ -200,6 +200,54 @@ fn test_name_deduplication_produces_unique_names() {
 }
 
 #[test]
+fn test_directory_records_written_in_collation_order() {
+    // Supply files and directories in deliberately unsorted input order; the
+    // writer must emit them in ascending File Identifier order (ECMA-119 9.3).
+    let files = vec![
+        IsoFile::File {
+            name: Arc::new("zebra.txt".to_string()),
+            contents: b"z".to_vec(),
+        },
+        IsoFile::Directory {
+            name: Arc::new("mango".to_string()),
+            children: vec![IsoFile::File {
+                name: Arc::new("inner.txt".to_string()),
+                contents: b"i".to_vec(),
+            }],
+        },
+        IsoFile::File {
+            name: Arc::new("alpha.txt".to_string()),
+            contents: b"a".to_vec(),
+        },
+        IsoFile::File {
+            name: Arc::new("apple.txt".to_string()),
+            contents: b"p".to_vec(),
+        },
+    ];
+
+    let image = write_and_open(files, default_options());
+    let root = image.root_dir();
+    let names = entry_names(&image, root.dir_ref());
+
+    // Uppercased ISO identifiers, sorted: ALPHA.TXT, APPLE.TXT, MANGO, ZEBRA.TXT.
+    let mut expected = names.clone();
+    expected.sort();
+    assert_eq!(
+        names, expected,
+        "directory records must be in ascending identifier order, got {names:?}"
+    );
+    assert_eq!(
+        names,
+        vec![
+            "ALPHA.TXT".to_string(),
+            "APPLE.TXT".to_string(),
+            "MANGO".to_string(),
+            "ZEBRA.TXT".to_string(),
+        ],
+    );
+}
+
+#[test]
 fn test_dedup_with_no_extension() {
     let files = vec![
         IsoFile::File {

--- a/crates/optical/hadris-iso/tests/rrip_reader.rs
+++ b/crates/optical/hadris-iso/tests/rrip_reader.rs
@@ -55,6 +55,40 @@ fn test_rrip_detection_with_rock_ridge() {
 }
 
 #[test]
+fn no_alloc_reader_resolves_rrip_names() {
+    use hadris_iso::read::IsoReader;
+
+    // A name that cannot survive the primary ISO namespace unchanged (spaces,
+    // lowercase, long) but is preserved verbatim in the Rock Ridge NM field.
+    let original = "My Long Rock Ridge Name.txt";
+    let files = vec![IsoFile::File {
+        name: Arc::new(original.to_string()),
+        contents: b"payload".to_vec(),
+    }];
+    let iso_data = create_iso(files, CreationFeatures::rock_ridge());
+
+    let mut reader = IsoReader::open(Cursor::new(iso_data)).unwrap();
+    let root = reader.primary_root();
+    let mut dir = reader.open_dir(root);
+
+    let mut found = false;
+    while let Some(entry) = dir.next_entry().unwrap() {
+        if entry.is_directory() {
+            continue;
+        }
+        let mut buffer = [0u8; 255];
+        if let Some(Ok(name)) = entry.rrip_name_into(&mut buffer) {
+            assert_eq!(name, original, "RRIP NM name must round-trip verbatim");
+            assert!(entry.rrip_name_matches(original));
+            assert!(!entry.rrip_name_matches("something else"));
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "the file's Rock Ridge name should be resolvable");
+}
+
+#[test]
 fn test_rrip_detection_without_rock_ridge() {
     let files = vec![IsoFile::File {
         name: Arc::new("hello.txt".to_string()),

--- a/crates/optical/hadris-iso/tests/rrip_writer_metadata.rs
+++ b/crates/optical/hadris-iso/tests/rrip_writer_metadata.rs
@@ -100,6 +100,42 @@ fn writes_posix_metadata_and_special_entries() {
 }
 
 #[test]
+fn writes_and_reads_back_creation_timestamp() {
+    // 2001-09-09 01:46:40 UTC — distinct from modify/access so we can tell them
+    // apart on read-back.
+    let metadata = InputMetadata {
+        created: Some(1_000_000_000),
+        modified: Some(946_684_800),
+        accessed: Some(946_684_801),
+        ..InputMetadata::default()
+    };
+    let image = write(
+        vec![InputEntry::file("data.txt", b"data".to_vec()).with_metadata(metadata)],
+        RripOptions::default(),
+    );
+    let entry = image
+        .root_dir()
+        .iter(&image)
+        .entries()
+        .filter_map(Result::ok)
+        .find(|entry| entry.matches_name("data.txt"))
+        .unwrap();
+    let ts = entry
+        .rrip
+        .as_ref()
+        .unwrap()
+        .timestamps
+        .as_ref()
+        .expect("TF timestamps present");
+    let creation = ts.creation.as_ref().expect("creation timestamp emitted");
+    assert_eq!(creation.year, 2001, "creation year round-trips");
+    // Modify and access must still be present and distinct from creation.
+    assert!(ts.modify.is_some());
+    assert!(ts.access.is_some());
+    assert_ne!(creation.year, ts.modify.as_ref().unwrap().year);
+}
+
+#[test]
 fn disabled_preservation_uses_stable_defaults() {
     let metadata = InputMetadata {
         mode: Some(0o600),

--- a/crates/optical/hadris-iso/tests/xorriso_boot.rs
+++ b/crates/optical/hadris-iso/tests/xorriso_boot.rs
@@ -107,6 +107,73 @@ fn test_hadris_multisection_boot_catalog() {
 }
 
 #[test]
+fn test_floppy_emulation_media_type_and_default_load_size() {
+    use hadris_iso::boot::EmulationType;
+    use hadris_iso::boot::options::{BootEntryOptions, BootOptions};
+    use hadris_iso::read::PathSeparator;
+    use hadris_iso::write::options::{CreationFeatures, FormatOptions};
+    use hadris_iso::write::{InputEntry, InputTree, IsoImageWriter};
+
+    // A 1.44 MB floppy image; emulation must be recorded and its default load
+    // size must be a single virtual sector (not the whole image / 512).
+    let floppy = vec![0x44u8; 2048];
+    let tree = InputTree::new(
+        PathSeparator::ForwardSlash,
+        vec![InputEntry::file("floppy.img", floppy)],
+    );
+    let boot = BootOptions {
+        write_boot_catalog: true,
+        default: BootEntryOptions {
+            load_size: None, // exercise the emulation-aware default
+            boot_image_path: "floppy.img".to_string(),
+            boot_info_table: false,
+            grub2_boot_info: false,
+            emulation: EmulationType::Floppy1_44,
+        },
+        entries: vec![],
+    };
+    let options = FormatOptions {
+        volume_name: "FLOPPYBOOT".to_string(),
+        system_id: None,
+        volume_set_id: None,
+        publisher_id: None,
+        preparer_id: None,
+        application_id: None,
+        sector_size: 2048,
+        features: CreationFeatures {
+            el_torito: Some(boot),
+            ..CreationFeatures::default()
+        },
+        path_separator: PathSeparator::ForwardSlash,
+        strict_charset: false,
+    };
+    let output = IsoImageWriter::create(Cursor::new(vec![0; 2 * 1024 * 1024]), tree, options)
+        .unwrap()
+        .into_inner();
+
+    let descriptor = (16..32)
+        .map(|sector| &output[sector * 2048..(sector + 1) * 2048])
+        .find(|descriptor| descriptor[0] == 0 && &descriptor[1..6] == b"CD001")
+        .expect("boot record volume descriptor");
+    let catalog_lba = u32::from_le_bytes(descriptor[71..75].try_into().unwrap()) as usize;
+    let catalog = &output[catalog_lba * 2048..];
+
+    // Default/initial entry starts at offset 32 in the catalog.
+    // [0] boot indicator (0x88), [1] media type, [6..8] sector count.
+    assert_eq!(catalog[32], 0x88, "entry must be bootable");
+    assert_eq!(
+        catalog[33],
+        EmulationType::Floppy1_44.to_u8(),
+        "media type must record 1.44 MB floppy emulation"
+    );
+    assert_eq!(
+        u16::from_le_bytes([catalog[38], catalog[39]]),
+        1,
+        "emulated media default load size must be one virtual sector"
+    );
+}
+
+#[test]
 fn test_eltorito_boot_catalog_comparison() {
     if !xorriso_available() {
         eprintln!("Skipping test: xorriso not available");

--- a/crates/optical/hadris-optical/Cargo.toml
+++ b/crates/optical/hadris-optical/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-optical"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-udf/Cargo.toml
+++ b/crates/optical/hadris-udf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-udf"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-cd-cli/Cargo.toml
+++ b/crates/tools/hadris-cd-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-cpio-cli/Cargo.toml
+++ b/crates/tools/hadris-cpio-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-fat-cli/Cargo.toml
+++ b/crates/tools/hadris-fat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fat-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 description = "CLI utility for FAT filesystem analysis and management"
 readme = "README.md"
 keywords = ["fat", "fat32", "filesystem", "cli", "disk"]

--- a/crates/tools/hadris-iso-cli/Cargo.toml
+++ b/crates/tools/hadris-iso-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-iso-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-udf-cli/Cargo.toml
+++ b/crates/tools/hadris-udf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-udf-cli"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs/hadris-1-to-2-migration.md
+++ b/docs/hadris-1-to-2-migration.md
@@ -3,7 +3,7 @@
 Hadris 2.0 reorganizes the project into a storage ecosystem with consistent
 feature flags, explicit synchronous and asynchronous namespaces, category-level
 detection and opening, and recoverable writer lifecycles. This guide targets
-`2.0.0-rc.1`.
+`2.0.0-rc.2`.
 
 Most common FAT and UDF renames have deprecated aliases, but new code should use
 the canonical 2.0 names. The aliases remain available for migration, but are
@@ -34,10 +34,10 @@ implementations.
 
 ```toml
 [dependencies]
-hadris-fat = "2.0.0-rc.1"
+hadris-fat = "2.0.0-rc.2"
 
 # Or select several categories through the umbrella:
-hadris = { version = "2.0.0-rc.1", features = ["block", "optical"] }
+hadris = { version = "2.0.0-rc.2", features = ["block", "optical"] }
 ```
 
 ## Update feature flags
@@ -62,7 +62,7 @@ For explicit or `no_std` configurations, select every required dimension:
 ```toml
 [dependencies]
 hadris-fat = {
-    version = "2.0.0-rc.1",
+    version = "2.0.0-rc.2",
     default-features = false,
     features = ["alloc", "read", "write", "sync"]
 }
@@ -153,7 +153,7 @@ An allocation-free build selects `read` plus an I/O mode and does not require
 `alloc`:
 
 ```toml
-hadris-iso = { version = "2.0.0-rc.1", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
 ```
 
 Use `IsoDir::read_entries` for collection-oriented traversal in either mode,
@@ -285,7 +285,7 @@ through the leaf crate's opt-in `unstable-exfat` feature:
 
 ```toml
 hadris-fat = {
-    version = "2.0.0-rc.1",
+    version = "2.0.0-rc.2",
     features = ["unstable-exfat"]
 }
 ```
@@ -315,7 +315,7 @@ specialized tools.
 
 ## Migration checklist
 
-1. Change dependency requirements to `2.0.0-rc.1`.
+1. Change dependency requirements to `2.0.0-rc.2`.
 2. Make platform, mode, and operation features explicit when disabling defaults.
 3. Move I/O calls to `sync` or `async` namespaces.
 4. Replace deprecated types and fluent setters with canonical names.

--- a/docs/hadris-2-perf-notes.md
+++ b/docs/hadris-2-perf-notes.md
@@ -1,0 +1,46 @@
+# Hadris performance & caching notes
+
+Status: findings and roadmap; **no performance code is planned for 2.0**.
+
+Caching and performance were deliberately deferred out of the 2.0 line. This
+note records what exists today and where future work should go, so the decisions
+are not re-derived later. It complements the roadmap's position that caching
+should become a `hadris-storage` adapter "only after the base interface is
+stable" ([`hadris-2-roadmap.md`](hadris-2-roadmap.md)).
+
+## What exists
+
+- **FAT sector cache (sync only).** `hadris-fat` has a feature-gated
+  (`cache`) write-back LRU sector cache (`crates/block/hadris-fat/src/cache.rs`).
+  Built-in `FatFs` operations route FAT-table reads/writes through it when
+  installed. It is **sync only** — the async path silently bypasses the cache
+  (deferred as issue #27 / "phase C5b").
+- **ISO criterion benches.** `hadris-iso` has `benches/iso_benchmarks.rs` plus a
+  timing comparison against xorriso.
+- **Allocation-free `IsoReader`.** Reads and streams without allocating, but does
+  **no buffering** — every access re-seeks and re-reads from the source.
+
+## Findings / opportunities (post-2.0)
+
+1. **Async FAT cache parity.** The cheapest concrete win: give the async `FatFs`
+   the same write-back cache the sync path has. Bounded scope, real benefit.
+2. **`IsoReader` scratch buffer.** A caller-supplied window/scratch buffer would
+   cut repeated seeks for sequential directory and file reads while staying
+   `no_std`- and allocation-free at the library level.
+3. **`hadris-storage` is an unused island.** Its `BlockDevice` /
+   `BlockDeviceMut` traits (`crates/core/hadris-storage/src/sync.rs`) are consumed
+   by **no format crate** — FAT, ISO, UDF, and partitioning all sit directly on
+   `hadris-io`'s `Read + Seek`. A generic block-cache or instrumentation adapter
+   written against `BlockDevice` would therefore benefit nobody today. The real
+   architectural question is whether block-oriented formats should adopt
+   `BlockDevice` so a single cache/instrumentation layer can serve all of them.
+   That is a 2.x design question, not a 2.0 change.
+4. **No FAT benchmarks.** ISO has criterion benches; FAT has none. Adding FAT
+   criterion benches is the right first step before any FAT performance work, so
+   changes are measured rather than assumed.
+
+## Guidance
+
+Do not add a caching layer to a format crate speculatively. Establish the
+`hadris-storage` consumer story (finding 3) and a benchmark baseline (finding 4)
+first; then adapters have both a place to live and a way to prove their value.

--- a/docs/hadris-2.0.0-rc.2-release-notes.md
+++ b/docs/hadris-2.0.0-rc.2-release-notes.md
@@ -1,0 +1,113 @@
+# Hadris 2.0.0-rc.2 Release Notes
+
+Hadris 2.0.0-rc.2 is the second release candidate for Hadris V2. It continues
+the V2 feature and public-API freeze established by
+[2.0.0-rc.1](hadris-2.0.0-rc.1-release-notes.md): changes are limited to
+correctness fixes, interoperability qualification, additive spec features,
+documentation, and release engineering. This candidate contains no breaking
+changes to the frozen public API — every API change below is additive, except
+the removal of one unused, always-empty stub type.
+
+For the full V2 overview (the storage stack, feature tiers, per-format
+capabilities, exFAT preview, and migration guidance), see the
+[2.0.0-rc.1 release notes](hadris-2.0.0-rc.1-release-notes.md). This document
+covers only what changed since rc.1.
+
+## Highlights since rc.1
+
+### FAT: lowercase 8.3 names round-trip correctly
+
+Lowercase short names such as `readme.txt` are now stored as a single directory
+entry carrying the Windows NT `DIR_NTRes` case flags (new `NtCaseFlags`,
+`FileEntry::nt_case`, `ShortFileName::with_nt_case`) and read back in their
+original case. Previously they were either uppercased on read or forced to spend
+a long-file-name entry. This matches how Windows and the Linux `vfat` driver
+present the same names, verified against `mtools` as an external reference. As
+part of the fix, `rename` now records case flags for the *new* name rather than
+carrying over the source entry's.
+
+`Fat12` and `Fat16` also gained `allocate_chain` / `extend_chain`, matching
+`Fat32`, for callers performing manual multi-cluster allocation.
+
+### ISO: conformance and interoperability fixes
+
+- **Joliet is now conformant UCS-2.** Characters outside the Basic Multilingual
+  Plane are substituted with `_` instead of leaking UTF-16 surrogate pairs, and
+  names are capped at the Joliet 64-character limit (previously up to 103).
+- **Directory records are written in File Identifier order** (ECMA-119 9.3)
+  instead of input/tree order, so images validate against strict readers.
+- **Non-2048 logical block sizes are rejected on read.** `IsoImage::open` now
+  returns a clear `Unsupported` error instead of silently misreading extents.
+  (The allocation-free `IsoReader` already honors the declared block size.)
+- **Files larger than 4 GiB fail with a clear error** instead of silently
+  truncating their length to 32 bits. Multi-extent *write* (which would lift the
+  limit) is not yet emitted and remains a documented limitation.
+
+### ISO: additive boot and metadata features
+
+- **El Torito emulation media types.** `EmulationType` now names the 1.2/1.44/
+  2.88 MB floppy and hard-disk emulation modes with an `is_emulated` helper;
+  emulated boot entries default their load size to one virtual sector.
+- **Rock Ridge creation timestamps.** `TF` entries now include the creation time
+  when the input entry carries one (new `RripBuilder::add_tf`), alongside the
+  existing modify and access times.
+- **No-alloc Rock Ridge name resolution.** The allocation-free `IsoReader` can
+  resolve Rock Ridge alternate names via `IsoDirEntry::rrip_name_into` /
+  `rrip_name_matches`, decoding and comparing the `NM` field without allocating.
+  (Inline system-use areas only; `CE`-continued names are not followed.)
+
+### Compliance annotations and specification notes
+
+- Expanded the `@hadris-spec` compliance annotations and `docs/spec-coverage.md`
+  to cover more ISO volume descriptors, path tables, and El Torito section
+  entries, the FAT FSInfo sector, and a new `hadris-part` (MBR/GPT) section.
+- Completed the in-repo ISO 9660 specification notes (volume descriptors, path
+  table, directory record, and an extensions index) and documented the ISO
+  writer's known limitations.
+
+## Removed
+
+- **hadris-iso:** the unused, always-empty `read::SupportedFeatures` bitflags
+  stub. It carried no variants and was not referenced by any public API, so its
+  removal does not affect working code.
+
+## Known limitations
+
+The rc.1 known-limitations list still applies. Newly documented in this
+candidate:
+
+- **ISO multi-extent write.** Files larger than 4 GiB cannot yet be written;
+  the writer emits a single extent and rejects oversized inputs rather than
+  producing a truncated image. Multi-extent *reading* is supported.
+- **Non-2048 block sizes in `IsoImage`.** Reading such images returns
+  `Unsupported`; the allocation-free `IsoReader` reads them.
+- Additional niche ISO features (Volume Partition Descriptor bodies, interleaved
+  files, zisofs, Extended Attribute Record contents, Rock Ridge `SF`/`RR`, and
+  spec-valid backup GPT for hybrid images) remain out of scope for 2.0 and are
+  recorded in the `hadris-iso` crate documentation.
+
+## Performance and caching
+
+No performance code landed in this candidate. The caching and performance
+findings deferred out of the 2.0 line — the sync-only FAT sector cache, the
+unbuffered allocation-free `IsoReader`, the unused `hadris-storage` block-device
+traits, and the absence of FAT benchmarks — are recorded in
+[`docs/hadris-2-perf-notes.md`](hadris-2-perf-notes.md) so the decisions are not
+re-derived later.
+
+## What prerelease testers should exercise
+
+In addition to the rc.1 testing focus, this candidate especially benefits from:
+
+- FAT images with lowercase short names, cross-checked against `mtools`,
+  Windows, and the Linux `vfat` driver;
+- ISO images validated by strict readers for directory-record ordering and
+  Joliet name conformance;
+- BIOS boot workflows using El Torito floppy and hard-disk emulation entries;
+- Rock Ridge images carrying creation timestamps and alternate names read
+  through the allocation-free `IsoReader`.
+
+Please report bugs and migration problems through the
+[Hadris issue tracker](https://github.com/hxyulin/hadris/issues). Security
+issues should follow the private reporting process in
+[SECURITY.md](../SECURITY.md).

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -38,14 +38,30 @@ Fuzz columns name targets under `fuzz/` (local only — not PR CI).
 
 | Spec | Item | Compliance | Tests | Fuzz | Notes |
 |------|------|------------|-------|------|-------|
+| ECMA-119:8.2 | `BootRecordVolumeDescriptor` | full | `xorriso_boot::test_hadris_multisection_boot_catalog` | `iso_read` | Locates the El Torito boot catalog |
+| ECMA-119:8.3 | `VolumeDescriptorSetTerminator` | full | `comprehensive_iso::test_pvd_standard_identifier` | `iso_read` | |
 | ECMA-119:8.4 | `PrimaryVolumeDescriptor` | full | `comprehensive_iso::test_pvd_standard_identifier` | `iso_read` | |
+| ECMA-119:8.5 | `SupplementaryVolumeDescriptor` | partial | | `iso_read` | Joliet SVD (UCS-2, BMP only); version-2 EVD repurposed as a UDF-bridge signal, not conformant ISO 9660:1999 |
 | ECMA-119:9.1 | `DirectoryRecordHeader` | full | `directory::tests::directory_record_parse_roundtrip` | `iso_read` | Fixed fields; covered by parse roundtrip |
-| ECMA-119:9.1 | `DirectoryRecord` | partial | `directory::tests::directory_record_parse_roundtrip` | `iso_read` | Joliet+RRIP coexistence on read may hide one namespace |
+| ECMA-119:9.1 | `DirectoryRecord` | partial | `directory::tests::directory_record_parse_roundtrip` | `iso_read` | Joliet+RRIP coexistence on read may hide one namespace; records written in collation order |
+| ECMA-119:9.4 | `PathTableEntryHeader` | partial | | `iso_read` | L- and M-type tables written/read; optional secondary path tables not populated |
 | El-Torito:validation | `BootValidationEntry` | full | `xorriso_boot::test_eltorito_boot_catalog_comparison` | `iso_read` | |
+| El-Torito:section-header | `BootSectionHeaderEntry` | full | `xorriso_boot::test_hadris_multisection_boot_catalog` | `iso_read` | |
+| El-Torito:section-entry | `BootSectionEntry` | full | `xorriso_boot::test_floppy_emulation_media_type_and_default_load_size` | `iso_read` | Named floppy/HDD emulation media types |
 
 ## hadris-fat
 
 | Spec | Item | Compliance | Tests | Fuzz | Notes |
 |------|------|------------|-------|------|-------|
 | FAT:BPB | `RawBpb` | full | `comprehensive_fat::test_valid_sector_sizes` | `fat_read` | |
+| FAT:FSInfo | `RawFsInfo` | full | `comprehensive_fat::test_fsinfo_free_cluster_unknown` | `fat_read` | FAT32 free-cluster/next-free tracking |
 | FAT:LFN | `RawLfnEntry` | full | `comprehensive_fat::test_lfn_builder_sequence`, `test_write::lfn_cluster_boundary_tests` | `fat_read` | Read/write supports directory-entry runs across cluster boundaries |
+| FAT:DirEntry | `RawFileEntry` | partial | `test_write::test_lowercase_short_name_uses_nt_case_flags` | `fat_read` | Short-name entry incl. NT `DIR_NTRes` case flags (lowercase 8.3 round-trip); extended access-time granularity not modeled |
+
+## hadris-part
+
+| Spec | Item | Compliance | Tests | Fuzz | Notes |
+|------|------|------------|-------|------|-------|
+| MBR:layout | `MasterBootRecord` | full | `roundtrip::mbr_write_read_roundtrip` | | 512-byte MBR incl. protective/hybrid MBR support |
+| UEFI:GPT-Header | `GptHeader` | full | `io_roundtrip::gpt_scheme_sync_write_open_and_detect_roundtrip` | | Primary/backup header validation |
+| UEFI:GPT-Entry | `GptPartitionEntry` | full | `roundtrip::gpt_partition_entry_roundtrip` | | |

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -9,10 +9,10 @@ Choose the narrowest crate that covers your application:
 ```toml
 [dependencies]
 # A single filesystem:
-hadris-fat = "2.0.0-rc.1"
+hadris-fat = "2.0.0-rc.2"
 
 # Or several storage categories:
-hadris = { version = "2.0.0-rc.1", features = ["block", "optical"] }
+hadris = { version = "2.0.0-rc.2", features = ["block", "optical"] }
 ```
 
 Hadris separates platform support, I/O mode, and capabilities. For a
@@ -21,7 +21,7 @@ freestanding read-only FAT consumer:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.0.0-rc.1",
+  version = "2.0.0-rc.2",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/build-initramfs.md
+++ b/website/docs/guides/build-initramfs.md
@@ -6,7 +6,7 @@ title: Build a CPIO initramfs
 
 ```toml
 [dependencies]
-hadris-cpio = "2.0.0-rc.1"
+hadris-cpio = "2.0.0-rc.2"
 ```
 
 ```rust

--- a/website/docs/guides/no-std.md
+++ b/website/docs/guides/no-std.md
@@ -10,7 +10,7 @@ that the target needs:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.0.0-rc.1",
+  version = "2.0.0-rc.2",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/read-fat-image.md
+++ b/website/docs/guides/read-fat-image.md
@@ -6,7 +6,7 @@ title: Read a FAT image
 
 ```toml
 [dependencies]
-hadris-fat = "2.0.0-rc.1"
+hadris-fat = "2.0.0-rc.2"
 ```
 
 ```rust

--- a/website/docs/guides/read-partition-table.md
+++ b/website/docs/guides/read-partition-table.md
@@ -6,7 +6,7 @@ title: Read a partition table
 
 ```toml
 [dependencies]
-hadris-part = "2.0.0-rc.1"
+hadris-part = "2.0.0-rc.2"
 ```
 
 ```rust

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -18,7 +18,7 @@ and asynchronous feature tiers.
 
 :::caution Release candidate
 
-`2.0.0-rc.1` freezes the intended V2 public API while downstream testing is in
+`2.0.0-rc.2` freezes the intended V2 public API while downstream testing is in
 progress. The `unstable-exfat` feature remains outside that stability promise.
 
 :::

--- a/website/docs/release-candidate.md
+++ b/website/docs/release-candidate.md
@@ -1,14 +1,14 @@
 ---
-title: 2.0.0-rc.1
+title: 2.0.0-rc.2
 ---
 
-# Hadris 2.0.0-rc.1
+# Hadris 2.0.0-rc.2
 
 This release candidate freezes the intended V2 public surface while correctness,
 interoperability, documentation, and release engineering continue.
 
 Read the complete
-[release notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-rc.1-release-notes.md)
+[release notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-rc.2-release-notes.md)
 and report real-world compatibility findings through
 [GitHub Issues](https://github.com/hxyulin/hadris/issues).
 


### PR DESCRIPTION
## Summary

Polishes FAT and ISO into a **`2.0.0-rc.2`** release candidate: closes correctness/interop defects, lands high-value additive spec features, widens the external-tool interop matrix, expands `@hadris-spec` compliance coverage, and cuts the version bump. Per the agreed scope, **no performance code** this round — findings are documented only.

All changes are **additive** to the public API **except** the intentional removal of the unused, empty `SupportedFeatures` stub. Public-API snapshots, `docs/spec-coverage.md`, and the CHANGELOG are updated accordingly.

## Commits
1. **`feat`: spec-polish + interop qualification** — the feature/fix content below.
2. **`test`: fix pre-existing default-feature build/lint breakage** — two issues that predate this branch and only surface off CI's `--all-features` path (`hadris-part` `io_roundtrip` had no feature gate; a `hadris-fat` `v2_api` `drop` tripped `-D warnings`).
3. **`release`: bump workspace to 2.0.0-rc.2** — every crate `version` + internal-dep requirement `rc.1 → rc.2`, regenerated `Cargo.lock`, dated CHANGELOG section, new `docs/hadris-2.0.0-rc.2-release-notes.md`, and refreshed version strings across READMEs / website / migration guide.

## FAT (`hadris-fat`)
- **NT case bits (`DIR_NTRes`).** A pure-lowercase 8.3 name (`readme.txt`) now roundtrips in its original case *without* an LFN, matching Windows/`vfat`. Fixes a latent `rename` bug that carried stale case bits over.
- **FAT12/16 chain allocators.** Added `allocate_chain`/`extend_chain` for API parity with FAT32.

## ISO (`hadris-iso`)
- **>4 GiB write guard** — typed error instead of silent `size as u32` truncation (multi-extent *write* deferred; needs a streaming input source).
- **Directory-record collation** — records emitted in ECMA-119 §9.3 order.
- **Joliet conformance** — strict UCS-2/BMP encoding + 64-char limit enforced.
- **Non-2048 block size on read** — rejected with `Unsupported` rather than misread.
- **El Torito emulation types** — floppy 1.2/1.44/2.88 + hard disk, with emulation-aware default load size.
- **RRIP `TF` creation time** on write; **no-alloc `IsoReader`** now resolves SUSP/`NM` names in `no_std`.

## Audit / interop / docs
- Expanded `@hadris-spec` annotations across FAT, ISO, and a new **`hadris-part`** section; completed the in-repo ISO `Specification.md` notes.
- Removed the dead `SupportedFeatures` stub; refreshed public-API snapshots.
- New **`mtools` FAT fidelity test** (names + contents vs. a reference driver; skips when `mtools` absent) — wired into CI.
- Documented **Tier 3 known limitations** and **perf/caching findings** (`docs/hadris-2-perf-notes.md`).

## Testing
- `cargo test -p hadris-fat -p hadris-iso` + `hadris-part` (`--all-features`): all pass.
- `cargo fmt --check`, strict clippy (`--all-targets --all-features -D warnings` on touched crates), `scripts/check-spec-annotations.py`, `scripts/check-public-api.sh check`, `cargo check --workspace`, `cargo metadata`: all green.
- Public-API snapshots are version-agnostic and unchanged by the bump.

## Deferred (documented, not built)
- ISO multi-extent **write** (T1.1) — blocked on the in-memory `Vec<u8>` input API; recorded as a Tier 3 limitation.
- `isoinfo`/`genisoimage` cross-check and QEMU-boot-of-emulation tests — couldn't validate the tool invocations locally on macOS; the `mtools` FAT fidelity test did land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)