### PR TITLE
Prepare Hadris 2.0.0-rc.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,6 +119,9 @@ jobs:
             tier: alloc
             features: "alloc,sync,bytemuck,optical"
           - crate: hadris-common
+            tier: std-without-sync
+            features: "std,bytemuck,optical"
+          - crate: hadris-common
             tier: std
             features: "std,sync,bytemuck,optical"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+## [2.0.0-rc.3] - 2026-07-22
+
+### Added
+
+- **hadris-iso:** Added an explicit ISO interchange `BaseIsoLevel::Level3` and
+  corrected the CLI `--level 3` mapping.
+- **hadris-iso:** Allocation-free readers now discover and explicitly select
+  the ISO 9660:1999 enhanced namespace, including its root directory.
+
+### Fixed
+
+- **hadris-udf:** Directory FID extents are planned from exact encoded record
+  lengths instead of an unsafe per-entry estimate.
+- **hadris-udf:** OSTA CS0 filenames now select compression ID 8 or 16 from
+  their Unicode contents, enforce the 255-byte encoded limit, and decode
+  8-bit values as one-byte Unicode code points.
+- **hadris-iso:** `has_evd()` now reports an ISO 9660:1999 Enhanced Volume
+  Descriptor rather than implying that UDF is present.
+
+### Changed
+
+- **hadris-io / hadris-common:** `std` no longer activates `sync`; hosted
+  support and I/O mode selection are independent.
+- Broken Markdown links now fail the documentation build.
+
 ## [2.0.0-rc.2] - 2026-07-19
 
 ### Added
@@ -238,7 +263,8 @@ Each published package owns its version and may be released independently.
 Baseline for this changelog. See the git history for changes at and before this
 tag.
 
-[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.3...HEAD
+[2.0.0-rc.3]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.2...v2.0.0-rc.3
 [2.0.0-rc.2]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/hxyulin/hadris/compare/v1.2.1...v2.0.0-rc.1
 [1.2.1]: https://github.com/hxyulin/hadris/compare/v1.2.0...v1.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "hadris"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "hadris-archive",
  "hadris-block",
@@ -468,14 +468,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-archive"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "hadris-cpio",
 ]
 
 [[package]]
 name = "hadris-block"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bytemuck",
  "hadris-fat",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "hadris-io",
  "hadris-iso",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "clap",
  "hadris-cd",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "hadris-common",
  "hadris-io",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -607,14 +607,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "hadris-io"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "clap",
  "hadris-iso",
@@ -655,14 +655,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-optical"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "hadris-cd",
  "hadris-io",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-part"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bytemuck",
  "crc",
@@ -684,11 +684,11 @@ dependencies = [
 
 [[package]]
 name = "hadris-path"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 
 [[package]]
 name = "hadris-storage"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "embedded-io",
  "hadris-io",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "clap",
  "hadris-udf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,18 +43,18 @@ clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 
 # Internal crates
-hadris-macros = { version = "2.0.0-rc.2", path = "crates/core/hadris-macros" }
-hadris-io = { version = "2.0.0-rc.2", path = "crates/core/hadris-io", default-features = false }
-hadris-fixed = { version = "2.0.0-rc.2", path = "crates/core/hadris-fixed", default-features = false }
-hadris-path = { version = "2.0.0-rc.2", path = "crates/core/hadris-path", default-features = false }
-hadris-common = { version = "2.0.0-rc.2", path = "crates/core/hadris-common", default-features = false }
-hadris-storage = { version = "2.0.0-rc.2", path = "crates/core/hadris-storage", default-features = false }
-hadris-block = { version = "2.0.0-rc.2", path = "crates/block/hadris-block", default-features = false }
-hadris-fat = { version = "2.0.0-rc.2", path = "crates/block/hadris-fat", default-features = false }
-hadris-part = { version = "2.0.0-rc.2", path = "crates/block/hadris-part", default-features = false }
-hadris-optical = { version = "2.0.0-rc.2", path = "crates/optical/hadris-optical", default-features = false }
-hadris-iso = { version = "2.0.0-rc.2", path = "crates/optical/hadris-iso", default-features = false }
-hadris-udf = { version = "2.0.0-rc.2", path = "crates/optical/hadris-udf", default-features = false }
-hadris-cd = { version = "2.0.0-rc.2", path = "crates/optical/hadris-cd", default-features = false }
-hadris-archive = { version = "2.0.0-rc.2", path = "crates/archive/hadris-archive", default-features = false }
-hadris-cpio = { version = "2.0.0-rc.2", path = "crates/archive/hadris-cpio", default-features = false }
+hadris-macros = { version = "2.0.0-rc.3", path = "crates/core/hadris-macros" }
+hadris-io = { version = "2.0.0-rc.3", path = "crates/core/hadris-io", default-features = false }
+hadris-fixed = { version = "2.0.0-rc.3", path = "crates/core/hadris-fixed", default-features = false }
+hadris-path = { version = "2.0.0-rc.3", path = "crates/core/hadris-path", default-features = false }
+hadris-common = { version = "2.0.0-rc.3", path = "crates/core/hadris-common", default-features = false }
+hadris-storage = { version = "2.0.0-rc.3", path = "crates/core/hadris-storage", default-features = false }
+hadris-block = { version = "2.0.0-rc.3", path = "crates/block/hadris-block", default-features = false }
+hadris-fat = { version = "2.0.0-rc.3", path = "crates/block/hadris-fat", default-features = false }
+hadris-part = { version = "2.0.0-rc.3", path = "crates/block/hadris-part", default-features = false }
+hadris-optical = { version = "2.0.0-rc.3", path = "crates/optical/hadris-optical", default-features = false }
+hadris-iso = { version = "2.0.0-rc.3", path = "crates/optical/hadris-iso", default-features = false }
+hadris-udf = { version = "2.0.0-rc.3", path = "crates/optical/hadris-udf", default-features = false }
+hadris-cd = { version = "2.0.0-rc.3", path = "crates/optical/hadris-cd", default-features = false }
+hadris-archive = { version = "2.0.0-rc.3", path = "crates/archive/hadris-archive", default-features = false }
+hadris-cpio = { version = "2.0.0-rc.3", path = "crates/archive/hadris-cpio", default-features = false }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ layers coherent without hiding format-specific capabilities.
 ## Stability and Versioning
 
 Hadris follows [Semantic Versioning](https://semver.org/). The
-`2.0.0-rc.1` prerelease marked the V2 feature and public-API freeze, which the
-`2.0.0-rc.2` candidate continues: until the
+The release-candidate series marked the V2 feature and public-API freeze, which
+the `2.0.0-rc.3` candidate continues: until the
 final `2.0.0` release, changes are limited to correctness fixes,
 interoperability qualification, documentation, and release engineering.
 Breaking changes to the frozen public API require explicit review and a new
@@ -146,10 +146,10 @@ Choose the narrowest entry point that fits the application:
 ```toml
 [dependencies]
 # One filesystem:
-hadris-fat = "2.0.0-rc.2"
+hadris-fat = "2.0.0-rc.3"
 
 # Or the unified storage ecosystem:
-hadris = { version = "2.0.0-rc.2", features = ["block", "optical"] }
+hadris = { version = "2.0.0-rc.3", features = ["block", "optical"] }
 ```
 
 The umbrella crate re-exports the same underlying format crates through
@@ -157,15 +157,15 @@ The umbrella crate re-exports the same underlying format crates through
 grow into partition detection or additional disk-image formats without
 replacing their filesystem implementation.
 
-Each package now owns its version; all current packages target **2.0.0-rc.2**:
+Each package now owns its version; all current packages target **2.0.0-rc.3**:
 
 ```toml
 [dependencies]
-hadris-iso = "2.0.0-rc.2"
-hadris-fat = "2.0.0-rc.2"
-hadris-part = { version = "2.0.0-rc.2", features = ["read"] }
-hadris-fixed = "2.0.0-rc.2"
-hadris-path = "2.0.0-rc.2"
+hadris-iso = "2.0.0-rc.3"
+hadris-fat = "2.0.0-rc.3"
+hadris-part = { version = "2.0.0-rc.3", features = ["read"] }
+hadris-fixed = "2.0.0-rc.3"
+hadris-path = "2.0.0-rc.3"
 ```
 
 For allocation-free `no_std` ISO reading:
@@ -173,8 +173,8 @@ For allocation-free `no_std` ISO reading:
 ```toml
 [dependencies]
 # No heap allocator: ISO 9660/Joliet lookup and streamed file reads.
-hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
-hadris-fat = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
 ```
 
 Add the `alloc` feature to `hadris-iso` when owned collections, convenience
@@ -197,7 +197,7 @@ See [CLAUDE.md](CLAUDE.md) for detailed build instructions and architecture note
 Users upgrading from Hadris 1.x should read the
 [2.0 migration guide](docs/hadris-1-to-2-migration.md). Prerelease testers
 should also review the
-[`2.0.0-rc.2` release notes](docs/hadris-2.0.0-rc.2-release-notes.md).
+[`2.0.0-rc.3` release notes](docs/hadris-2.0.0-rc.3-release-notes.md).
 The Docusaurus source for the task-oriented documentation site lives in
 [`website/`](website/); it includes getting-started, crate-selection, and
 FAT, partition, ISO, CPIO, and `no_std` use-case guides.

--- a/api-snapshots/hadris-iso.txt
+++ b/api-snapshots/hadris-iso.txt
@@ -380,6 +380,7 @@ pub enum hadris_iso::async::read::FilenameType
 pub hadris_iso::async::read::FilenameType::Builtin
 pub hadris_iso::async::read::FilenameType::Joliet
 pub enum hadris_iso::async::read::IsoNamespace
+pub hadris_iso::async::read::IsoNamespace::Enhanced
 pub hadris_iso::async::read::IsoNamespace::Joliet(hadris_iso::joliet::JolietLevel)
 pub hadris_iso::async::read::IsoNamespace::Primary
 pub enum hadris_iso::async::read::NameError
@@ -490,6 +491,7 @@ pub async fn hadris_iso::async::read::IsoReader<R>::open(R) -> hadris_io::error:
 pub fn hadris_iso::async::read::IsoReader<R>::open_dir(&mut self, hadris_iso::async::read::IsoRoot) -> hadris_iso::async::read::IsoDirReader<'_, R>
 pub fn hadris_iso::async::read::IsoReader<R>::open_file<'a>(&'a mut self, &hadris_iso::async::read::IsoDirEntry) -> hadris_io::error::Result<hadris_iso::async::read::IsoFileReader<'a, R>>
 impl<R> hadris_iso::async::read::IsoReader<R>
+pub const fn hadris_iso::async::read::IsoReader<R>::enhanced_root(&self) -> core::option::Option<hadris_iso::async::read::IsoRoot>
 pub fn hadris_iso::async::read::IsoReader<R>::into_inner(self) -> R
 pub const fn hadris_iso::async::read::IsoReader<R>::joliet_root(&self) -> core::option::Option<hadris_iso::async::read::IsoRoot>
 pub const fn hadris_iso::async::read::IsoReader<R>::preferred_root(&self) -> hadris_iso::async::read::IsoRoot
@@ -1818,6 +1820,7 @@ pub enum hadris_iso::read::FilenameType
 pub hadris_iso::read::FilenameType::Builtin
 pub hadris_iso::read::FilenameType::Joliet
 pub enum hadris_iso::read::IsoNamespace
+pub hadris_iso::read::IsoNamespace::Enhanced
 pub hadris_iso::read::IsoNamespace::Joliet(hadris_iso::joliet::JolietLevel)
 pub hadris_iso::read::IsoNamespace::Primary
 pub enum hadris_iso::read::NameError
@@ -1943,6 +1946,7 @@ pub fn hadris_iso::read::IsoReader<R>::open(R) -> hadris_io::error::Result<Self>
 pub fn hadris_iso::read::IsoReader<R>::open_dir(&mut self, hadris_iso::read::IsoRoot) -> hadris_iso::read::IsoDirReader<'_, R>
 pub fn hadris_iso::read::IsoReader<R>::open_file<'a>(&'a mut self, &hadris_iso::read::IsoDirEntry) -> hadris_io::error::Result<hadris_iso::read::IsoFileReader<'a, R>>
 impl<R> hadris_iso::read::IsoReader<R>
+pub const fn hadris_iso::read::IsoReader<R>::enhanced_root(&self) -> core::option::Option<hadris_iso::read::IsoRoot>
 pub fn hadris_iso::read::IsoReader<R>::into_inner(self) -> R
 pub const fn hadris_iso::read::IsoReader<R>::joliet_root(&self) -> core::option::Option<hadris_iso::read::IsoRoot>
 pub const fn hadris_iso::read::IsoReader<R>::preferred_root(&self) -> hadris_iso::read::IsoRoot
@@ -3048,6 +3052,7 @@ pub enum hadris_iso::sync::read::FilenameType
 pub hadris_iso::sync::read::FilenameType::Builtin
 pub hadris_iso::sync::read::FilenameType::Joliet
 pub enum hadris_iso::sync::read::IsoNamespace
+pub hadris_iso::sync::read::IsoNamespace::Enhanced
 pub hadris_iso::sync::read::IsoNamespace::Joliet(hadris_iso::joliet::JolietLevel)
 pub hadris_iso::sync::read::IsoNamespace::Primary
 pub enum hadris_iso::sync::read::NameError
@@ -3173,6 +3178,7 @@ pub fn hadris_iso::read::IsoReader<R>::open(R) -> hadris_io::error::Result<Self>
 pub fn hadris_iso::read::IsoReader<R>::open_dir(&mut self, hadris_iso::read::IsoRoot) -> hadris_iso::read::IsoDirReader<'_, R>
 pub fn hadris_iso::read::IsoReader<R>::open_file<'a>(&'a mut self, &hadris_iso::read::IsoDirEntry) -> hadris_io::error::Result<hadris_iso::read::IsoFileReader<'a, R>>
 impl<R> hadris_iso::read::IsoReader<R>
+pub const fn hadris_iso::read::IsoReader<R>::enhanced_root(&self) -> core::option::Option<hadris_iso::read::IsoRoot>
 pub fn hadris_iso::read::IsoReader<R>::into_inner(self) -> R
 pub const fn hadris_iso::read::IsoReader<R>::joliet_root(&self) -> core::option::Option<hadris_iso::read::IsoRoot>
 pub const fn hadris_iso::read::IsoReader<R>::preferred_root(&self) -> hadris_iso::read::IsoRoot
@@ -4039,6 +4045,9 @@ pub hadris_iso::sync::write::options::BaseIsoLevel::Level1::supports_rrip: bool
 pub hadris_iso::sync::write::options::BaseIsoLevel::Level2
 pub hadris_iso::sync::write::options::BaseIsoLevel::Level2::supports_lowercase: bool
 pub hadris_iso::sync::write::options::BaseIsoLevel::Level2::supports_rrip: bool
+pub hadris_iso::sync::write::options::BaseIsoLevel::Level3
+pub hadris_iso::sync::write::options::BaseIsoLevel::Level3::supports_lowercase: bool
+pub hadris_iso::sync::write::options::BaseIsoLevel::Level3::supports_rrip: bool
 impl core::convert::From<hadris_iso::write::options::BaseIsoLevel> for hadris_iso::file::EntryType
 pub fn hadris_iso::file::EntryType::from(hadris_iso::write::options::BaseIsoLevel) -> Self
 pub enum hadris_iso::sync::write::options::PartitionScheme
@@ -4531,6 +4540,9 @@ pub hadris_iso::write::options::BaseIsoLevel::Level1::supports_rrip: bool
 pub hadris_iso::write::options::BaseIsoLevel::Level2
 pub hadris_iso::write::options::BaseIsoLevel::Level2::supports_lowercase: bool
 pub hadris_iso::write::options::BaseIsoLevel::Level2::supports_rrip: bool
+pub hadris_iso::write::options::BaseIsoLevel::Level3
+pub hadris_iso::write::options::BaseIsoLevel::Level3::supports_lowercase: bool
+pub hadris_iso::write::options::BaseIsoLevel::Level3::supports_rrip: bool
 impl core::convert::From<hadris_iso::write::options::BaseIsoLevel> for hadris_iso::file::EntryType
 pub fn hadris_iso::file::EntryType::from(hadris_iso::write::options::BaseIsoLevel) -> Self
 pub enum hadris_iso::write::options::PartitionScheme

--- a/crates/archive/hadris-archive/Cargo.toml
+++ b/crates/archive/hadris-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-archive"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-cpio/Cargo.toml
+++ b/crates/archive/hadris-cpio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-cpio/README.md
+++ b/crates/archive/hadris-cpio/README.md
@@ -76,21 +76,21 @@ configurations should enable `sync`, `async`, or both explicitly.
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-cpio = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Kernels with Heap (no-std + alloc)
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.0.0-rc.2", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-cpio = { version = "2.0.0-rc.3", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-cpio = "2.0.0-rc.2"  # Uses default features
+hadris-cpio = "2.0.0-rc.3"  # Uses default features
 ```
 
 ## Archive Format

--- a/crates/block/hadris-block/Cargo.toml
+++ b/crates/block/hadris-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-block"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-fat/Cargo.toml
+++ b/crates/block/hadris-fat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fat"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 description = "Rust FAT12/FAT16/FAT32 filesystem library for disk images, embedded devices, and no-std"
 readme = "README.md"
 keywords = ["fat", "fat32", "vfat", "filesystem", "no-std"]

--- a/crates/block/hadris-fat/README.md
+++ b/crates/block/hadris-fat/README.md
@@ -146,21 +146,21 @@ Automatic FAT type selection follows Microsoft recommendations:
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Embedded Systems with Heap
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.0.0-rc.2", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
+hadris-fat = { version = "2.0.0-rc.3", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-fat = "2.0.0-rc.2"  # Uses default features
+hadris-fat = "2.0.0-rc.3"  # Uses default features
 ```
 
 ## FAT Variant Support

--- a/crates/block/hadris-part/Cargo.toml
+++ b/crates/block/hadris-part/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-part"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-part/README.md
+++ b/crates/block/hadris-part/README.md
@@ -114,16 +114,16 @@ for (idx, entry) in gpt.partitions() {
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-part = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Desktop Applications
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.0.0-rc.2", features = ["write"] }  # read is already default
+hadris-part = { version = "2.0.0-rc.3", features = ["write"] }  # read is already default
 # Optional GPT CRC verification:
-# hadris-part = { version = "2.0.0-rc.2", features = ["write", "crc"] }
+# hadris-part = { version = "2.0.0-rc.3", features = ["write", "crc"] }
 ```
 
 ## Partition Types

--- a/crates/core/hadris-common/Cargo.toml
+++ b/crates/core/hadris-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-common"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -17,9 +17,9 @@ default = ["bytemuck", "std"]
 sync = ["hadris-io/sync"]
 async = ["hadris-io/async"]
 alloc = ["hadris-fixed/alloc", "hadris-io/alloc", "hadris-path/alloc"]
-std = ["sync", "dep:chrono", "chrono?/std", "dep:crc", "dep:rand", "alloc"]
+std = ["dep:chrono", "chrono?/std", "dep:crc", "dep:rand", "alloc", "hadris-io/std"]
 bytemuck = ["dep:bytemuck", "hadris-fixed/bytemuck"]
-optical = ["alloc"]  # Optical media types (SessionInfo, OpticalMetadataWriter)
+optical = ["alloc"]  # Mode-neutral optical types; writer traits also require `sync`.
 
 [dependencies]
 bytemuck = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/core/hadris-common/README.md
+++ b/crates/core/hadris-common/README.md
@@ -55,14 +55,14 @@ assert_eq!(hadris_common::BOOT_SECTOR_BIN[511], 0xAA);
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.0.0-rc.2", default-features = false, features = ["alloc", "bytemuck"] }
+hadris-common = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "bytemuck"] }
 ```
 
 ### Minimal (No Heap)
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.0.0-rc.2", default-features = false, features = ["bytemuck"] }
+hadris-common = { version = "2.0.0-rc.3", default-features = false, features = ["bytemuck"] }
 ```
 
 ## License

--- a/crates/core/hadris-common/boot_sector/Cargo.lock
+++ b/crates/core/hadris-common/boot_sector/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "boot_sector"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.3"

--- a/crates/core/hadris-common/boot_sector/Cargo.toml
+++ b/crates/core/hadris-common/boot_sector/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "boot_sector"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/hadris-common/src/optical.rs
+++ b/crates/core/hadris-common/src/optical.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "sync"))]
 use super::types::layout::DirectoryLayout;
 
 /// Standard sector size for optical media (CD/DVD/Blu-ray).
@@ -87,7 +87,7 @@ impl Default for SessionInfo {
 /// tree with extents already calculated, and writes only the
 /// filesystem metadata (volume descriptors, directory records, etc.)
 /// without writing any file data.
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "sync"))]
 pub trait OpticalMetadataWriter {
     /// Options type for the writer.
     type Options;

--- a/crates/core/hadris-fixed/Cargo.toml
+++ b/crates/core/hadris-fixed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fixed"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/Cargo.toml
+++ b/crates/core/hadris-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-io"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ default = ["sync", "std"]
 sync = []
 async = ["dep:embedded-io-async"]
 alloc = []
-std = ["sync", "alloc", "embedded-io/std", "embedded-io-async?/std"]
+std = ["alloc", "embedded-io/std", "embedded-io-async?/std"]
 
 [dependencies]
 cfg-if.workspace = true

--- a/crates/core/hadris-io/README.md
+++ b/crates/core/hadris-io/README.md
@@ -32,14 +32,14 @@ When the `std` feature is enabled, traits re-export from `std::io`. In `no_std` 
 
 ```toml
 [dependencies]
-hadris-io = "2.0.0-rc.2"
+hadris-io = "2.0.0-rc.3"
 ```
 
 ### No-std
 
 ```toml
 [dependencies]
-hadris-io = { version = "2.0.0-rc.2", default-features = false, features = ["sync"] }
+hadris-io = { version = "2.0.0-rc.3", default-features = false, features = ["sync"] }
 ```
 
 ## Quick Start

--- a/crates/core/hadris-macros/Cargo.toml
+++ b/crates/core/hadris-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-macros"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-path/Cargo.toml
+++ b/crates/core/hadris-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-path"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-storage/Cargo.toml
+++ b/crates/core/hadris-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-storage"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris/Cargo.toml
+++ b/crates/core/hadris/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-cd/Cargo.toml
+++ b/crates/optical/hadris-cd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-iso"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -117,7 +117,7 @@ only under `sync`.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
 ```
 
 The `read` feature exposes `IsoReader`, which opens and navigates ISO 9660 and
@@ -147,14 +147,14 @@ the allocation-free reader exposes raw system-use bytes for custom handling.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-iso = { version = "2.0.0-rc.3", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-iso = "2.0.0-rc.2"  # Uses default features
+hadris-iso = "2.0.0-rc.3"  # Uses default features
 ```
 
 ## Extension Support

--- a/crates/optical/hadris-iso/src/read/basic.rs
+++ b/crates/optical/hadris-iso/src/read/basic.rs
@@ -21,6 +21,8 @@ pub enum IsoNamespace {
     Primary,
     /// A Joliet supplementary directory tree.
     Joliet(JolietLevel),
+    /// The ISO 9660:1999 enhanced directory tree.
+    Enhanced,
 }
 
 /// A root directory and the namespace it represents.
@@ -100,6 +102,9 @@ impl<'a> IsoName<'a> {
                 strip_primary_version(self.raw).eq_ignore_ascii_case(candidate.as_bytes())
             }
             IsoNamespace::Joliet(_) => joliet_matches(strip_joliet_version(self.raw), candidate),
+            IsoNamespace::Enhanced => {
+                strip_primary_version(self.raw).eq_ignore_ascii_case(candidate.as_bytes())
+            }
         }
     }
 
@@ -124,6 +129,15 @@ impl<'a> IsoName<'a> {
                 core::str::from_utf8(&output[..raw.len()]).map_err(|_| NameError::InvalidEncoding)
             }
             IsoNamespace::Joliet(_) => decode_joliet_into(strip_joliet_version(self.raw), output),
+            IsoNamespace::Enhanced => {
+                let raw = strip_primary_version(self.raw);
+                core::str::from_utf8(raw).map_err(|_| NameError::InvalidEncoding)?;
+                if raw.len() > output.len() {
+                    return Err(NameError::BufferTooSmall);
+                }
+                output[..raw.len()].copy_from_slice(raw);
+                core::str::from_utf8(&output[..raw.len()]).map_err(|_| NameError::InvalidEncoding)
+            }
         }
     }
 }
@@ -346,6 +360,7 @@ pub struct IsoReader<R> {
     source: R,
     primary: IsoRoot,
     joliet: Option<IsoRoot>,
+    enhanced: Option<IsoRoot>,
 }
 
 impl<R> IsoReader<R> {
@@ -364,17 +379,25 @@ impl<R> IsoReader<R> {
         self.joliet
     }
 
-    /// Returns the preferred root, choosing Joliet over the primary namespace.
+    /// Returns the ISO 9660:1999 enhanced root, when present.
+    pub const fn enhanced_root(&self) -> Option<IsoRoot> {
+        self.enhanced
+    }
+
+    /// Returns the preferred root, choosing Joliet, then enhanced, then primary.
     pub const fn preferred_root(&self) -> IsoRoot {
-        match self.joliet {
-            Some(root) => root,
-            None => self.primary,
+        match (self.joliet, self.enhanced) {
+            (Some(root), _) => root,
+            (None, Some(root)) => root,
+            (None, None) => self.primary,
         }
     }
 
-    /// Iterates over the primary root followed by the optional Joliet root.
+    /// Iterates over the primary, enhanced, and Joliet roots.
     pub fn roots(&self) -> impl Iterator<Item = IsoRoot> {
-        [Some(self.primary), self.joliet].into_iter().flatten()
+        [Some(self.primary), self.enhanced, self.joliet]
+            .into_iter()
+            .flatten()
     }
 
     /// Selects a root by namespace.
@@ -384,6 +407,7 @@ impl<R> IsoReader<R> {
             IsoNamespace::Joliet(level) => self
                 .joliet
                 .filter(|root| root.namespace == IsoNamespace::Joliet(level)),
+            IsoNamespace::Enhanced => self.enhanced,
         }
     }
 }
@@ -394,6 +418,7 @@ impl<R: Read + Seek> IsoReader<R> {
     pub async fn open(mut source: R) -> io::Result<Self> {
         let mut primary = None;
         let mut joliet = None;
+        let mut enhanced = None;
         let mut sector = FIRST_DESCRIPTOR;
         loop {
             source.seek(SeekFrom::Start(sector.checked_mul(DESCRIPTOR_SIZE).ok_or_else(overflow)?))
@@ -409,7 +434,9 @@ impl<R: Read + Seek> IsoReader<R> {
             match VolumeDescriptor::new(bytes) {
                 VolumeDescriptor::Primary(descriptor) => primary = Some(root_from_primary(&descriptor)?),
                 VolumeDescriptor::Supplementary(descriptor) => {
-                    if let Some(root) = root_from_joliet(&descriptor)?
+                    if descriptor.header.version == 2 && descriptor.file_structure_version == 2 {
+                        enhanced = Some(root_from_enhanced(&descriptor)?);
+                    } else if let Some(root) = root_from_joliet(&descriptor)?
                         && joliet.map(|old: IsoRoot| joliet_level(old) < joliet_level(root)).unwrap_or(true)
                     { joliet = Some(root); }
                 }
@@ -418,7 +445,7 @@ impl<R: Read + Seek> IsoReader<R> {
             sector = sector.checked_add(1).ok_or_else(overflow)?;
         }
         let primary = primary.ok_or_else(|| invalid("primary volume descriptor not found"))?;
-        Ok(Self { source, primary, joliet })
+        Ok(Self { source, primary, joliet, enhanced })
     }
 
     /// Opens an allocation-free directory reader.
@@ -661,10 +688,22 @@ fn root_from_joliet(descriptor: &SupplementaryVolumeDescriptor) -> io::Result<Op
     )?))
 }
 
+fn root_from_enhanced(descriptor: &SupplementaryVolumeDescriptor) -> io::Result<IsoRoot> {
+    make_root(
+        IsoNamespace::Enhanced,
+        descriptor.logical_block_size.read(),
+        descriptor.dir_record.header.extent.read(),
+        descriptor.dir_record.header.data_len.read(),
+        descriptor.dir_record.header.extended_attr_record,
+    )
+}
+
 fn joliet_level(root: IsoRoot) -> JolietLevel {
     match root.namespace {
         IsoNamespace::Joliet(level) => level,
-        IsoNamespace::Primary => unreachable!("primary root used as Joliet root"),
+        IsoNamespace::Primary | IsoNamespace::Enhanced => {
+            unreachable!("non-Joliet root used as Joliet root")
+        }
     }
 }
 

--- a/crates/optical/hadris-iso/src/read/mod.rs
+++ b/crates/optical/hadris-iso/src/read/mod.rs
@@ -43,8 +43,7 @@ pub struct IsoImageInfo {
     boot_catalog: Option<u32>,
     path_table: PathTableRef,
     pub(crate) susp_info: SuspInfo,
-    /// True if an Enhanced Volume Descriptor (EVD) was found, indicating
-    /// this may be a UDF bridge ISO (combined ISO 9660 + UDF).
+    /// True if an ISO 9660:1999 Enhanced Volume Descriptor (EVD) was found.
     has_evd: bool,
     /// Cached path table entries, parsed once during open() to avoid
     /// repeated seeks for directory hierarchy traversal.
@@ -286,12 +285,18 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
                     }
                 }
             } else if svd.file_structure_version == 2 {
-                // Enhanced Volume Descriptor (EVD) — indicates UDF bridge ISO.
-                // The ISO 9660 spec defines this as a supplementary VD with
-                // file_structure_version == 2. Its presence signals that the
-                // image likely also contains a UDF filesystem that can be
-                // accessed via hadris-udf for richer metadata.
+                // ISO 9660:1999 enhanced namespace (ECMA-119, 3rd edition).
                 info.has_evd = true;
+                info.root_dirs.dirs.push(RootDir {
+                    ty: EntryType::Level3 {
+                        supports_lowercase: true,
+                        supports_rrip: false,
+                    },
+                    dir_ref: DirectoryRef {
+                        extent: LogicalSector(svd.dir_record.header.extent.read() as usize),
+                        size: svd.dir_record.header.data_len.read() as usize,
+                    },
+                });
             }
         }
 
@@ -412,10 +417,7 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
         self.info.susp_info.rrip_detected
     }
 
-    /// Returns whether an Enhanced Volume Descriptor (EVD) was found.
-    ///
-    /// An EVD indicates this is likely a UDF bridge ISO containing both
-    /// ISO 9660 and UDF filesystems. Use `hadris-udf` for UDF access.
+    /// Returns whether an ISO 9660:1999 Enhanced Volume Descriptor was found.
     pub fn has_evd(&self) -> bool {
         self.info.has_evd
     }

--- a/crates/optical/hadris-iso/src/write/options.rs
+++ b/crates/optical/hadris-iso/src/write/options.rs
@@ -123,6 +123,16 @@ pub enum BaseIsoLevel {
         /// The `supports_rrip` field.
         supports_rrip: bool,
     },
+    /// ISO 9660 interchange level 3.
+    ///
+    /// Level 3 retains the Level 2 filename rules and permits a logical file
+    /// to be represented by multiple consecutive directory records/extents.
+    Level3 {
+        /// Whether lowercase ASCII names are accepted.
+        supports_lowercase: bool,
+        /// Whether Rock Ridge system-use fields are emitted.
+        supports_rrip: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -243,6 +253,13 @@ impl From<BaseIsoLevel> for crate::file::EntryType {
                 supports_rrip,
             },
             BaseIsoLevel::Level2 {
+                supports_lowercase,
+                supports_rrip,
+            } => Self::Level2 {
+                supports_lowercase,
+                supports_rrip,
+            },
+            BaseIsoLevel::Level3 {
                 supports_lowercase,
                 supports_rrip,
             } => Self::Level2 {

--- a/crates/optical/hadris-optical/Cargo.toml
+++ b/crates/optical/hadris-optical/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-optical"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-udf/Cargo.toml
+++ b/crates/optical/hadris-udf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-udf"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-udf/src/descriptor/primary.rs
+++ b/crates/optical/hadris-udf/src/descriptor/primary.rs
@@ -95,8 +95,8 @@ pub fn decode_dstring(data: &[u8]) -> alloc::string::String {
 
     match compression_id {
         8 => {
-            // UTF-8 (or Latin-1 in older implementations)
-            alloc::string::String::from_utf8_lossy(content).into_owned()
+            // CS0 compression ID 8 stores one Unicode code point per byte.
+            content.iter().map(|byte| char::from(*byte)).collect()
         }
         16 => {
             // UTF-16 BE

--- a/crates/optical/hadris-udf/src/dir.rs
+++ b/crates/optical/hadris-udf/src/dir.rs
@@ -205,8 +205,8 @@ pub fn decode_filename(data: &[u8]) -> String {
 
     match compression_id {
         8 => {
-            // 8-bit characters (Latin-1/UTF-8)
-            String::from_utf8_lossy(content).into_owned()
+            // CS0 compression ID 8 stores one Unicode code point per byte.
+            content.iter().map(|byte| char::from(*byte)).collect()
         }
         16 => {
             // 16-bit characters (UTF-16 BE)

--- a/crates/optical/hadris-udf/src/write/mod.rs
+++ b/crates/optical/hadris-udf/src/write/mod.rs
@@ -461,10 +461,22 @@ impl<W: Write + Seek> UdfFormatter<W> {
         let icb_block = self.allocate_block();
         let unique_id = self.next_unique_id();
 
-        // Calculate FID size
-        let entry_count = 1 + dir.files.len() + dir.subdirs.len(); // parent + files + subdirs
-        let estimated_fid_bytes = entry_count * 50; // ~50 bytes per FID entry
-        let fid_sectors = estimated_fid_bytes.div_ceil(SECTOR_SIZE) as u32;
+        // Every FID is 38 bytes plus the CS0 identifier, padded to four bytes.
+        // Plan from the actual encoded lengths so directory data cannot overlap
+        // the ICB or payload extent that follows it.
+        let mut fid_bytes = 40usize; // parent FID has an empty identifier
+        for name in dir
+            .files
+            .iter()
+            .map(|file| file.name.as_str())
+            .chain(dir.subdirs.iter().map(|subdir| subdir.name.as_str()))
+        {
+            let encoded_len = self.encode_filename(name)?.len();
+            fid_bytes = fid_bytes
+                .checked_add((38 + encoded_len + 3) & !3)
+                .ok_or(crate::error::UdfError::PathTooLong)?;
+        }
+        let fid_sectors = fid_bytes.div_ceil(SECTOR_SIZE) as u32;
 
         let fid_block = self.allocate_block();
         // Allocate additional FID sectors if needed
@@ -1084,7 +1096,7 @@ impl<W: Write + Seek> UdfFormatter<W> {
             } else {
                 FileCharacteristics::empty()
             };
-            let encoded_name = self.encode_filename(name);
+            let encoded_name = self.encode_filename(name)?;
             let fid = self.create_fid(location, icb, chars, &encoded_name);
             buffer.extend_from_slice(&fid);
         }
@@ -1159,11 +1171,22 @@ impl<W: Write + Seek> UdfFormatter<W> {
             return;
         }
 
-        let bytes = s.as_bytes();
         let max_content = buffer.len() - 2;
-        let content_len = bytes.len().min(max_content);
-        buffer[0] = 8;
-        buffer[1..1 + content_len].copy_from_slice(&bytes[..content_len]);
+        let mut encoded = Vec::new();
+        if s.chars().all(|ch| (ch as u32) <= 0xff) {
+            buffer[0] = 8;
+            encoded.extend(s.chars().map(|ch| ch as u8));
+        } else {
+            buffer[0] = 16;
+            for unit in s.encode_utf16() {
+                if encoded.len() + 2 > max_content {
+                    break;
+                }
+                encoded.extend_from_slice(&unit.to_be_bytes());
+            }
+        }
+        let content_len = encoded.len().min(max_content);
+        buffer[1..1 + content_len].copy_from_slice(&encoded[..content_len]);
         buffer[buffer.len() - 1] = (content_len + 1) as u8;
     }
 
@@ -1176,12 +1199,8 @@ impl<W: Write + Seek> UdfFormatter<W> {
         }
     }
 
-    fn encode_filename(&self, name: &str) -> Vec<u8> {
-        let bytes = name.as_bytes();
-        let mut result = Vec::with_capacity(bytes.len() + 1);
-        result.push(8);
-        result.extend_from_slice(bytes);
-        result
+    fn encode_filename(&self, name: &str) -> UdfResult<Vec<u8>> {
+        encode_cs0_filename(name)
     }
 }
 
@@ -1751,7 +1770,7 @@ impl<W: Write + Seek> UdfWriter<W> {
             } else {
                 FileCharacteristics::empty()
             };
-            let encoded_name = self.encode_filename(name);
+            let encoded_name = self.encode_filename(name)?;
             let fid = self.create_fid(location, icb, chars, &encoded_name);
             buffer.extend_from_slice(&fid);
         }
@@ -1890,13 +1909,22 @@ impl<W: Write + Seek> UdfWriter<W> {
             return;
         }
 
-        // Use 8-bit encoding for ASCII-compatible strings
-        let bytes = s.as_bytes();
         let max_content = buffer.len() - 2; // Reserve 1 byte for compression ID, 1 for length
-
-        let content_len = bytes.len().min(max_content);
-        buffer[0] = 8; // Compression ID (8-bit)
-        buffer[1..1 + content_len].copy_from_slice(&bytes[..content_len]);
+        let mut encoded = Vec::new();
+        if s.chars().all(|ch| (ch as u32) <= 0xff) {
+            buffer[0] = 8;
+            encoded.extend(s.chars().map(|ch| ch as u8));
+        } else {
+            buffer[0] = 16;
+            for unit in s.encode_utf16() {
+                if encoded.len() + 2 > max_content {
+                    break;
+                }
+                encoded.extend_from_slice(&unit.to_be_bytes());
+            }
+        }
+        let content_len = encoded.len().min(max_content);
+        buffer[1..1 + content_len].copy_from_slice(&encoded[..content_len]);
         buffer[buffer.len() - 1] = (content_len + 1) as u8; // Length including compression ID
     }
 
@@ -1914,13 +1942,49 @@ impl<W: Write + Seek> UdfWriter<W> {
     }
 
     /// Encode a filename for UDF
-    fn encode_filename(&self, name: &str) -> Vec<u8> {
-        // Use 8-bit encoding for ASCII
-        let bytes = name.as_bytes();
-        let mut result = Vec::with_capacity(bytes.len() + 1);
-        result.push(8); // Compression ID
-        result.extend_from_slice(bytes);
-        result
+    fn encode_filename(&self, name: &str) -> UdfResult<Vec<u8>> {
+        encode_cs0_filename(name)
+    }
+}
+
+fn encode_cs0_filename(name: &str) -> UdfResult<Vec<u8>> {
+    let mut result = if name.chars().all(|ch| (ch as u32) <= 0xff) {
+        let mut encoded = Vec::with_capacity(name.chars().count() + 1);
+        encoded.push(8);
+        encoded.extend(name.chars().map(|ch| ch as u8));
+        encoded
+    } else {
+        let mut encoded = Vec::with_capacity(name.encode_utf16().count() * 2 + 1);
+        encoded.push(16);
+        for unit in name.encode_utf16() {
+            encoded.extend_from_slice(&unit.to_be_bytes());
+        }
+        encoded
+    };
+    if result.len() > u8::MAX as usize {
+        result.clear();
+        return Err(crate::error::UdfError::InvalidEncoding);
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod cs0_tests {
+    use super::encode_cs0_filename;
+
+    #[test]
+    fn selects_eight_bit_for_latin1() {
+        assert_eq!(encode_cs0_filename("café").unwrap(), b"\x08caf\xe9");
+    }
+
+    #[test]
+    fn selects_sixteen_bit_for_wide_unicode() {
+        assert_eq!(encode_cs0_filename("文").unwrap(), [16, 0x65, 0x87]);
+    }
+
+    #[test]
+    fn rejects_fid_identifiers_over_255_bytes() {
+        assert!(encode_cs0_filename(&"文".repeat(128)).is_err());
     }
 }
 

--- a/crates/tools/hadris-cd-cli/Cargo.toml
+++ b/crates/tools/hadris-cd-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-cpio-cli/Cargo.toml
+++ b/crates/tools/hadris-cpio-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-fat-cli/Cargo.toml
+++ b/crates/tools/hadris-fat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fat-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 description = "CLI utility for FAT filesystem analysis and management"
 readme = "README.md"
 keywords = ["fat", "fat32", "filesystem", "cli", "disk"]

--- a/crates/tools/hadris-iso-cli/Cargo.toml
+++ b/crates/tools/hadris-iso-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-iso-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-iso-cli/src/args.rs
+++ b/crates/tools/hadris-iso-cli/src/args.rs
@@ -242,7 +242,7 @@ impl FromStr for ArgLevel {
                 supports_lowercase: true,
                 supports_rrip: false,
             }),
-            "3" => Self(BaseIsoLevel::Level2 {
+            "3" => Self(BaseIsoLevel::Level3 {
                 supports_lowercase: true,
                 supports_rrip: false,
             }),

--- a/crates/tools/hadris-iso-cli/src/commands/create.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/create.rs
@@ -84,6 +84,9 @@ pub fn create(args: CreateArgs) -> Result<()> {
             hadris_iso::write::options::BaseIsoLevel::Level2 { supports_rrip, .. } => {
                 *supports_rrip = true
             }
+            hadris_iso::write::options::BaseIsoLevel::Level3 { supports_rrip, .. } => {
+                *supports_rrip = true
+            }
         }
     }
 

--- a/crates/tools/hadris-udf-cli/Cargo.toml
+++ b/crates/tools/hadris-udf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-udf-cli"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs/hadris-1-to-2-migration.md
+++ b/docs/hadris-1-to-2-migration.md
@@ -3,7 +3,7 @@
 Hadris 2.0 reorganizes the project into a storage ecosystem with consistent
 feature flags, explicit synchronous and asynchronous namespaces, category-level
 detection and opening, and recoverable writer lifecycles. This guide targets
-`2.0.0-rc.2`.
+`2.0.0-rc.3`.
 
 Most common FAT and UDF renames have deprecated aliases, but new code should use
 the canonical 2.0 names. The aliases remain available for migration, but are
@@ -34,10 +34,10 @@ implementations.
 
 ```toml
 [dependencies]
-hadris-fat = "2.0.0-rc.2"
+hadris-fat = "2.0.0-rc.3"
 
 # Or select several categories through the umbrella:
-hadris = { version = "2.0.0-rc.2", features = ["block", "optical"] }
+hadris = { version = "2.0.0-rc.3", features = ["block", "optical"] }
 ```
 
 ## Update feature flags
@@ -62,7 +62,7 @@ For explicit or `no_std` configurations, select every required dimension:
 ```toml
 [dependencies]
 hadris-fat = {
-    version = "2.0.0-rc.2",
+    version = "2.0.0-rc.3",
     default-features = false,
     features = ["alloc", "read", "write", "sync"]
 }
@@ -153,7 +153,7 @@ An allocation-free build selects `read` plus an I/O mode and does not require
 `alloc`:
 
 ```toml
-hadris-iso = { version = "2.0.0-rc.2", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.0.0-rc.3", default-features = false, features = ["read", "sync"] }
 ```
 
 Use `IsoDir::read_entries` for collection-oriented traversal in either mode,
@@ -285,7 +285,7 @@ through the leaf crate's opt-in `unstable-exfat` feature:
 
 ```toml
 hadris-fat = {
-    version = "2.0.0-rc.2",
+    version = "2.0.0-rc.3",
     features = ["unstable-exfat"]
 }
 ```
@@ -315,7 +315,7 @@ specialized tools.
 
 ## Migration checklist
 
-1. Change dependency requirements to `2.0.0-rc.2`.
+1. Change dependency requirements to `2.0.0-rc.3`.
 2. Make platform, mode, and operation features explicit when disabling defaults.
 3. Move I/O calls to `sync` or `async` namespaces.
 4. Replace deprecated types and fluent setters with canonical names.

--- a/docs/hadris-2.0.0-rc.3-release-notes.md
+++ b/docs/hadris-2.0.0-rc.3-release-notes.md
@@ -1,0 +1,28 @@
+# Hadris 2.0.0-rc.3 Release Notes
+
+Hadris 2.0.0-rc.3 is the final planned API-reset candidate before 2.0.0. It
+corrects contracts discovered during the RC2 optical-format audit. It must soak
+for seven days; any functional change requires RC4 and restarts that period.
+
+## Compatibility changes
+
+- `std` and `sync` are independent in `hadris-io` and `hadris-common`.
+- ISO interchange level 3 is represented by `BaseIsoLevel::Level3`; it is no
+  longer conflated with the ISO 9660:1999 enhanced filename namespace.
+- Allocation-free ISO readers expose `IsoNamespace::Enhanced` and prefer
+  Joliet, then enhanced, then primary roots.
+
+## Correctness fixes
+
+- ISO 9660:1999 enhanced roots are discovered by both reader surfaces, and
+  `has_evd()` has its standards-defined meaning rather than acting as a UDF
+  heuristic.
+- UDF directory layouts use exact padded FID sizes.
+- UDF filenames use conforming OSTA CS0 8-bit or 16-bit encoding with encoded
+  identifier length enforcement.
+
+## Promotion policy
+
+Promotion to 2.0.0 changes only package versions, lockfiles, changelog/release
+metadata, the tag, and publication metadata. The functional source must remain
+identical to this candidate.

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_version="${1:-2.0.0-rc.3}"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "release check failed: working tree is not clean" >&2
+  exit 1
+fi
+
+for tool in cargo git rg python3; do
+  command -v "$tool" >/dev/null || {
+    echo "release check failed: missing required tool: $tool" >&2
+    exit 1
+  }
+done
+
+manifest_versions="$(rg '^version = ' --glob 'Cargo.toml' crates | sed -E 's/.*version = "([^"]+)"/\1/' | sort -u)"
+if [[ "$manifest_versions" != "$expected_version" ]]; then
+  echo "release check failed: publishable manifests are not uniformly $expected_version" >&2
+  echo "$manifest_versions" >&2
+  exit 1
+fi
+
+if rg -n '2\.0\.0-rc\.[12]' Cargo.toml Cargo.lock README.md crates website \
+  --glob '!**/CHANGELOG.md' \
+  --glob '!**/hadris-2.0.0-rc.1-release-notes.md' \
+  --glob '!**/hadris-2.0.0-rc.2-release-notes.md'; then
+  echo "release check failed: stale active RC1/RC2 reference" >&2
+  exit 1
+fi
+
+cargo fmt --all -- --check
+cargo check --workspace --all-features
+cargo test --workspace --all-features
+if [[ "${RELEASE_DEPENDENCIES_PUBLISHED:-0}" == "1" ]]; then
+  cargo package --workspace --allow-dirty
+else
+  # Cargo resolves versioned path dependencies through crates.io while
+  # packaging, even with --no-verify. The dependency-free first wave can be
+  # inspected before publication; rerun with RELEASE_DEPENDENCIES_PUBLISHED=1
+  # after publishing in topological order to inspect and verify all archives.
+  for crate in hadris-fixed hadris-io hadris-path hadris-macros; do
+    cargo package -p "$crate" --allow-dirty
+  done
+fi
+
+echo "release check passed for $expected_version"
+echo "publish in workspace dependency order; do not promote before the soak completes"

--- a/website/docs/creation/fat.md
+++ b/website/docs/creation/fat.md
@@ -1,0 +1,125 @@
+---
+title: Create FAT filesystems
+---
+
+# Create FAT filesystems
+
+`hadris-fat` formats FAT12, FAT16, and FAT32 volumes and then opens the new
+filesystem for mutation. It works with files, memory buffers, partition views,
+and other targets implementing the selected Hadris I/O mode.
+
+## Dependency
+
+```toml
+[dependencies]
+hadris-fat = { version = "2.0.0-rc.3", features = ["write", "sync", "lfn"] }
+```
+
+## Format an image file
+
+The target must already have the desired length. Automatic selection chooses a
+FAT variant from the volume geometry; use `FatTypeSelection` when the format is
+part of an external contract.
+
+```rust
+use std::fs::OpenOptions;
+
+use hadris_fat::format::{FatTypeSelection, FatVolumeFormatter, FormatOptions};
+
+fn main() -> hadris_fat::Result<()> {
+    const SIZE: u64 = 64 * 1024 * 1024;
+
+    let image = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("disk.img")?;
+    image.set_len(SIZE)?;
+
+    let options = FormatOptions::new(SIZE)
+        .volume_label("HADRIS")
+        .fat_type(FatTypeSelection::Fat16);
+
+    let fs = FatVolumeFormatter::format(image, options)?;
+    assert_eq!(fs.volume_info().volume_label(), "HADRIS");
+    Ok(())
+}
+```
+
+Common starting points are roughly 2 MiB for FAT12, 64 MiB for FAT16, and a
+forced FAT32 selection for moderately sized test images. Always let
+`calculate_params` validate the exact geometry instead of relying on a rule of
+thumb.
+
+## Preview the layout
+
+```rust
+use hadris_fat::format::{FatVolumeFormatter, FormatOptions};
+
+let options = FormatOptions::new(64 * 1024 * 1024).volume_label("PREVIEW");
+let params = FatVolumeFormatter::calculate_params(&options)?;
+println!("FAT type: {:?}, clusters: {}", params.fat_type, params.cluster_count);
+# Ok::<(), hadris_fat::Error>(())
+```
+
+This performs validation without writing the target.
+
+## Create directories and files
+
+Mutation methods are supplied by `FatFsWriteExt`. File writers must be finished
+so directory size and cluster-chain metadata are committed.
+
+```rust
+use hadris_fat::FatFsWriteExt;
+
+# fn populate<DATA>(fs: &hadris_fat::FatFs<DATA>) -> hadris_fat::Result<()>
+# where DATA: hadris_fat::io::Read + hadris_fat::io::Write + hadris_fat::io::Seek {
+let root = fs.root_dir();
+let docs = fs.create_dir(&root, "DOCS")?;
+let readme = fs.create_file(&docs, "README.TXT")?;
+
+let mut writer = fs.write_file(&readme)?;
+writer.write(b"Created by Hadris\r\n")?;
+writer.finish()?;
+# Ok(())
+# }
+```
+
+Long filenames require the `lfn` feature. Names that fit FAT's short-name rules
+are stored as 8.3 entries, including the standard lowercase case flags.
+
+## In-memory and async formatting
+
+For tests, format a fixed-size byte buffer:
+
+```rust
+use std::io::Cursor;
+use hadris_fat::format::{FatVolumeFormatter, FormatOptions};
+
+let mut bytes = vec![0_u8; 4 * 1024 * 1024];
+let cursor = Cursor::new(bytes.as_mut_slice());
+let fs = FatVolumeFormatter::format(cursor, FormatOptions::new(bytes.len() as u64))?;
+# Ok::<(), hadris_fat::Error>(())
+```
+
+The same formatter name exists in `hadris_fat::r#async` when the crate is built
+with `async`. Enable exactly the I/O mode your application uses; `std` does not
+implicitly select `sync`.
+
+## Format a partition rather than a whole disk
+
+Create or open the partition table with `hadris-part`, obtain a bounded
+partition view, and pass that view to `FatVolumeFormatter`. The formatter sees
+sector zero relative to the partition and cannot write outside the view.
+
+## Validate the result
+
+```bash
+fsck.fat -vn disk.img
+7z l disk.img
+hadris-fat info disk.img
+```
+
+Use read-only validation first. Do not allow a repair tool to modify a release
+artifact until its original image has been preserved.

--- a/website/docs/creation/iso.md
+++ b/website/docs/creation/iso.md
@@ -1,0 +1,159 @@
+---
+title: Create ISO images
+---
+
+# Create ISO 9660 images
+
+Use `hadris-iso` to create a seekable ISO image from an in-memory input tree.
+The writer can emit the primary ISO namespace, ISO 9660:1999 enhanced names,
+Joliet, Rock Ridge, and El Torito boot metadata. Creation currently uses the
+synchronous API and requires a target implementing `Read + Write + Seek`.
+
+## Dependency
+
+```toml
+[dependencies]
+hadris-iso = { version = "2.0.0-rc.3", features = ["write", "sync", "joliet"] }
+```
+
+## Create a basic image
+
+`InputTree` describes the directory hierarchy. `IsoImageWriter::create`
+returns the target so the caller retains ownership of the completed image.
+
+```rust
+use std::fs::OpenOptions;
+
+use hadris_iso::read::PathSeparator;
+use hadris_iso::write::options::{CreationFeatures, FormatOptions};
+use hadris_iso::write::{InputEntry, InputTree, IsoImageWriter};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tree = InputTree::new(
+        PathSeparator::ForwardSlash,
+        vec![
+            InputEntry::file("README.TXT", b"Hello from Hadris\n"),
+            InputEntry::directory(
+                "DOCS",
+                vec![InputEntry::file("GUIDE.TXT", b"Getting started\n")],
+            ),
+        ],
+    );
+
+    let options = FormatOptions {
+        volume_name: "HADRIS_DEMO".into(),
+        system_id: None,
+        volume_set_id: None,
+        publisher_id: None,
+        preparer_id: Some("HADRIS".into()),
+        application_id: Some("MY_APP".into()),
+        sector_size: 2048,
+        features: CreationFeatures::default(),
+        path_separator: PathSeparator::ForwardSlash,
+        strict_charset: true,
+    };
+
+    let image = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("demo.iso")?;
+    let _image = IsoImageWriter::create(image, tree, options)?;
+    Ok(())
+}
+```
+
+The output file does not need to be pre-sized. Keep `sector_size` at 2048 for
+optical interoperability.
+
+## Enable filename namespaces
+
+The base interchange level and additional filename namespaces are independent:
+
+```rust
+use hadris_iso::joliet::JolietLevel;
+use hadris_iso::write::options::{BaseIsoLevel, CreationFeatures};
+
+let portable = CreationFeatures {
+    filenames: BaseIsoLevel::Level2 {
+        supports_lowercase: false,
+        supports_rrip: false,
+    },
+    joliet: Some(JolietLevel::Level3),
+    ..CreationFeatures::default()
+};
+
+let iso_1999 = CreationFeatures {
+    // Compatibility spelling for the ISO 9660:1999 enhanced namespace.
+    long_filenames: true,
+    ..CreationFeatures::default()
+};
+```
+
+`BaseIsoLevel::Level3` selects interchange level 3; it is not the switch for
+ISO 9660:1999 names. The `long_filenames` field is retained for compatibility.
+Joliet is usually the most interoperable choice for Unicode names.
+
+## Preserve POSIX metadata with Rock Ridge
+
+```rust
+use hadris_iso::write::options::CreationFeatures;
+use hadris_iso::write::{InputEntry, InputMetadata};
+
+let entry = InputEntry::file("run.sh", b"#!/bin/sh\necho hello\n").with_metadata(
+    InputMetadata {
+        mode: Some(0o755),
+        uid: Some(1000),
+        gid: Some(1000),
+        modified: Some(1_700_000_000),
+        ..InputMetadata::default()
+    },
+);
+
+let features = CreationFeatures::rock_ridge();
+```
+
+Explicit timestamps make builds reproducible. Host filesystem scanning can
+populate metadata, but inputs constructed in code give the caller full control.
+
+## Create from a host directory
+
+```rust
+use std::path::Path;
+use hadris_iso::read::PathSeparator;
+use hadris_iso::write::InputTree;
+
+let tree = InputTree::from_fs(
+    Path::new("image-root"),
+    PathSeparator::ForwardSlash,
+)?;
+# Ok::<(), hadris_iso::write::FileConversionError>(())
+```
+
+The current host-directory convenience API loads regular-file contents into
+memory. For very large trees, construct inputs deliberately and budget memory
+accordingly.
+
+## Bootable and hybrid images
+
+El Torito and hybrid MBR/GPT options live under `CreationFeatures`. For a full
+boot-catalog example, run:
+
+```bash
+cargo run -p hadris-iso --example create_bootable_iso
+```
+
+Use `hadris-cd` instead when the same payload must be visible through both ISO
+9660 and UDF namespaces.
+
+## Validate the result
+
+```bash
+xorriso -indev demo.iso -toc
+7z l demo.iso
+hadris-iso info demo.iso
+```
+
+Treat external validation as part of release testing, especially for bootable,
+enhanced-namespace, and hybrid images.

--- a/website/docs/creation/udf.md
+++ b/website/docs/creation/udf.md
@@ -1,0 +1,128 @@
+---
+title: Create UDF filesystems
+---
+
+# Create UDF filesystems
+
+`hadris-udf` creates mastered, read-only Type-1 UDF images on a seekable target.
+The high-level tree API is appropriate for standalone images; `hadris-cd`
+should be used when authoring a shared ISO/UDF bridge image.
+
+## Dependency
+
+```toml
+[dependencies]
+hadris-udf = { version = "2.0.0-rc.3", features = ["write", "sync"] }
+```
+
+## Create a directory tree
+
+`SimpleDir` and `SimpleFile` own their payloads. Sort the tree when deterministic
+directory ordering matters.
+
+```rust
+use std::fs::OpenOptions;
+
+use hadris_udf::write::{SimpleDir, SimpleFile, UdfWriteOptions, UdfWriter};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut root = SimpleDir::root();
+    root.add_file(SimpleFile::new(
+        "README.txt",
+        b"Hello from a UDF image\n".to_vec(),
+    ));
+
+    let mut docs = SimpleDir::new("docs");
+    docs.add_file(SimpleFile::new("guide.txt", b"UDF guide\n".to_vec()));
+    root.add_dir(docs);
+    root.sort();
+
+    let target = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("volume.udf")?;
+
+    let output = UdfWriter::create(target, &root, UdfWriteOptions::default())?;
+    println!("wrote {} sectors", output.sectors_written);
+    let _target = output.into_inner();
+    Ok(())
+}
+```
+
+The output reports the number of 2048-byte sectors used and returns the target.
+Unlike FAT formatting, the standalone UDF writer lays out and grows an ordinary
+file as it writes, so it does not need to be pre-sized.
+
+## Select a mastered revision
+
+```rust
+use hadris_udf::UdfRevision;
+use hadris_udf::write::UdfWriteOptions;
+
+let options = UdfWriteOptions {
+    volume_id: "ARCHIVE_2026".into(),
+    revision: UdfRevision::V2_01,
+    ..UdfWriteOptions::default()
+};
+```
+
+The revision describes a mastered/read-only Type-1 image. It does not enable
+packet writing, VAT, sparing, metadata partitions, or pseudo-overwrite. Choose
+the oldest revision that provides the compatibility your consumers need, and
+validate it with the tools used by those consumers.
+
+## Unicode names and limits
+
+Filenames are encoded with OSTA Compressed Unicode (CS0). Hadris selects 8-bit
+compression for names representable in one byte per character and 16-bit
+compression otherwise. A filename whose encoded FID identifier exceeds 255
+bytes is rejected rather than truncated.
+
+The high-level API currently owns every file payload in memory. Very large
+payloads and live streaming are outside this convenience surface.
+
+## Create an in-memory image
+
+Preallocate enough space when the target is a bounded cursor:
+
+```rust
+use std::io::Cursor;
+use hadris_udf::write::{SimpleDir, SimpleFile, UdfWriteOptions, UdfWriter};
+
+let mut root = SimpleDir::root();
+root.add_file(SimpleFile::new("hello.txt", b"hello\n".to_vec()));
+
+let mut storage = vec![0_u8; 8 * 1024 * 1024];
+let cursor = Cursor::new(storage.as_mut_slice());
+let output = UdfWriter::create(cursor, &root, UdfWriteOptions::default())?;
+assert!(output.sectors_written > 0);
+# Ok::<(), hadris_udf::UdfError>(())
+```
+
+## Author an ISO/UDF bridge
+
+Do not independently concatenate ISO and UDF images. A bridge must coordinate
+descriptor locations, directory ICBs, and payload extents. Use the bridge crate
+or CLI:
+
+```bash
+hadris-cd create image-root bridge.iso
+hadris-cd verify bridge.iso
+```
+
+The verifier compares both namespace trees and confirms that shared files are
+readable through ISO and UDF.
+
+## Validate the result
+
+```bash
+udfinfo volume.udf
+7z l volume.udf
+hadris-udf info volume.udf
+```
+
+For interoperability work, also create reference images with `mkudffs` and
+confirm that Hadris can read them. Validation should cover every UDF revision
+your application accepts.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -9,10 +9,10 @@ Choose the narrowest crate that covers your application:
 ```toml
 [dependencies]
 # A single filesystem:
-hadris-fat = "2.0.0-rc.2"
+hadris-fat = "2.0.0-rc.3"
 
 # Or several storage categories:
-hadris = { version = "2.0.0-rc.2", features = ["block", "optical"] }
+hadris = { version = "2.0.0-rc.3", features = ["block", "optical"] }
 ```
 
 Hadris separates platform support, I/O mode, and capabilities. For a
@@ -21,7 +21,7 @@ freestanding read-only FAT consumer:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.0.0-rc.2",
+  version = "2.0.0-rc.3",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/build-initramfs.md
+++ b/website/docs/guides/build-initramfs.md
@@ -6,7 +6,7 @@ title: Build a CPIO initramfs
 
 ```toml
 [dependencies]
-hadris-cpio = "2.0.0-rc.2"
+hadris-cpio = "2.0.0-rc.3"
 ```
 
 ```rust

--- a/website/docs/guides/no-std.md
+++ b/website/docs/guides/no-std.md
@@ -10,7 +10,7 @@ that the target needs:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.0.0-rc.2",
+  version = "2.0.0-rc.3",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/read-and-create-iso.md
+++ b/website/docs/guides/read-and-create-iso.md
@@ -1,8 +1,10 @@
 ---
-title: Read and create ISO images
+title: Read ISO images
 ---
 
-# Read and create ISO 9660 images
+# Read ISO 9660 images
+
+For authoring, see the dedicated [ISO filesystem creation guide](../creation/iso.md).
 
 The ISO crate includes runnable examples for the common workflows:
 
@@ -12,8 +14,8 @@ cargo run -p hadris-iso --example extract_files -- image.iso output/
 cargo run -p hadris-iso --example create_bootable_iso
 ```
 
-The reader supports ISO 9660 namespaces, Joliet, Rock Ridge/SUSP, and El Torito
-metadata. Image creation is synchronous; reading is available through both the
+The reader supports the primary and ISO 9660:1999 enhanced namespaces, Joliet,
+Rock Ridge/SUSP, and El Torito metadata. Reading is available through both the
 sync and async APIs.
 
 Use `hadris-optical` when an application must detect and open ISO-only,

--- a/website/docs/guides/read-fat-image.md
+++ b/website/docs/guides/read-fat-image.md
@@ -6,7 +6,7 @@ title: Read a FAT image
 
 ```toml
 [dependencies]
-hadris-fat = "2.0.0-rc.2"
+hadris-fat = "2.0.0-rc.3"
 ```
 
 ```rust

--- a/website/docs/guides/read-partition-table.md
+++ b/website/docs/guides/read-partition-table.md
@@ -6,7 +6,7 @@ title: Read a partition table
 
 ```toml
 [dependencies]
-hadris-part = "2.0.0-rc.2"
+hadris-part = "2.0.0-rc.3"
 ```
 
 ```rust

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -18,7 +18,7 @@ and asynchronous feature tiers.
 
 :::caution Release candidate
 
-`2.0.0-rc.2` freezes the intended V2 public API while downstream testing is in
+`2.0.0-rc.3` freezes the intended V2 public API while downstream testing is in
 progress. The `unstable-exfat` feature remains outside that stability promise.
 
 :::

--- a/website/docs/release-candidate.md
+++ b/website/docs/release-candidate.md
@@ -1,14 +1,14 @@
 ---
-title: 2.0.0-rc.2
+title: 2.0.0-rc.3
 ---
 
-# Hadris 2.0.0-rc.2
+# Hadris 2.0.0-rc.3
 
 This release candidate freezes the intended V2 public surface while correctness,
 interoperability, documentation, and release engineering continue.
 
 Read the complete
-[release notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-rc.2-release-notes.md)
+[release notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-rc.3-release-notes.md)
 and report real-world compatibility findings through
 [GitHub Issues](https://github.com/hxyulin/hadris/issues).
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   onBrokenLinks: "throw",
   markdown: {
     hooks: {
-      onBrokenMarkdownLinks: "warn",
+      onBrokenMarkdownLinks: "throw",
     },
   },
   i18n: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hadris-docs",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hadris-docs",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.3",
       "dependencies": {
         "@docusaurus/core": "3.10.2",
         "@docusaurus/preset-classic": "3.10.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hadris-docs",
   "private": true,
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.3",
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -17,6 +17,15 @@ module.exports = {
     },
     {
       type: "category",
+      label: "Filesystem creation",
+      items: [
+        "creation/iso",
+        "creation/fat",
+        "creation/udf",
+      ],
+    },
+    {
+      type: "category",
       label: "Migration",
       items: ["migration/v1-to-v2"],
     },


### PR DESCRIPTION
## Summary

- bump all workspace crates, lockfiles, examples, and website metadata to 2.0.0-rc.3
- correct ISO 9660 Level 3 and enhanced-namespace behavior
- fix UDF CS0 encoding and exact FID extent planning
- decouple std and sync feature selection
- add RC3 release tooling, notes, and extensive ISO/FAT/UDF creation guides

## Verification

- full workspace tests with all features
- Clippy with warnings denied
- public API snapshots
- spec annotation checker
- Docusaurus production build with broken links treated as errors
- available xorriso, udfinfo, mkudffs, and 7-Zip interoperability tests

After required checks pass, this PR is ready for maintainer merge into main.