### PR TITLE
fix: deepen filesystem specification compliance

### DIFF
--- a/api-snapshots/hadris-fat.txt
+++ b/api-snapshots/hadris-fat.txt
@@ -261,7 +261,7 @@ pub fn hadris_fat::async::fat_table::Fat32::max_cluster(&self) -> u32
 pub fn hadris_fat::async::fat_table::Fat32::new(usize, usize, usize, u32) -> Self
 pub async fn hadris_fat::async::fat_table::Fat32::next_cluster<T: hadris_io::async_api::Read + hadris_io::async_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<core::option::Option<u32>>
 pub async fn hadris_fat::async::fat_table::Fat32::truncate_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u32) -> hadris_fat::error::Result<u32>
-pub async fn hadris_fat::async::fat_table::Fat32::write_clus<T: hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
+pub async fn hadris_fat::async::fat_table::Fat32::write_clus<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
 pub mod hadris_fat::async::format
 pub enum hadris_fat::async::format::FatTypeSelection
 pub hadris_fat::async::format::FatTypeSelection::Auto
@@ -535,7 +535,7 @@ pub fn hadris_fat::async::fat_table::Fat32::max_cluster(&self) -> u32
 pub fn hadris_fat::async::fat_table::Fat32::new(usize, usize, usize, u32) -> Self
 pub async fn hadris_fat::async::fat_table::Fat32::next_cluster<T: hadris_io::async_api::Read + hadris_io::async_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<core::option::Option<u32>>
 pub async fn hadris_fat::async::fat_table::Fat32::truncate_chain<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, u32) -> hadris_fat::error::Result<u32>
-pub async fn hadris_fat::async::fat_table::Fat32::write_clus<T: hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
+pub async fn hadris_fat::async::fat_table::Fat32::write_clus<T: hadris_io::async_api::Read + hadris_io::async_api::Write + hadris_io::async_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
 pub struct hadris_fat::async::FatDateTime
 pub hadris_fat::async::FatDateTime::date: u16
 pub hadris_fat::async::FatDateTime::time: u16
@@ -963,7 +963,7 @@ pub fn hadris_fat::fat_table::Fat32::max_cluster(&self) -> u32
 pub fn hadris_fat::fat_table::Fat32::new(usize, usize, usize, u32) -> Self
 pub fn hadris_fat::fat_table::Fat32::next_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<core::option::Option<u32>>
 pub fn hadris_fat::fat_table::Fat32::truncate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u32) -> hadris_fat::error::Result<u32>
-pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
+pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
 impl hadris_fat::fat_table::Fat32
 pub fn hadris_fat::fat_table::Fat32::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u32>
 pub mod hadris_fat::file
@@ -1784,7 +1784,7 @@ pub fn hadris_fat::fat_table::Fat32::max_cluster(&self) -> u32
 pub fn hadris_fat::fat_table::Fat32::new(usize, usize, usize, u32) -> Self
 pub fn hadris_fat::fat_table::Fat32::next_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<core::option::Option<u32>>
 pub fn hadris_fat::fat_table::Fat32::truncate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u32) -> hadris_fat::error::Result<u32>
-pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
+pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
 impl hadris_fat::fat_table::Fat32
 pub fn hadris_fat::fat_table::Fat32::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u32>
 pub mod hadris_fat::sync::format
@@ -2242,7 +2242,7 @@ pub fn hadris_fat::fat_table::Fat32::max_cluster(&self) -> u32
 pub fn hadris_fat::fat_table::Fat32::new(usize, usize, usize, u32) -> Self
 pub fn hadris_fat::fat_table::Fat32::next_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<core::option::Option<u32>>
 pub fn hadris_fat::fat_table::Fat32::truncate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u32) -> hadris_fat::error::Result<u32>
-pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
+pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
 impl hadris_fat::fat_table::Fat32
 pub fn hadris_fat::fat_table::Fat32::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u32>
 pub struct hadris_fat::sync::FatDateTime
@@ -2703,7 +2703,7 @@ pub fn hadris_fat::fat_table::Fat32::max_cluster(&self) -> u32
 pub fn hadris_fat::fat_table::Fat32::new(usize, usize, usize, u32) -> Self
 pub fn hadris_fat::fat_table::Fat32::next_cluster<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<core::option::Option<u32>>
 pub fn hadris_fat::fat_table::Fat32::truncate_chain<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, u32) -> hadris_fat::error::Result<u32>
-pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
+pub fn hadris_fat::fat_table::Fat32::write_clus<T: hadris_io::sync_api::Read + hadris_io::sync_api::Write + hadris_io::sync_api::Seek>(&self, &mut T, usize, u32) -> hadris_fat::error::Result<()>
 impl hadris_fat::fat_table::Fat32
 pub fn hadris_fat::fat_table::Fat32::read_entry<T: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>(&self, &mut T, usize) -> hadris_fat::error::Result<u32>
 pub struct hadris_fat::FatDateTime

--- a/crates/archive/hadris-cpio/src/header.rs
+++ b/crates/archive/hadris-cpio/src/header.rs
@@ -73,6 +73,20 @@ impl RawNewcHeader {
         Ok(Self { data })
     }
 
+    /// Read a header, returning `None` only when input is exhausted before any
+    /// header byte is read.
+    ///
+    /// A partially present header remains an error.
+    pub async fn parse_optional<R: Read>(reader: &mut R) -> Result<Option<Self>> {
+        let mut data = [0u8; HEADER_SIZE];
+        let read = reader.read(&mut data[..1]).await?;
+        if read == 0 {
+            return Ok(None);
+        }
+        reader.read_exact(&mut data[read..]).await?;
+        Ok(Some(Self { data }))
+    }
+
     /// Write this header to the given writer.
     pub async fn write<W: Write>(&self, writer: &mut W) -> Result<()> {
         writer.write_all(&self.data).await?;

--- a/crates/archive/hadris-cpio/src/header.rs
+++ b/crates/archive/hadris-cpio/src/header.rs
@@ -77,7 +77,7 @@ impl RawNewcHeader {
     /// header byte is read.
     ///
     /// A partially present header remains an error.
-    pub async fn parse_optional<R: Read>(reader: &mut R) -> Result<Option<Self>> {
+    pub(crate) async fn parse_optional<R: Read>(reader: &mut R) -> Result<Option<Self>> {
         let mut data = [0u8; HEADER_SIZE];
         let read = reader.read(&mut data[..1]).await?;
         if read == 0 {

--- a/crates/archive/hadris-cpio/src/read.rs
+++ b/crates/archive/hadris-cpio/src/read.rs
@@ -179,8 +179,11 @@ impl<R: Read> CpioArchiveReader<R> {
 
         let entry_offset = self.offset;
 
-        // Read the 110-byte header
-        let raw = RawNewcHeader::parse(&mut self.reader).await?;
+        // A trailer is optional when input ends at an entry boundary.
+        let Some(raw) = RawNewcHeader::parse_optional(&mut self.reader).await? else {
+            self.finished = true;
+            return Ok(None);
+        };
         self.offset += HEADER_SIZE as u64;
 
         let magic = raw.magic().ok_or_else(|| {
@@ -379,7 +382,10 @@ impl<R: Read> CpioArchiveReader<R> {
 
         let entry_offset = self.offset;
 
-        let raw = RawNewcHeader::parse(&mut self.reader).await?;
+        let Some(raw) = RawNewcHeader::parse_optional(&mut self.reader).await? else {
+            self.finished = true;
+            return Ok(None);
+        };
         self.offset += HEADER_SIZE as u64;
 
         let magic = raw.magic().ok_or_else(|| {

--- a/crates/archive/hadris-cpio/tests/roundtrip.rs
+++ b/crates/archive/hadris-cpio/tests/roundtrip.rs
@@ -341,12 +341,85 @@ fn alignment_padding_edge_cases() {
 }
 
 #[test]
+fn reader_rejects_nonzero_name_and_data_padding() {
+    let mut tree = FileTree::new();
+    tree.add(FileNode::file("ab", b"xy".to_vec(), 0o644));
+    let archive = write_archive(&tree, false);
+
+    // HEADER_SIZE + namesize ("ab\0") is 113, so bytes 113..116 pad the name.
+    let mut bad_name_padding = archive.clone();
+    bad_name_padding[113] = 1;
+    let mut reader = CpioArchiveReader::new(bad_name_padding.as_slice());
+    assert!(matches!(
+        reader.next_entry_alloc(),
+        Err(hadris_cpio::Error::InvalidHeader {
+            reason: "alignment padding must be zero"
+        })
+    ));
+
+    // The two-byte body starts at 116, so bytes 118..120 pad the data.
+    let mut bad_data_padding = archive;
+    bad_data_padding[118] = 1;
+    let mut reader = CpioArchiveReader::new(bad_data_padding.as_slice());
+    let entry = reader.next_entry_alloc().unwrap().unwrap();
+    assert!(matches!(
+        reader.read_entry_data_alloc(&entry),
+        Err(hadris_cpio::Error::InvalidHeader {
+            reason: "alignment padding must be zero"
+        })
+    ));
+}
+
+#[test]
 fn trailer_detection() {
     // An archive with no entries should still have a TRAILER
     let tree = FileTree::new();
     let archive = write_archive(&tree, false);
     let mut reader = CpioArchiveReader::new(archive.as_slice());
     assert!(reader.next_entry_alloc().unwrap().is_none());
+}
+
+#[test]
+fn reader_rejects_trailer_with_nonzero_filesize() {
+    let tree = FileTree::new();
+    let mut archive = write_archive(&tree, false);
+    archive[54..62].copy_from_slice(b"00000001");
+
+    let mut reader = CpioArchiveReader::new(archive.as_slice());
+    assert!(matches!(
+        reader.next_entry_alloc(),
+        Err(hadris_cpio::Error::InvalidHeader {
+            reason: "TRAILER!!! c_filesize must be zero"
+        })
+    ));
+}
+
+#[test]
+fn reader_accepts_aligned_eof_without_trailer() {
+    let mut tree = FileTree::new();
+    tree.add(FileNode::file("ab", b"xy".to_vec(), 0o644));
+    let archive = write_archive(&tree, false);
+
+    let trailer_offset = {
+        let mut reader = CpioArchiveReader::new(archive.as_slice());
+        let entry = reader.next_entry_alloc().unwrap().unwrap();
+        reader.read_entry_data_alloc(&entry).unwrap();
+        reader.offset() as usize
+    };
+    let trailerless = &archive[..trailer_offset];
+
+    let mut reader = CpioArchiveReader::new(trailerless);
+    let entry = reader.next_entry_alloc().unwrap().unwrap();
+    assert_eq!(reader.read_entry_data_alloc(&entry).unwrap(), b"xy");
+    assert!(reader.next_entry_alloc().unwrap().is_none());
+
+    let mut reader = CpioArchiveReader::new(trailerless);
+    let mut name = [0_u8; 8];
+    let entry = reader.next_entry_with_buf(&mut name).unwrap().unwrap();
+    let mut data = [0_u8; 2];
+    reader.read_entry_data(&entry, &mut data).unwrap();
+    assert_eq!(&data, b"xy");
+    assert!(reader.next_entry_with_buf(&mut name).unwrap().is_none());
 }
 
 #[test]

--- a/crates/block/hadris-fat/src/cache.rs
+++ b/crates/block/hadris-fat/src/cache.rs
@@ -586,7 +586,13 @@ impl FatSectorCache {
         let offset_in_sector = byte_offset % sector_size;
 
         let data = self.get_sector_mut(io, sector)?;
-        let bytes = value.to_le_bytes();
+        let existing = u32::from_le_bytes([
+            data[offset_in_sector],
+            data[offset_in_sector + 1],
+            data[offset_in_sector + 2],
+            data[offset_in_sector + 3],
+        ]);
+        let bytes = ((existing & 0xF000_0000) | (value & 0x0FFF_FFFF)).to_le_bytes();
         data[offset_in_sector] = bytes[0];
         data[offset_in_sector + 1] = bytes[1];
         data[offset_in_sector + 2] = bytes[2];

--- a/crates/block/hadris-fat/src/exfat/boot.rs
+++ b/crates/block/hadris-fat/src/exfat/boot.rs
@@ -239,16 +239,13 @@ impl ExFatBootSector {
     /// The checksum is computed over sectors 0-10 and stored in sector 11.
     /// This validates both the main boot region and optionally the backup.
     pub fn validate_checksum<DATA: Read + Seek>(data: &mut DATA, sector_size: usize) -> Result<()> {
-        // Read sectors 0-10 and compute checksum
         let mut checksum: u32 = 0;
+        let mut sector_data = [0_u8; 4096];
 
         for sector in 0..11 {
             data.seek(SeekFrom::Start(sector as u64 * sector_size as u64))?;
-
-            for byte_idx in 0..sector_size {
-                let mut byte = [0u8; 1];
-                data.read_exact(&mut byte)?;
-
+            data.read_exact(&mut sector_data[..sector_size])?;
+            for (byte_idx, &byte) in sector_data[..sector_size].iter().enumerate() {
                 // Skip VolumeFlags (bytes 106-107) and PercentInUse (byte 112)
                 // in sector 0 as they may change
                 if sector == 0 && (byte_idx == 106 || byte_idx == 107 || byte_idx == 112) {
@@ -256,7 +253,7 @@ impl ExFatBootSector {
                 }
 
                 // Rotate right and add
-                checksum = checksum.rotate_right(1).wrapping_add(byte[0] as u32);
+                checksum = checksum.rotate_right(1).wrapping_add(byte as u32);
             }
         }
 

--- a/crates/block/hadris-fat/src/exfat/entry.rs
+++ b/crates/block/hadris-fat/src/exfat/entry.rs
@@ -340,6 +340,9 @@ pub fn parse_entry_set(entries: &[RawDirectoryEntry]) -> Option<(ExFatFileEntry,
     if entries.len() < total_entries {
         return None; // Not enough entries
     }
+    if compute_entry_set_checksum(&entries[..total_entries]) != primary.set_checksum.get() {
+        return None;
+    }
 
     // Second entry must be a Stream Extension Entry
     let stream = unsafe { &entries[1].stream };

--- a/crates/block/hadris-fat/src/exfat/entry.rs
+++ b/crates/block/hadris-fat/src/exfat/entry.rs
@@ -296,7 +296,6 @@ impl ExFatFileEntry {
 ///
 /// The checksum is computed over all entries in the set, with the
 /// set_checksum field (bytes 2-3 of the primary entry) set to zero.
-#[cfg(feature = "write")]
 pub fn compute_entry_set_checksum(entries: &[RawDirectoryEntry]) -> u16 {
     let mut checksum: u16 = 0;
 

--- a/crates/block/hadris-fat/src/exfat/entry_writer.rs
+++ b/crates/block/hadris-fat/src/exfat/entry_writer.rs
@@ -236,6 +236,7 @@ fn to_raw_entry<T: bytemuck::NoUninit>(entry: &T) -> RawDirectoryEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exfat::entry::parse_entry_set;
 
     #[test]
     fn test_entry_set_builder() {
@@ -253,6 +254,18 @@ mod tests {
             entry_type::STREAM_EXTENSION
         );
         assert_eq!(unsafe { entries[2].entry_type }, entry_type::FILE_NAME);
+    }
+
+    #[test]
+    fn parser_rejects_an_invalid_entry_set_checksum() {
+        let upcase = UpcaseTable::create_default();
+        let builder = EntrySetBuilder::file("test.txt").unwrap();
+        let mut entries = builder.build(&upcase);
+        unsafe {
+            entries[2].bytes[2] ^= 1;
+        }
+
+        assert!(parse_entry_set(&entries).is_none());
     }
 
     #[test]

--- a/crates/block/hadris-fat/src/exfat/fs.rs
+++ b/crates/block/hadris-fat/src/exfat/fs.rs
@@ -61,6 +61,7 @@ where
         // Read and validate the boot sector
         let boot = ExFatBootSector::read(&mut data)?;
         let info = boot.info().clone();
+        ExFatBootSector::validate_checksum(&mut data, info.bytes_per_sector)?;
 
         // Create sector cursor
         let cursor = SectorCursor::new(data, info.bytes_per_sector, info.bytes_per_cluster);
@@ -111,16 +112,18 @@ where
                         // We'll load the upcase table after this loop
                         let first_cluster = upcase_entry.first_cluster.get();
                         let size = upcase_entry.data_length.get();
+                        let checksum = upcase_entry.table_checksum.get();
 
                         // Load immediately since we have the guard
                         drop(guard);
                         let mut guard2 = data.lock();
-                        upcase.load(
+                        upcase.load_checked(
                             &mut guard2.data,
                             &info,
                             first_cluster,
                             size,
                             true, // Assume contiguous
+                            checksum,
                         )?;
                         guard = guard2;
                     }

--- a/crates/block/hadris-fat/src/exfat/upcase.rs
+++ b/crates/block/hadris-fat/src/exfat/upcase.rs
@@ -50,6 +50,38 @@ impl UpcaseTable {
         size: u64,
         is_contiguous: bool,
     ) -> Result<()> {
+        self.load_impl(data, info, first_cluster, size, is_contiguous, None)
+    }
+
+    /// Load an up-case table and validate it against its directory-entry checksum.
+    pub fn load_checked<DATA: Read + Seek>(
+        &mut self,
+        data: &mut DATA,
+        info: &ExFatInfo,
+        first_cluster: u32,
+        size: u64,
+        is_contiguous: bool,
+        expected_checksum: u32,
+    ) -> Result<()> {
+        self.load_impl(
+            data,
+            info,
+            first_cluster,
+            size,
+            is_contiguous,
+            Some(expected_checksum),
+        )
+    }
+
+    fn load_impl<DATA: Read + Seek>(
+        &mut self,
+        data: &mut DATA,
+        info: &ExFatInfo,
+        first_cluster: u32,
+        size: u64,
+        is_contiguous: bool,
+        expected_checksum: Option<u32>,
+    ) -> Result<()> {
         // `size` is the untrusted `data_length` of the up-case table directory
         // entry — a full u64. Bound it against the volume's cluster heap before
         // allocating, otherwise a corrupt entry in a tiny image could claim
@@ -75,6 +107,13 @@ impl UpcaseTable {
             return Err(Error::UnsupportedFatType(
                 "fragmented exFAT upcase table not yet supported",
             ));
+        }
+
+        if let Some(expected) = expected_checksum {
+            let found = compute_upcase_checksum(&raw_data);
+            if found != expected {
+                return Err(Error::ExFatInvalidChecksum { expected, found });
+            }
         }
 
         // Decompress the table

--- a/crates/block/hadris-fat/src/exfat/upcase.rs
+++ b/crates/block/hadris-fat/src/exfat/upcase.rs
@@ -246,7 +246,6 @@ impl Default for UpcaseTable {
 }
 
 /// Compute the checksum for an up-case table.
-#[cfg(feature = "write")]
 pub fn compute_upcase_checksum(data: &[u8]) -> u32 {
     let mut checksum: u32 = 0;
 

--- a/crates/block/hadris-fat/src/fat_table.rs
+++ b/crates/block/hadris-fat/src/fat_table.rs
@@ -1160,29 +1160,34 @@ impl Fat32 {
 
     /// Write a cluster entry to the FAT table at the specified FAT copy
     #[cfg(feature = "write")]
-    async fn write_clus_at<T: Write + Seek>(
+    async fn write_clus_at<T: Read + Write + Seek>(
         &self,
-        writer: &mut T,
+        io: &mut T,
         cluster: usize,
         value: u32,
         fat_index: usize,
     ) -> Result<()> {
         let offset = self.start + fat_index * self.size + cluster * size_of::<u32>();
-        writer.seek(SeekFrom::Start(offset as u64)).await?;
-        writer.write_all(&value.to_le_bytes()).await?;
+        io.seek(SeekFrom::Start(offset as u64)).await?;
+        let mut existing = [0_u8; size_of::<u32>()];
+        io.read_exact(&mut existing).await?;
+        let preserved = u32::from_le_bytes(existing) & !Self::ENTRY_MASK;
+        let updated = preserved | (value & Self::ENTRY_MASK);
+        io.seek(SeekFrom::Start(offset as u64)).await?;
+        io.write_all(&updated.to_le_bytes()).await?;
         Ok(())
     }
 
     /// Write a cluster entry to all FAT table copies
     #[cfg(feature = "write")]
-    pub async fn write_clus<T: Write + Seek>(
+    pub async fn write_clus<T: Read + Write + Seek>(
         &self,
-        writer: &mut T,
+        io: &mut T,
         cluster: usize,
         value: u32,
     ) -> Result<()> {
         for i in 0..self.count {
-            self.write_clus_at(writer, cluster, value, i).await?;
+            self.write_clus_at(io, cluster, value, i).await?;
         }
         Ok(())
     }

--- a/crates/block/hadris-fat/src/format/calc.rs
+++ b/crates/block/hadris-fat/src/format/calc.rs
@@ -78,6 +78,12 @@ pub fn calculate_params(options: &FatFormatOptions) -> Result<FormatParams> {
             reason: "must be a power of 2 and <= 128",
         });
     }
+    if sectors_per_cluster as usize * sector_size > 32 * 1024 {
+        return Err(Error::InvalidFormatOption {
+            option: "sectors_per_cluster",
+            reason: "cluster size must not exceed 32 KiB",
+        });
+    }
 
     // Calculate reserved sectors
     let reserved_sectors: u16 = match fat_type {

--- a/crates/block/hadris-fat/src/fs.rs
+++ b/crates/block/hadris-fat/src/fs.rs
@@ -355,6 +355,11 @@ where
             });
         }
         let cluster_size = (bpb.sectors_per_cluster as usize) * sector_size;
+        if cluster_size > 32 * 1024 {
+            return Err(Error::CorruptFilesystem {
+                context: "BPB cluster size must not exceed 32 KiB",
+            });
+        }
         let data = SectorCursor::new(data, sector_size, cluster_size);
 
         // Determine FAT type by checking root_entry_count and sectors_per_fat_16
@@ -542,6 +547,11 @@ where
         let signature = bpb_ext32.signature_word.get();
         if signature != 0xAA55 {
             return Err(Error::InvalidBootSignature { found: signature });
+        }
+        if bpb_ext32.version != [0, 0] {
+            return Err(Error::CorruptFilesystem {
+                context: "unsupported FAT32 filesystem version",
+            });
         }
 
         // FAT requires 1 or 2 file allocation tables (BPB_NumFATs) — see the

--- a/crates/block/hadris-fat/tests/cache_integration.rs
+++ b/crates/block/hadris-fat/tests/cache_integration.rs
@@ -158,6 +158,37 @@ fn cache_writes_persist_across_remount_after_flush() {
     let _ = FatVolume::open(Cursor::new(&bytes[..])).expect("re-open after flush");
 }
 
+#[test]
+fn cache_fat32_writes_preserve_reserved_high_bits() {
+    let mut bytes = vec![0u8; FAT32_SIZE];
+    let opts = fat32_options();
+    let layout = format_into_buffer(&mut bytes, &opts);
+    patch_fat32_entry_all_copies(&mut bytes, &layout, 100, 0xA000_0000);
+
+    {
+        let cursor = Cursor::new(&mut bytes[..]);
+        let fs = FatVolume::builder(cursor)
+            .fat_cache(8)
+            .open()
+            .expect("open");
+        fs.with_fat_cache_locked(|cache, disk| {
+            cache
+                .write_fat32_entry(disk, 100, 0x0FFF_FFF7)
+                .expect("write_fat32_entry");
+        })
+        .expect("with_fat_cache_locked");
+        fs.flush().expect("flush");
+    }
+
+    for copy in 0..layout.fat_count {
+        let offset = layout.fat32_entry_offset(copy, 100);
+        assert_eq!(
+            u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()),
+            0xAFFF_FFF7
+        );
+    }
+}
+
 // =============================================================================
 // Dirty eviction (regression test)
 // =============================================================================

--- a/crates/block/hadris-fat/tests/comprehensive_fat.rs
+++ b/crates/block/hadris-fat/tests/comprehensive_fat.rs
@@ -3,6 +3,7 @@
 //! These tests cover edge cases, extensions, and various scenarios for FAT12/16/32.
 //! Tests are designed to run without external tools where possible.
 
+use hadris_fat::format::{FatFormatOptions, FatVolumeFormatter, SectorSize};
 use hadris_fat::{Error, FatType, FatVolume};
 use std::io::Cursor;
 
@@ -488,6 +489,17 @@ mod fat_type_detection_tests {
             }
         }
     }
+
+    #[test]
+    fn fat32_rejects_unknown_filesystem_version() {
+        let mut data = create_fat32_boot_sector(512, 8, 32, 2, 100000, 2048, 2);
+        data[42..44].copy_from_slice(&1_u16.to_le_bytes());
+
+        assert!(matches!(
+            FatVolume::open(Cursor::new(data)),
+            Err(Error::CorruptFilesystem { .. })
+        ));
+    }
 }
 
 // =============================================================================
@@ -786,6 +798,9 @@ mod directory_entry_tests {
 mod cluster_chain_tests {
     // These tests verify the logic for cluster chain traversal
 
+    use hadris_fat::Fat32;
+    use std::io::Cursor;
+
     #[test]
     fn test_fat12_cluster_values() {
         // FAT12 uses 12 bits per entry
@@ -842,6 +857,27 @@ mod cluster_chain_tests {
     }
 
     #[test]
+    fn fat32_writes_preserve_each_copy_reserved_high_bits() {
+        let mut bytes = vec![0_u8; 32];
+        bytes[8..12].copy_from_slice(&0xA000_0000_u32.to_le_bytes());
+        bytes[24..28].copy_from_slice(&0xB000_0000_u32.to_le_bytes());
+
+        let fat = Fat32::new(0, 16, 2, 3);
+        let mut cursor = Cursor::new(bytes);
+        fat.write_clus(&mut cursor, 2, 0x0FFF_FFF7).unwrap();
+        let bytes = cursor.into_inner();
+
+        assert_eq!(
+            u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+            0xAFFF_FFF7
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[24..28].try_into().unwrap()),
+            0xBFFF_FFF7
+        );
+    }
+
+    #[test]
     fn test_cluster_to_sector_calculation() {
         // Cluster to sector: ((cluster - 2) * sectors_per_cluster) + first_data_sector
         let cluster = 5u32;
@@ -893,12 +929,25 @@ mod edge_case_tests {
     }
 
     #[test]
-    fn test_maximum_cluster_size() {
-        // FAT32 allows up to 64KB clusters (128 sectors of 512 bytes)
-        // But typical maximum is 32KB (64 sectors)
-        let max_sectors_per_cluster = 128u8;
-        let bytes_per_cluster = max_sectors_per_cluster as u32 * 512;
-        assert_eq!(bytes_per_cluster, 65536); // 64KB
+    fn reader_rejects_clusters_larger_than_32k() {
+        let data = create_fat32_boot_sector(512, 128, 32, 2, 100000, 2048, 2);
+        let cursor = Cursor::new(data);
+
+        assert!(matches!(
+            FatVolume::open(cursor),
+            Err(Error::CorruptFilesystem { .. })
+        ));
+
+        let options = FatFormatOptions::new(64 * 1024 * 1024)
+            .sector_size(SectorSize::S4096)
+            .sectors_per_cluster(16);
+        assert!(matches!(
+            FatVolumeFormatter::calculate_params(&options),
+            Err(Error::InvalidFormatOption {
+                option: "sectors_per_cluster",
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/block/hadris-fat/tests/exfat_upcase_dos.rs
+++ b/crates/block/hadris-fat/tests/exfat_upcase_dos.rs
@@ -66,3 +66,16 @@ fn oversized_upcase_data_length_does_not_preallocate() {
     let result = table.load(&mut data, &info, 2, 0x1_0000_0000, true);
     assert!(result.is_err());
 }
+
+#[test]
+fn checked_upcase_load_rejects_checksum_mismatch() {
+    let info = tiny_info();
+    let mut data = Cursor::new(vec![0xFF, 0xFF, 1, 0]);
+    let mut table = UpcaseTable::new();
+
+    let result = table.load_checked(&mut data, &info, 2, 4, true, 0);
+    assert!(matches!(
+        result,
+        Err(hadris_fat::Error::ExFatInvalidChecksum { .. })
+    ));
+}

--- a/crates/block/hadris-fat/tests/test_exfat.rs
+++ b/crates/block/hadris-fat/tests/test_exfat.rs
@@ -128,6 +128,15 @@ mod boot_sector_tests {
     }
 
     #[test]
+    fn mount_rejects_invalid_boot_region_checksum() {
+        let mut data = load_partition_image();
+        data[512] ^= 1;
+
+        let result = ExFatVolume::open(Cursor::new(data));
+        assert!(matches!(result, Err(Error::ExFatInvalidChecksum { .. })));
+    }
+
+    #[test]
     fn test_cluster_to_offset() {
         let data = load_boot_sectors();
         let mut cursor = Cursor::new(data);

--- a/crates/block/hadris-ntfs/tests/compliance.rs
+++ b/crates/block/hadris-ntfs/tests/compliance.rs
@@ -1,6 +1,7 @@
 use hadris_ntfs::NtfsError;
 use hadris_ntfs::attr::{
-    AttrIter, DataRun, apply_fixups, decode_data_runs, decode_record_size, decode_utf16le,
+    ATTR_DATA, ATTR_END, AttrIter, DataRun, apply_fixups, decode_data_runs, decode_record_size,
+    decode_utf16le,
 };
 use hadris_ntfs::sync::NtfsFs;
 
@@ -158,6 +159,41 @@ fn attributes_reject_used_sizes_beyond_the_record() {
         AttrIter::new(&record),
         Err(NtfsError::InvalidAttribute)
     ));
+}
+
+fn record_with_one_resident_attribute() -> Vec<u8> {
+    let mut record = vec![0_u8; 1024];
+    record[0x14..0x16].copy_from_slice(&0x30_u16.to_le_bytes());
+    record[0x18..0x1C].copy_from_slice(&0x4C_u32.to_le_bytes());
+
+    record[0x30..0x34].copy_from_slice(&ATTR_DATA.to_le_bytes());
+    record[0x34..0x38].copy_from_slice(&0x18_u32.to_le_bytes());
+    record[0x44..0x46].copy_from_slice(&0x18_u16.to_le_bytes());
+    record
+}
+
+#[test]
+fn attributes_stop_at_end_marker() {
+    let mut record = record_with_one_resident_attribute();
+    record[0x48..0x4C].copy_from_slice(&ATTR_END.to_le_bytes());
+
+    let mut attrs = AttrIter::new(&record).unwrap();
+    assert_eq!(attrs.next().unwrap().unwrap().attr_type, ATTR_DATA);
+    assert!(attrs.next().is_none());
+    assert!(attrs.next().is_none());
+}
+
+#[test]
+fn attributes_reject_a_missing_end_marker() {
+    let record = record_with_one_resident_attribute();
+
+    let mut attrs = AttrIter::new(&record).unwrap();
+    assert_eq!(attrs.next().unwrap().unwrap().attr_type, ATTR_DATA);
+    assert!(matches!(
+        attrs.next(),
+        Some(Err(NtfsError::InvalidAttribute))
+    ));
+    assert!(attrs.next().is_none());
 }
 
 #[test]

--- a/crates/optical/hadris-cd/src/layout.rs
+++ b/crates/optical/hadris-cd/src/layout.rs
@@ -65,8 +65,8 @@ impl LayoutManager {
         // Calculate starting positions based on what we need to write
         let vds_end = self.calculate_vds_end(options);
 
-        // Main/reserve VDS occupy 257-268 and the LVID occupies 269.
-        let udf_partition_start = 270;
+        // Main/reserve VDS occupy 257-288 and the LVID occupies 289.
+        let udf_partition_start = 290;
 
         // Plan every UDF metadata object once, globally. Block 0 is the FSD;
         // directory/file ICBs and exact-sized FID extents follow it.

--- a/crates/optical/hadris-cd/src/writer.rs
+++ b/crates/optical/hadris-cd/src/writer.rs
@@ -300,13 +300,27 @@ impl<W: Read + Write + Seek> OpticalImageWriter<W> {
             .seek(SeekFrom::End(0))
             .await
             .map_err(hadris_io::Error::erase)?;
-        let image_sectors = image_bytes / self.options.sector_size as u64;
+        let image_sectors = image_bytes.div_ceil(self.options.sector_size as u64);
+        let required_sectors = u64::from(layout_info.total_sectors)
+            .checked_add(257)
+            .ok_or_else(|| crate::error::Error::InvalidConfig("image is too large".into()))?;
+        let final_sector_count = image_sectors.max(required_sectors);
+        let last_sector = u32::try_from(final_sector_count - 1)
+            .map_err(|_| crate::error::Error::InvalidConfig("image has too many sectors".into()))?;
+        let trailing_anchor = last_sector - 256;
+        let partition_length = trailing_anchor
+            .checked_sub(layout_info.udf_partition_start)
+            .ok_or_else(|| {
+                crate::error::Error::InvalidConfig(
+                    "UDF partition overlaps the trailing anchor".into(),
+                )
+            })?;
 
         let udf_options = UdfWriteOptions {
             volume_id: self.options.volume_id.clone(),
             revision: self.options.udf.revision,
             partition_start: layout_info.udf_partition_start,
-            partition_length: layout_info.udf_partition_length(),
+            partition_length,
         };
 
         let mut udf_writer = UdfWriter::new(Borrowed::new(&mut self.writer), udf_options);
@@ -333,14 +347,9 @@ impl<W: Read + Write + Seek> OpticalImageWriter<W> {
             location: reserve_vds_start,
         };
         udf_writer.write_avdp(main_vds, reserve_vds)?;
-        if image_sectors > 256 {
-            let last = u32::try_from(image_sectors - 1).map_err(|_| {
-                crate::error::Error::InvalidConfig("image has too many sectors".into())
-            })?;
-            // UDF 1.02 records exactly two candidate anchors. Use sector 256
-            // and N-256, leaving N without a third anchor.
-            udf_writer.write_avdp_at(last - 256, main_vds, reserve_vds)?;
-        }
+        // The partition ends before this anchor, and the final 256 sectors are
+        // reserved so its N-256 position cannot overlap ISO or UDF content.
+        udf_writer.write_avdp_at(trailing_anchor, main_vds, reserve_vds)?;
 
         // File Set Descriptor location (first block in partition)
         let fsd_block = 0u32;
@@ -396,6 +405,19 @@ impl<W: Read + Write + Seek> OpticalImageWriter<W> {
             &layout_info.udf_root,
             layout_info,
         )?;
+        drop(udf_writer);
+
+        if final_sector_count > image_sectors {
+            self.writer
+                .seek(SeekFrom::Start(
+                    u64::from(last_sector) * self.options.sector_size as u64,
+                ))
+                .await
+                .map_err(hadris_io::Error::erase)?;
+            self.writer
+                .write_all(&vec![0_u8; self.options.sector_size])
+                .await?;
+        }
 
         Ok(())
     }

--- a/crates/optical/hadris-cd/src/writer.rs
+++ b/crates/optical/hadris-cd/src/writer.rs
@@ -47,6 +47,12 @@ impl<W: Read + Write + Seek> OpticalImageWriter<W> {
 
     /// Finishes the image and returns its output target.
     pub async fn finish(mut self, mut tree: FileTree) -> Result<W> {
+        if self.options.udf.enabled && self.options.sector_size != UDF_SECTOR_SIZE {
+            return Err(crate::error::Error::InvalidConfig(format!(
+                "UDF bridge images require {UDF_SECTOR_SIZE}-byte logical sectors"
+            )));
+        }
+
         // Sort the tree for consistent output
         tree.sort();
 
@@ -309,12 +315,13 @@ impl<W: Read + Write + Seek> OpticalImageWriter<W> {
         // streams remain independently parseable.
         udf_writer.write_vrs_at(layout_info.vds_end)?;
 
-        // VDS at sectors 257-262
+        // Each VDS extent occupies sixteen sectors. The six descriptors are
+        // followed by reserved sectors within the declared extent.
         let vds_start = 257u32;
-        let vds_length = 6u32; // 6 descriptors
+        let vds_length = 16u32;
 
         // Reserve VDS extent
-        let reserve_vds_start = 263u32;
+        let reserve_vds_start = vds_start + vds_length;
 
         // Write Anchor Volume Descriptor Pointer
         let main_vds = ExtentDescriptor {
@@ -330,7 +337,8 @@ impl<W: Read + Write + Seek> OpticalImageWriter<W> {
             let last = u32::try_from(image_sectors - 1).map_err(|_| {
                 crate::error::Error::InvalidConfig("image has too many sectors".into())
             })?;
-            udf_writer.write_avdp_at(last, main_vds, reserve_vds)?;
+            // UDF 1.02 records exactly two candidate anchors. Use sector 256
+            // and N-256, leaving N without a third anchor.
             udf_writer.write_avdp_at(last - 256, main_vds, reserve_vds)?;
         }
 

--- a/crates/optical/hadris-cd/tests/bridge_roundtrip.rs
+++ b/crates/optical/hadris-cd/tests/bridge_roundtrip.rs
@@ -119,6 +119,28 @@ fn bridge_reopens_through_iso_and_udf_and_recovers_source() {
 }
 
 #[test]
+fn bridge_extends_a_compact_image_to_reserve_the_trailing_anchor() {
+    let (tree, large) = fixture();
+    let initial_sector_count = 512;
+    let cursor = Cursor::new(vec![0_u8; initial_sector_count * SECTOR_SIZE]);
+    let bytes =
+        OpticalImageWriter::new(cursor, OpticalImageOptions::default().volume_id(VOLUME_ID))
+            .finish(tree)
+            .expect("create compact bridge")
+            .into_inner();
+    let sector_count = bytes.len() / SECTOR_SIZE;
+    let trailing_anchor = sector_count - 1 - 256;
+
+    assert!(
+        sector_count > initial_sector_count,
+        "the image must grow to reserve 256 sectors after the trailing anchor"
+    );
+    assert_eq!(tag_id_at(&bytes, trailing_anchor), 2);
+    verify_iso(&bytes, &large);
+    verify_udf(&bytes, &large);
+}
+
+#[test]
 fn bridge_uses_udf_102_anchor_and_vds_layout() {
     let bytes = create(OpticalImageOptions::default().volume_id(VOLUME_ID));
     let sector_count = bytes.len() / SECTOR_SIZE;
@@ -231,6 +253,11 @@ fn bridge_descriptor_profile_is_visible_in_raw_sectors() {
     ) as usize;
     assert_eq!(partition_number, 0);
     assert_eq!(partition_start, 290);
+    assert_eq!(
+        partition_start + partition_length,
+        bytes.len() / SECTOR_SIZE - 1 - 256,
+        "the UDF partition must end before the N-256 anchor"
+    );
 
     let mut file_entries = 0;
     for sector in partition_start..partition_start + partition_length {

--- a/crates/optical/hadris-cd/tests/bridge_roundtrip.rs
+++ b/crates/optical/hadris-cd/tests/bridge_roundtrip.rs
@@ -9,6 +9,12 @@ use hadris_udf::dir::UdfDirEntry;
 use hadris_udf::sync::UdfVolume;
 
 const VOLUME_ID: &str = "BRIDGE_TEST";
+const SECTOR_SIZE: usize = 2048;
+
+fn tag_id_at(bytes: &[u8], sector: usize) -> u16 {
+    let offset = sector * SECTOR_SIZE;
+    u16::from_le_bytes([bytes[offset], bytes[offset + 1]])
+}
 
 fn fixture() -> (FileTree, Vec<u8>) {
     let large: Vec<u8> = (0..5000).map(|index| (index % 251) as u8).collect();
@@ -110,6 +116,152 @@ fn bridge_reopens_through_iso_and_udf_and_recovers_source() {
     let formats = detect(&mut source).unwrap().expect("detect bridge");
     assert!(formats.is_bridge());
     assert_eq!(source.stream_position().unwrap(), 1234);
+}
+
+#[test]
+fn bridge_uses_udf_102_anchor_and_vds_layout() {
+    let bytes = create(OpticalImageOptions::default().volume_id(VOLUME_ID));
+    let sector_count = bytes.len() / SECTOR_SIZE;
+    let last_sector = sector_count - 1;
+
+    assert_eq!(tag_id_at(&bytes, 256), 2, "anchor at sector 256");
+    assert_eq!(
+        tag_id_at(&bytes, last_sector - 256),
+        2,
+        "second anchor at N-256"
+    );
+    assert_ne!(
+        tag_id_at(&bytes, last_sector),
+        2,
+        "UDF 1.02 records exactly two candidate anchors"
+    );
+
+    let avdp = 256 * SECTOR_SIZE;
+    let main_length = u32::from_le_bytes(bytes[avdp + 16..avdp + 20].try_into().unwrap()) as usize;
+    let main_location =
+        u32::from_le_bytes(bytes[avdp + 20..avdp + 24].try_into().unwrap()) as usize;
+    let reserve_length =
+        u32::from_le_bytes(bytes[avdp + 24..avdp + 28].try_into().unwrap()) as usize;
+    let reserve_location =
+        u32::from_le_bytes(bytes[avdp + 28..avdp + 32].try_into().unwrap()) as usize;
+
+    assert_eq!(main_length, 16 * SECTOR_SIZE);
+    assert_eq!(reserve_length, 16 * SECTOR_SIZE);
+    assert_eq!(main_location, 257);
+    assert_eq!(reserve_location, main_location + 16);
+}
+
+#[test]
+fn bridge_descriptor_profile_is_visible_in_raw_sectors() {
+    let bytes = create(OpticalImageOptions::default().volume_id(VOLUME_ID));
+
+    let vrs_start = (16..256)
+        .find(|&sector| {
+            let offset = sector * SECTOR_SIZE;
+            bytes.get(offset + 1..offset + 6) == Some(b"BEA01")
+        })
+        .expect("BEA01 after the ECMA-119 descriptor sequence");
+    for (index, identifier) in [b"BEA01", b"NSR02", b"TEA01"].iter().enumerate() {
+        let offset = (vrs_start + index) * SECTOR_SIZE;
+        assert_eq!(&bytes[offset + 1..offset + 6], *identifier);
+    }
+
+    let descriptor_ids = [1_u16, 4, 5, 6, 7, 8];
+    for (index, expected_id) in descriptor_ids.into_iter().enumerate() {
+        let main_offset = (257 + index) * SECTOR_SIZE;
+        let reserve_offset = (273 + index) * SECTOR_SIZE;
+        assert_eq!(tag_id_at(&bytes, 257 + index), expected_id);
+        assert_eq!(tag_id_at(&bytes, 273 + index), expected_id);
+
+        let mut main = bytes[main_offset..main_offset + SECTOR_SIZE].to_vec();
+        let mut reserve = bytes[reserve_offset..reserve_offset + SECTOR_SIZE].to_vec();
+        main[4] = 0;
+        reserve[4] = 0;
+        main[8..10].fill(0);
+        reserve[8..10].fill(0);
+        main[12..16].fill(0);
+        reserve[12..16].fill(0);
+        if index == 0 {
+            // The two PVD calls may sample the clock independently.
+            main[376..388].fill(0);
+            reserve[376..388].fill(0);
+        }
+        assert_eq!(main, reserve, "reserve VDS descriptor {index} differs");
+    }
+
+    let lvd_offset = 260 * SECTOR_SIZE;
+    let integrity_length = u32::from_le_bytes(
+        bytes[lvd_offset + 432..lvd_offset + 436]
+            .try_into()
+            .unwrap(),
+    );
+    let integrity_location = u32::from_le_bytes(
+        bytes[lvd_offset + 436..lvd_offset + 440]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    assert_eq!(integrity_length, SECTOR_SIZE as u32);
+    assert_eq!(tag_id_at(&bytes, integrity_location), 9);
+    let integrity_offset = integrity_location * SECTOR_SIZE;
+    assert_eq!(
+        u32::from_le_bytes(
+            bytes[integrity_offset + 28..integrity_offset + 32]
+                .try_into()
+                .unwrap()
+        ),
+        1,
+        "the sole integrity descriptor is closed"
+    );
+
+    let partition_descriptor = 259 * SECTOR_SIZE;
+    let partition_number = u16::from_le_bytes(
+        bytes[partition_descriptor + 22..partition_descriptor + 24]
+            .try_into()
+            .unwrap(),
+    );
+    let partition_start = u32::from_le_bytes(
+        bytes[partition_descriptor + 188..partition_descriptor + 192]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let partition_length = u32::from_le_bytes(
+        bytes[partition_descriptor + 192..partition_descriptor + 196]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    assert_eq!(partition_number, 0);
+    assert_eq!(partition_start, 290);
+
+    let mut file_entries = 0;
+    for sector in partition_start..partition_start + partition_length {
+        if tag_id_at(&bytes, sector) == 261 {
+            file_entries += 1;
+            let offset = sector * SECTOR_SIZE;
+            let icb_flags = u16::from_le_bytes(bytes[offset + 34..offset + 36].try_into().unwrap());
+            assert_eq!(
+                icb_flags & 0x7,
+                0,
+                "File Entries must use short allocation descriptors"
+            );
+        }
+    }
+    assert!(file_entries > 0, "fixture should contain File Entries");
+}
+
+#[test]
+fn bridge_rejects_non_2048_byte_logical_sectors() {
+    let mut options = OpticalImageOptions::default().udf_only();
+    options.sector_size = 4096;
+
+    let result = OpticalImageWriter::create(
+        Cursor::new(vec![0_u8; 4 * 1024 * 1024]),
+        FileTree::new(),
+        options,
+    );
+    assert!(
+        matches!(result, Err(hadris_cd::Error::InvalidConfig(_))),
+        "fixed-size UDF bridge structures require 2048-byte sectors"
+    );
 }
 
 #[test]

--- a/crates/optical/hadris-iso/src/read/mod.rs
+++ b/crates/optical/hadris-iso/src/read/mod.rs
@@ -211,6 +211,24 @@ impl<DATA: Read + Seek> IsoImage<DATA> {
                 "volume descriptor sequence has no primary descriptor",
             )
         })?;
+        if !pvd.volume_space_size.is_consistent()
+            || !pvd.volume_set_size.is_consistent()
+            || !pvd.volume_sequence_number.is_consistent()
+            || !pvd.logical_block_size.is_consistent()
+            || !pvd.path_table_size.is_consistent()
+            || !pvd.dir_record.header.extent.is_consistent()
+            || !pvd.dir_record.header.data_len.is_consistent()
+            || !pvd
+                .dir_record
+                .header
+                .volume_sequence_number
+                .is_consistent()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "primary volume descriptor has inconsistent redundant endian fields",
+            ));
+        }
         let block_size = pvd.logical_block_size.read() as usize;
         // IsoImage's extent→byte math assumes a 2048-byte logical block. Rather
         // than silently misread an image that declares a different block size,

--- a/crates/optical/hadris-iso/tests/comprehensive_iso.rs
+++ b/crates/optical/hadris-iso/tests/comprehensive_iso.rs
@@ -338,6 +338,30 @@ mod volume_descriptor_tests {
     }
 
     #[test]
+    fn primary_volume_descriptor_is_required() {
+        let mut iso = create_minimal_iso("TEST");
+        let terminator = create_terminator();
+        iso[16 * 2048..17 * 2048].copy_from_slice(&terminator);
+
+        assert!(
+            IsoImage::open(Cursor::new(iso)).is_err(),
+            "a descriptor sequence without a primary descriptor must be rejected"
+        );
+    }
+
+    #[test]
+    fn pvd_rejects_inconsistent_redundant_endian_fields() {
+        let mut iso = create_minimal_iso("TEST");
+        let pvd_offset = 16 * 2048;
+        iso[pvd_offset + 84..pvd_offset + 88].copy_from_slice(&23_u32.to_be_bytes());
+
+        assert!(
+            IsoImage::open(Cursor::new(iso)).is_err(),
+            "the two volume-space-size representations must agree"
+        );
+    }
+
+    #[test]
     fn test_multiple_pvds() {
         // ISO allows multiple PVDs (for different versions)
         let mut iso = create_minimal_iso("PRIMARY");

--- a/crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs
+++ b/crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs
@@ -63,15 +63,18 @@ fn joliet_options() -> IsoFormatOptions {
     }
 }
 
-fn write_and_open(files: Vec<IsoFile>, options: IsoFormatOptions) -> IsoImage<Cursor<Vec<u8>>> {
+fn write_bytes(files: Vec<IsoFile>, options: IsoFormatOptions) -> Vec<u8> {
     let input = InputFiles {
         path_separator: PathSeparator::ForwardSlash,
         files,
     };
     let mut buffer = Cursor::new(vec![0u8; 8 * 1024 * 1024]);
     IsoImageWriter::create(&mut buffer, input, options).expect("Failed to write ISO");
-    let data = buffer.into_inner();
-    IsoImage::open(Cursor::new(data)).expect("Failed to open ISO")
+    buffer.into_inner()
+}
+
+fn write_and_open(files: Vec<IsoFile>, options: IsoFormatOptions) -> IsoImage<Cursor<Vec<u8>>> {
+    IsoImage::open(Cursor::new(write_bytes(files, options))).expect("Failed to open ISO")
 }
 
 /// Build a chain of N nested directories with a leaf file.
@@ -163,6 +166,96 @@ fn test_path_table_contains_all_subdirectories() {
             "Invalid parent index: {}",
             entry.parent_index
         );
+    }
+}
+
+#[test]
+fn path_table_sorts_adversarial_directory_input() {
+    let directory = |name: &str, child: &str| IsoFile::Directory {
+        name: Arc::new(name.to_string()),
+        children: vec![IsoFile::Directory {
+            name: Arc::new(child.to_string()),
+            children: Vec::new(),
+        }],
+    };
+    let files = vec![
+        directory("z", "zchild"),
+        directory("a", "achild"),
+        directory("m", "mchild"),
+    ];
+
+    let image = write_and_open(files, default_options());
+    let entries: Vec<_> = image
+        .path_table()
+        .entries(&image)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let names: Vec<_> = entries
+        .iter()
+        .skip(1)
+        .map(|entry| String::from_utf8_lossy(entry.name.as_bytes()).into_owned())
+        .collect();
+
+    assert_eq!(names, ["A", "M", "Z", "ACHILD", "MCHILD", "ZCHILD"]);
+    assert!(names.iter().all(|name| !name.contains(';')));
+}
+
+#[test]
+fn raw_directory_records_respect_sector_and_identifier_rules() {
+    let mut files: Vec<_> = (0..100)
+        .map(|index| IsoFile::File {
+            name: Arc::new(format!("FILE{index:03}.TXT")),
+            contents: vec![index as u8],
+        })
+        .collect();
+    files.push(IsoFile::Directory {
+        name: Arc::new("PLAIN_DIR".to_string()),
+        children: Vec::new(),
+    });
+    let bytes = write_bytes(files, default_options());
+
+    let pvd = 16 * 2048;
+    let root_record = pvd + 156;
+    let root_extent =
+        u32::from_le_bytes(bytes[root_record + 2..root_record + 6].try_into().unwrap()) as usize;
+    let root_size = u32::from_le_bytes(
+        bytes[root_record + 10..root_record + 14]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let root = &bytes[root_extent * 2048..root_extent * 2048 + root_size];
+
+    let mut position = 0;
+    while position < root.len() {
+        let remaining_in_sector = 2048 - position % 2048;
+        let record_length = root[position] as usize;
+        if record_length == 0 {
+            assert!(
+                root[position..position + remaining_in_sector]
+                    .iter()
+                    .all(|byte| *byte == 0),
+                "unused directory-sector bytes must be zero"
+            );
+            position += remaining_in_sector;
+            continue;
+        }
+
+        assert!(
+            record_length <= remaining_in_sector,
+            "directory record crosses a logical-sector boundary"
+        );
+        let record = &root[position..position + record_length];
+        let identifier_length = record[32] as usize;
+        let identifier = &record[33..33 + identifier_length];
+        let is_directory = record[25] & 0x02 != 0;
+        let is_special = identifier == [0] || identifier == [1];
+        if is_directory && !is_special {
+            assert!(
+                !identifier.contains(&b';'),
+                "directory identifiers must not have file version suffixes"
+            );
+        }
+        position += record_length;
     }
 }
 

--- a/crates/optical/hadris-iso/tests/no_alloc_reader.rs
+++ b/crates/optical/hadris-iso/tests/no_alloc_reader.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "std", feature = "sync", feature = "read"))]
 
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::cell::Cell;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::Mutex;
 
@@ -17,13 +18,22 @@ use hadris_iso::volume::{
 
 struct CountingAllocator;
 
-static COUNTING: AtomicBool = AtomicBool::new(false);
 static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
+thread_local! {
+    static COUNTING: Cell<bool> = const { Cell::new(false) };
+}
+
+fn is_counting() -> bool {
+    COUNTING
+        .try_with(|counting| counting.get())
+        .unwrap_or(false)
+}
+
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if COUNTING.load(Ordering::Relaxed) {
+        if is_counting() {
             ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
         }
         unsafe { System.alloc(layout) }
@@ -34,7 +44,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
-        if COUNTING.load(Ordering::Relaxed) {
+        if is_counting() {
             ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
         }
         unsafe { System.realloc(ptr, layout, size) }
@@ -170,10 +180,10 @@ fn navigation_and_streaming_allocate_nothing() {
     let mut primary_output = [0_u8; 11];
     let mut joliet_output = [0_u8; 7];
     ALLOCATIONS.store(0, Ordering::Relaxed);
-    COUNTING.store(true, Ordering::SeqCst);
+    COUNTING.set(true);
     exercise_navigation_and_streaming(&image, &mut primary_output, &mut joliet_output);
 
-    COUNTING.store(false, Ordering::SeqCst);
+    COUNTING.set(false);
     assert_eq!(ALLOCATIONS.load(Ordering::Relaxed), 0);
     assert_eq!(&primary_output, b"hello world");
     assert_eq!(&joliet_output, b"unicode");

--- a/crates/optical/hadris-udf/src/write/mod.rs
+++ b/crates/optical/hadris-udf/src/write/mod.rs
@@ -334,14 +334,18 @@ impl<W: Write + Seek> UdfFormatter<W> {
         // UDF disk layout:
         // Sector 16-18:  VRS (BEA01, NSR02, TEA01)
         // Sector 256:    AVDP
-        // Sector 257-262: Main VDS (PVD, IUVD, PD, LVD, USD, Term)
-        // Sector 263-268: Reserve VDS
-        // Sector 269:    LVID
-        // Sector 270+:   Partition starts here
+        // Sector 257-272: Main VDS (six descriptors plus reserved extent)
+        // Sector 273-288: Reserve VDS
+        // Sector 289:     LVID
+        // Sector 290+:    Partition starts here
         //   Block 0:     FSD
         //   Block 1+:    Root dir File Entry, FIDs, subdirs, file data
 
-        let partition_start = 270u32;
+        let vds_start = 257u32;
+        let vds_length = 16u32;
+        let reserve_vds_start = vds_start + vds_length;
+        let lvid_location = reserve_vds_start + vds_length;
+        let partition_start = lvid_location + 1;
 
         // Phase 2: Allocate all structures within the partition
         let fsd_block = self.allocate_block(); // 0
@@ -360,11 +364,6 @@ impl<W: Write + Seek> UdfFormatter<W> {
         self.write_vrs()?;
 
         // Write AVDP
-        let vds_start = 257u32;
-        let vds_length = 6u32;
-        let reserve_vds_start = 263u32;
-        let lvid_location = reserve_vds_start + vds_length; // 269
-
         let main_vds = ExtentDescriptor {
             length: vds_length * SECTOR_SIZE as u32,
             location: vds_start,
@@ -426,7 +425,8 @@ impl<W: Write + Seek> UdfFormatter<W> {
         // overlap partition space.
         let sector_count = partition_start + partition_length + 257;
         let last_sector = sector_count - 1;
-        self.write_avdp_at(last_sector, main_vds, reserve_vds)?;
+        // UDF 1.02 records exactly two of the three candidate anchors. Use
+        // sector 256 and N-256, leaving sector N free of an anchor.
         if last_sector > 256 {
             self.write_avdp_at(last_sector - 256, main_vds, reserve_vds)?;
         }
@@ -2135,7 +2135,8 @@ mod tests {
             sectors > 270,
             "Should have written at least partition start sectors"
         );
-        for location in [256, sectors - 257, sectors - 1] {
+        let anchor_locations = [256, sectors - 257];
+        for location in anchor_locations {
             let offset = location as usize * SECTOR_SIZE;
             assert_eq!(
                 u16::from_le_bytes([buffer[offset], buffer[offset + 1]]),
@@ -2143,6 +2144,29 @@ mod tests {
                 "missing anchor at sector {location}"
             );
         }
+
+        let last_sector = sectors - 1;
+        let last_offset = last_sector as usize * SECTOR_SIZE;
+        assert_ne!(
+            u16::from_le_bytes([buffer[last_offset], buffer[last_offset + 1]]),
+            TagIdentifier::AnchorVolumeDescriptorPointer.to_u16(),
+            "UDF 1.02 records exactly two of the three candidate anchors"
+        );
+
+        let avdp_offset = 256 * SECTOR_SIZE;
+        let main_length =
+            u32::from_le_bytes(buffer[avdp_offset + 16..avdp_offset + 20].try_into().unwrap());
+        let main_location =
+            u32::from_le_bytes(buffer[avdp_offset + 20..avdp_offset + 24].try_into().unwrap());
+        let reserve_length =
+            u32::from_le_bytes(buffer[avdp_offset + 24..avdp_offset + 28].try_into().unwrap());
+        let reserve_location =
+            u32::from_le_bytes(buffer[avdp_offset + 28..avdp_offset + 32].try_into().unwrap());
+
+        assert_eq!(main_length, 16 * SECTOR_SIZE as u32);
+        assert_eq!(reserve_length, 16 * SECTOR_SIZE as u32);
+        assert_eq!(main_location, 257);
+        assert_eq!(reserve_location, main_location + 16);
     }
 
     #[test]

--- a/docs/compliance/hadris-cd.md
+++ b/docs/compliance/hadris-cd.md
@@ -11,6 +11,8 @@ headers, modes, EDC, ECC, subchannels, or physical recording. The available
 report also cannot substantiate El Torito, Joliet, Rock Ridge/SUSP, UEFI
 partitioning, or later UDF bridge profiles.
 
-The extraction identified a concrete profile gap: main and reserve UDF volume
-descriptor sequence extents are currently declared as six sectors, while
-ECMA TR/71 requires each extent to occupy at least sixteen logical sectors.
+The logical-sector writer now has direct raw-image evidence for the pinned
+profile: fixed 2,048-byte sectors, consecutive recognition descriptors,
+permitted anchors, sixteen-sector main and reserve descriptor sequences, a
+single closed integrity descriptor, one partition, and short allocation
+descriptors. Higher recording-layer and extension claims remain out of scope.

--- a/docs/compliance/hadris-cpio.md
+++ b/docs/compliance/hadris-cpio.md
@@ -13,6 +13,7 @@ specification.
 The compliance pass added mandatory checksum verification to both read and
 skip paths, validates filename termination and zero padding, enforces checked
 name/data lengths, rejects empty symbolic-link targets, validates trailer
-size, and emits a consistent link count for hard-link groups. Remaining gaps
-include trailerless aligned archives, reader-side hard-link reconstruction,
-host hard-link discovery, and full initramfs buffer composition.
+size, accepts trailerless archives at an aligned entry boundary, and emits a
+consistent link count for hard-link groups. Remaining gaps include reader-side
+hard-link reconstruction, host hard-link discovery, and full initramfs buffer
+composition.

--- a/docs/compliance/hadris-fat.md
+++ b/docs/compliance/hadris-fat.md
@@ -1,0 +1,16 @@
+# `hadris-fat` compliance profile
+
+The crate is reviewed against Microsoft's FAT 1.03 document for FAT12,
+FAT16, and FAT32 and the Microsoft exFAT 1.00 specification. Atomic mappings
+and executable evidence are recorded in
+[`spec/requirements/hadris-fat.json`](../../spec/requirements/hadris-fat.json).
+
+This pass fixed FAT32 writes that discarded the reserved high nibble, rejected
+clusters larger than 32 KiB and unknown FAT32 filesystem versions, and made
+normal exFAT mounting enforce boot-region, up-case-table, and file entry-set
+checksums.
+
+Known gaps remain explicit in the catalog. FAT32 mounts do not honor the
+active-FAT selection when mirroring is disabled and do not recover through the
+backup boot record. exFAT mounts validate only the main boot region, and
+fragmented up-case tables are rejected rather than followed through the FAT.

--- a/docs/compliance/hadris-iso.md
+++ b/docs/compliance/hadris-iso.md
@@ -19,6 +19,11 @@ than read contiguously, directory records are kept within sector boundaries,
 directory identifiers no longer receive file version suffixes, path-table
 siblings are sorted, and descriptor dates use fixed-width digits.
 
+Follow-up regressions now also reject inconsistent redundant PVD integers and
+a descriptor sequence without a primary descriptor. Raw-image tests directly
+prove directory-sector padding, directory identifier grammar, and adversarial
+path-table ordering.
+
 Remaining `partial` entries are intentional work items. A status becomes
 `verified` only when a clause-sized claim has direct executable evidence; a
 successful Hadris-to-Hadris round trip is not by itself a conformance oracle.

--- a/docs/compliance/hadris-ntfs.md
+++ b/docs/compliance/hadris-ntfs.md
@@ -10,5 +10,8 @@ pairs, directory-index wire layouts, attribute offsets, compression,
 encryption, or filename encoding. Existing implementation and tests for those
 areas remain useful, but cannot be labeled source-verified from this document.
 
+Focused parser evidence verifies that `0xFFFFFFFF` terminates the attribute
+sequence and that exhaustion without the marker is rejected.
+
 The most important source-backed gap is attribute-list processing: files that
 spill attributes into extension MFT records cannot yet be assembled.

--- a/docs/compliance/hadris-udf.md
+++ b/docs/compliance/hadris-udf.md
@@ -10,9 +10,8 @@ edition while UDF 1.02 was originally based on an earlier edition. Only stable
 base structures are attributed to ECMA-167:1997; UDF-profile restrictions are
 attributed directly to the current ECMA technical report.
 
-The extraction found two concrete writer nonconformances: it records all three
-candidate anchor locations although UDF 1.02 requires exactly two, and it
-declares six-sector main/reserve descriptor extents although each must occupy
-at least sixteen sectors. Reader coverage is also partial for prevailing
-descriptor selection, allocation-extent chaining, and several mandatory
-descriptor families.
+The writer records exactly two permitted anchor locations and declares
+sixteen-sector main and reserve descriptor-sequence extents. Raw-image
+regressions cover both requirements. Reader coverage remains partial for
+prevailing descriptor selection, allocation-extent chaining, and several
+mandatory descriptor families.

--- a/spec/requirements/hadris-cd.json
+++ b/spec/requirements/hadris-cd.json
@@ -10,10 +10,10 @@
       "normativity": "shall",
       "summary": "UDF Bridge logical sectors and logical blocks are 2048 bytes.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/options.rs", "name": "OpticalImageOptions::default"}],
-      "tests": [{"path": "crates/optical/hadris-cd/src/options.rs", "name": "test_default_options", "kind": "unit"}],
-      "gap": "The default is 2048, but the public option is not rejected when incompatible with fixed-size UDF structures."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_rejects_non_2048_byte_logical_sectors", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.3#recognition-sequence-order",
@@ -22,10 +22,10 @@
       "normativity": "shall",
       "summary": "The recognition sequence follows the CD-ROM descriptors with consecutive BEA01, NSR02, and TEA01 descriptors.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/writer.rs", "name": "OpticalImageWriter::write_udf_structures"}],
-      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_reopens_through_iso_and_udf_and_recovers_source", "kind": "integration"}],
-      "gap": "Both namespaces reopen, but no raw-sector oracle proves exact descriptor adjacency and order."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_descriptor_profile_is_visible_in_raw_sectors", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.3#anchor-locations",
@@ -34,10 +34,10 @@
       "normativity": "shall",
       "summary": "Anchor descriptors occur at sector 256 and at least one of the final sector or final sector minus 256.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/writer.rs", "name": "OpticalImageWriter::write_udf_structures"}],
-      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_reopens_through_iso_and_udf_and_recovers_source", "kind": "integration"}],
-      "gap": "The writer attempts all positions, but their relationship to final volume length lacks a direct byte-level test."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_uses_udf_102_anchor_and_vds_layout", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.3#main-and-reserve-vds",
@@ -46,10 +46,10 @@
       "normativity": "shall",
       "summary": "Equivalent main and reserve descriptor sequences contain the required volume descriptors and terminator.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/writer.rs", "name": "OpticalImageWriter::write_udf_structures"}],
-      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_reopens_through_iso_and_udf_and_recovers_source", "kind": "integration"}],
-      "gap": "Matching calls emit both sequences, but tests neither compare their bytes nor traverse the reserve independently."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_descriptor_profile_is_visible_in_raw_sectors", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.6#vds-minimum-extent",
@@ -58,10 +58,10 @@
       "normativity": "shall",
       "summary": "Each main and reserve volume-descriptor-sequence extent occupies at least sixteen logical sectors.",
       "direction": "write",
-      "status": "not_implemented",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/writer.rs", "name": "OpticalImageWriter::write_udf_structures"}],
-      "tests": [],
-      "gap": "The writer currently declares six sectors for each sequence and places the reserve immediately afterward."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_uses_udf_102_anchor_and_vds_layout", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.1#closed-integrity-sequence",
@@ -70,10 +70,10 @@
       "normativity": "shall",
       "summary": "The integrity sequence contains exactly one closed logical-volume-integrity descriptor and no open descriptor.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/writer.rs", "name": "OpticalImageWriter::write_udf_structures"}],
-      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_reopens_through_iso_and_udf_and_recovers_source", "kind": "integration"}],
-      "gap": "One closed descriptor is requested, but no test enumerates the complete integrity sequence."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_descriptor_profile_is_visible_in_raw_sectors", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.3#single-partition",
@@ -82,10 +82,10 @@
       "normativity": "shall",
       "summary": "The UDF logical volume uses one partition with logical blocks numbered consecutively from its start.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/layout.rs", "name": "LayoutInfo::udf_partition_length"}],
-      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_reopens_through_iso_and_udf_and_recovers_source", "kind": "integration"}],
-      "gap": "A single readable partition is planned, but raw descriptor assertions do not cover all boundaries."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_descriptor_profile_is_visible_in_raw_sectors", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-71-1998:2.3#same-file-set",
@@ -118,10 +118,10 @@
       "normativity": "shall",
       "summary": "File Entry allocation descriptors use only Short Allocation Descriptors.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-cd/src/writer.rs", "name": "OpticalImageWriter::write_udf_directory_static"}],
-      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_reopens_through_iso_and_udf_and_recovers_source", "kind": "integration"}],
-      "gap": "Output reopens, but no test inspects every File Entry allocation-descriptor type."
+      "tests": [{"path": "crates/optical/hadris-cd/tests/bridge_roundtrip.rs", "name": "bridge_descriptor_profile_is_visible_in_raw_sectors", "kind": "integration"}],
+      "gap": null
     }
   ]
 }

--- a/spec/requirements/hadris-cpio.json
+++ b/spec/requirements/hadris-cpio.json
@@ -34,10 +34,13 @@
       "normativity": "shall",
       "summary": "Headers, names, and file bodies use the specified four-byte alignment with zero-valued padding.",
       "direction": "both",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/archive/hadris-cpio/src/read.rs", "name": "skip_zero_padding"}],
-      "tests": [{"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "alignment_padding_edge_cases", "kind": "integration"}],
-      "gap": "Generated alignment is covered across sizes, but malformed nonzero padding lacks a direct regression fixture."
+      "tests": [
+        {"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "alignment_padding_edge_cases", "kind": "integration"},
+        {"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "reader_rejects_nonzero_name_and_data_padding", "kind": "integration"}
+      ],
+      "gap": null
     },
     {
       "id": "LINUX-INITRAMFS-NEWC:c-namesize#nul-and-path-limit",
@@ -70,10 +73,13 @@
       "normativity": "shall",
       "summary": "The TRAILER!!! end marker has a zero file-data size.",
       "direction": "both",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/archive/hadris-cpio/src/read.rs", "name": "CpioArchiveReader::next_entry_alloc"}],
-      "tests": [{"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "trailer_detection", "kind": "integration"}],
-      "gap": "Writer output and reader validation are implemented, but the test only exercises a valid marker."
+      "tests": [
+        {"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "trailer_detection", "kind": "integration"},
+        {"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "reader_rejects_trailer_with_nonzero_filesize", "kind": "integration"}
+      ],
+      "gap": null
     },
     {
       "id": "LINUX-INITRAMFS-NEWC:hard-links#tuple-and-link-count",
@@ -106,10 +112,10 @@
       "normativity": "may",
       "summary": "An individual archive may end at aligned input exhaustion without a TRAILER!!! marker.",
       "direction": "read",
-      "status": "not_implemented",
-      "symbols": [{"path": "crates/archive/hadris-cpio/src/error.rs", "name": "Error::MissingTrailer"}],
-      "tests": [],
-      "gap": "The streaming reader currently expects another header and reports I/O failure at a trailerless aligned end."
+      "status": "verified",
+      "symbols": [{"path": "crates/archive/hadris-cpio/src/header.rs", "name": "RawNewcHeader::parse_optional"}],
+      "tests": [{"path": "crates/archive/hadris-cpio/tests/roundtrip.rs", "name": "reader_accepts_aligned_eof_without_trailer", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "GNU-CPIO:newc-format#maximum-file-size",

--- a/spec/requirements/hadris-fat.json
+++ b/spec/requirements/hadris-fat.json
@@ -1,0 +1,240 @@
+{
+  "schema_version": 1,
+  "crate": "block/hadris-fat",
+  "profile": "FAT12/FAT16/FAT32 and exFAT reader/writer",
+  "requirements": [
+    {
+      "id": "MICROSOFT-FAT-1.03:bpb#sector-and-cluster-size",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "Boot Sector and BPB, BPB_BytsPerSec and BPB_SecPerClus",
+      "normativity": "shall",
+      "summary": "Sector size is one of 512, 1024, 2048, or 4096 bytes; sectors per cluster is a nonzero power of two and the resulting cluster is no larger than 32 KiB.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [
+        {"path": "crates/block/hadris-fat/src/fs.rs", "name": "FatVolume::open_with_providers"},
+        {"path": "crates/block/hadris-fat/src/format/calc.rs", "name": "calculate_params"}
+      ],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_valid_sector_sizes", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "reader_rejects_clusters_larger_than_32k", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:fat-type-determination#cluster-count-thresholds",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT Type Determination",
+      "normativity": "shall",
+      "summary": "FAT12, FAT16, and FAT32 are selected from the count of data clusters rather than the informational filesystem-type string.",
+      "direction": "read",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/fs.rs", "name": "FatVolume::open_fat12_16"}],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_detect_fat12", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_detect_fat16", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_detect_fat32", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:fat32-bpb#filesystem-version",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT32 Structure, BPB_FSVer",
+      "normativity": "shall",
+      "summary": "A FAT32 driver rejects a volume whose filesystem version is not the defined 0.0 version.",
+      "direction": "read",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/fs.rs", "name": "FatVolume::open_fat32"}],
+      "tests": [{"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "fat32_rejects_unknown_filesystem_version", "kind": "integration"}],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:fat32-bpb#active-fat",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT32 Structure, BPB_ExtFlags",
+      "normativity": "shall",
+      "summary": "When FAT mirroring is disabled, reads and writes use only the active FAT selected by BPB_ExtFlags.",
+      "direction": "both",
+      "status": "not_implemented",
+      "symbols": [{"path": "crates/block/hadris-fat/src/raw.rs", "name": "BpbExt32Flags"}],
+      "tests": [],
+      "gap": "The flags are represented but the mounted volume always reads FAT copy zero and mirrors writes to every copy."
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:fat-data#fat32-reserved-high-bits",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT Data Structure, FAT32 entry access",
+      "normativity": "shall",
+      "summary": "Ordinary FAT32 entry updates change only the low 28 bits and preserve the existing reserved high four bits.",
+      "direction": "write",
+      "status": "verified",
+      "symbols": [
+        {"path": "crates/block/hadris-fat/src/fat_table.rs", "name": "Fat32::write_clus"},
+        {"path": "crates/block/hadris-fat/src/cache.rs", "name": "FatSectorCache::write_fat32_entry"}
+      ],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "fat32_writes_preserve_each_copy_reserved_high_bits", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/cache_integration.rs", "name": "cache_fat32_writes_preserve_reserved_high_bits", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:fat-data#chain-markers",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT Data Structure, cluster values and end-of-chain marks",
+      "normativity": "shall",
+      "summary": "Each FAT width recognizes its defined free, bad-cluster, and end-of-chain value ranges while traversing allocation chains.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/fat_table.rs", "name": "Fat"}],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_fat12_cluster_values", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_fat16_cluster_values", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_fat32_cluster_values", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/test_write.rs", "name": "test_read_returns_cluster_loop_on_2cycle", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:fsinfo#signatures-and-unknown-values",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT32 FSInfo Sector Structure",
+      "normativity": "shall",
+      "summary": "FAT32 FSInfo signatures are validated and the all-ones free-count and next-free values are accepted as unknown hints.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [
+        {"path": "crates/block/hadris-fat/src/fs.rs", "name": "FatVolume::open_fat32"},
+        {"path": "crates/block/hadris-fat/src/format/init.rs", "name": "write_fsinfo"}
+      ],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_invalid_fsinfo_signature1", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_invalid_fsinfo_signature2", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/test_write.rs", "name": "test_fsinfo_unknown_sentinels_mount_successfully", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:backup-boot#recovery-copy",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT32 FSInfo Sector Structure and Backup Boot Sector",
+      "normativity": "should",
+      "summary": "A FAT32 formatter creates the backup boot and FSInfo copies and a reader can use the backup when the primary boot record is unusable.",
+      "direction": "both",
+      "status": "partial",
+      "symbols": [{"path": "crates/block/hadris-fat/src/format/init.rs", "name": "write_backup_boot_sector"}],
+      "tests": [{"path": "crates/block/hadris-fat/tests/fat_roundtrip.rs", "name": "fat32_format_is_clean", "kind": "interop"}],
+      "gap": "Formatting writes sectors 6 and 7, but mounting does not attempt recovery from the backup boot record."
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:directory#free-entry-markers",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT Directory Structure, DIR_Name",
+      "normativity": "shall",
+      "summary": "Directory iteration treats 0xE5 as a deleted slot and 0x00 as the end of all used directory entries.",
+      "direction": "read",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/dir.rs", "name": "FatDirIter"}],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_deleted_entry_marker", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_end_of_directory_marker", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-FAT-1.03:long-directory-entries#sequence-and-checksum",
+      "source": "MICROSOFT-FAT-1.03",
+      "clause": "FAT Long Directory Entries",
+      "normativity": "shall",
+      "summary": "Long-name slots are ordered, carry the long-name attributes, and use the checksum derived from their associated short-name entry.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [
+        {"path": "crates/block/hadris-fat/src/file.rs", "name": "LfnBuilder"},
+        {"path": "crates/block/hadris-fat/src/write.rs", "name": "build_lfn_entries"}
+      ],
+      "tests": [
+        {"path": "crates/block/hadris-fat/tests/comprehensive_fat.rs", "name": "test_lfn_builder_sequence", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/test_write.rs", "name": "lfn_checksum_matches_short_name", "kind": "integration"},
+        {"path": "crates/block/hadris-fat/tests/test_write.rs", "name": "lfn_padding_uses_terminator_then_filler", "kind": "integration"}
+      ],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-EXFAT-1.00:boot-checksum#main-region",
+      "source": "MICROSOFT-EXFAT-1.00",
+      "clause": "3.4 Main and Backup Boot Checksum Sub-regions",
+      "normativity": "shall",
+      "summary": "The main exFAT boot checksum covers sectors zero through ten with the mutable fields excluded, and every checksum-sector entry matches it.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [
+        {"path": "crates/block/hadris-fat/src/exfat/boot.rs", "name": "ExFatBootSector::validate_checksum"},
+        {"path": "crates/block/hadris-fat/src/exfat/format.rs", "name": "write_boot_checksum"}
+      ],
+      "tests": [{"path": "crates/block/hadris-fat/tests/test_exfat.rs", "name": "mount_rejects_invalid_boot_region_checksum", "kind": "integration"}],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-EXFAT-1.00:boot-regions#backup-selection",
+      "source": "MICROSOFT-EXFAT-1.00",
+      "clause": "3 Main and Backup Boot Regions",
+      "normativity": "shall",
+      "summary": "Mounting validates both boot regions and selects a usable region according to the specification when one copy is invalid.",
+      "direction": "read",
+      "status": "not_implemented",
+      "symbols": [{"path": "crates/block/hadris-fat/src/exfat/fs.rs", "name": "ExFatVolume::open"}],
+      "tests": [],
+      "gap": "Mounting validates only the main boot region and does not fall back to the backup region."
+    },
+    {
+      "id": "MICROSOFT-EXFAT-1.00:allocation-bitmap#cluster-state",
+      "source": "MICROSOFT-EXFAT-1.00",
+      "clause": "7.1 Allocation Bitmap Directory Entry",
+      "normativity": "shall",
+      "summary": "The allocation bitmap records whether each cluster in the cluster heap is available or allocated.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/exfat/bitmap.rs", "name": "AllocationBitmap"}],
+      "tests": [{"path": "crates/block/hadris-fat/src/exfat/bitmap.rs", "name": "test_bitmap_bit_operations", "kind": "unit"}],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-EXFAT-1.00:upcase-table#checksum",
+      "source": "MICROSOFT-EXFAT-1.00",
+      "clause": "7.2 Up-case Table Directory Entry",
+      "normativity": "shall",
+      "summary": "The exFAT up-case table data matches the checksum stored in its root-directory metadata before it is used for name matching.",
+      "direction": "read",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/exfat/upcase.rs", "name": "UpcaseTable::load_checked"}],
+      "tests": [{"path": "crates/block/hadris-fat/tests/exfat_upcase_dos.rs", "name": "checked_upcase_load_rejects_checksum_mismatch", "kind": "integration"}],
+      "gap": null
+    },
+    {
+      "id": "MICROSOFT-EXFAT-1.00:upcase-table#fragmented-storage",
+      "source": "MICROSOFT-EXFAT-1.00",
+      "clause": "7.2.5 Up-case Table",
+      "normativity": "shall",
+      "summary": "An up-case table whose allocation is described by a FAT chain can be loaded when it is not physically contiguous.",
+      "direction": "read",
+      "status": "not_implemented",
+      "symbols": [{"path": "crates/block/hadris-fat/src/exfat/upcase.rs", "name": "UpcaseTable::load"}],
+      "tests": [],
+      "gap": "The loader explicitly rejects fragmented up-case tables instead of following their FAT chain."
+    },
+    {
+      "id": "MICROSOFT-EXFAT-1.00:file-entry-set#checksum",
+      "source": "MICROSOFT-EXFAT-1.00",
+      "clause": "7.4 File Directory Entry, SetChecksum",
+      "normativity": "shall",
+      "summary": "A file directory entry set is accepted only when its stored checksum matches the complete primary and secondary entry set.",
+      "direction": "both",
+      "status": "verified",
+      "symbols": [{"path": "crates/block/hadris-fat/src/exfat/entry.rs", "name": "parse_entry_set"}],
+      "tests": [{"path": "crates/block/hadris-fat/src/exfat/entry_writer.rs", "name": "parser_rejects_an_invalid_entry_set_checksum", "kind": "unit"}],
+      "gap": null
+    }
+  ]
+}

--- a/spec/requirements/hadris-iso.json
+++ b/spec/requirements/hadris-iso.json
@@ -70,10 +70,10 @@
       "normativity": "shall",
       "summary": "Every volume descriptor sequence contains a primary volume descriptor.",
       "direction": "both",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-iso/src/volume.rs", "name": "VolumeDescriptorList::try_primary"}],
-      "tests": [],
-      "gap": "The writer emits a primary descriptor and the reader returns InvalidData when absent, but a dedicated regression test is still needed."
+      "tests": [{"path": "crates/optical/hadris-iso/tests/comprehensive_iso.rs", "name": "primary_volume_descriptor_is_required", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-119-1987:8.1.2#descriptor-identifier",
@@ -106,10 +106,10 @@
       "normativity": "shall",
       "summary": "The volume-space size stores equal little- and big-endian 32-bit copies.",
       "direction": "both",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-iso/src/types.rs", "name": "LsbMsb::is_consistent"}],
-      "tests": [{"path": "crates/optical/hadris-iso/src/directory.rs", "name": "directory_record_rejects_invalid_bounds_and_endian_copy", "kind": "unit"}],
-      "gap": "Directory records validate redundant copies, but descriptor-wide validation has not yet been centralized."
+      "tests": [{"path": "crates/optical/hadris-iso/tests/comprehensive_iso.rs", "name": "pvd_rejects_inconsistent_redundant_endian_fields", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-119-1987:8.4.26.1#decimal-date-format",
@@ -190,10 +190,10 @@
       "normativity": "shall",
       "summary": "A directory record is contained within one logical sector and unused trailing bytes are zero.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-iso/src/write/mod.rs", "name": "write_directory"}],
-      "tests": [{"path": "crates/optical/hadris-iso/tests/xorriso_advanced.rs", "name": "test_multi_sector_directory", "kind": "interop"}],
-      "gap": "The writer now pads before a crossing record; the external test is useful but not yet a dedicated raw-byte oracle."
+      "tests": [{"path": "crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs", "name": "raw_directory_records_respect_sector_and_identifier_rules", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-119-1987:7.6.1#directory-identifier",
@@ -202,10 +202,10 @@
       "normativity": "shall",
       "summary": "Ordinary directory identifiers use directory-name grammar and do not carry a file version suffix.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-iso/src/file.rs", "name": "EntryType::convert_directory_name"}],
-      "tests": [],
-      "gap": "Primary hierarchy conversion is separated from file identifiers, but direct raw-byte coverage remains to be added."
+      "tests": [{"path": "crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs", "name": "raw_directory_records_respect_sector_and_identifier_rules", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-119-1987:6.9.1#path-table-order",
@@ -214,10 +214,10 @@
       "normativity": "shall",
       "summary": "Path-table records are ordered by level, parent record number, and directory identifier.",
       "direction": "write",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-iso/src/write/writer.rs", "name": "PathTableWriter::write"}],
-      "tests": [{"path": "crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs", "name": "test_path_table_contains_all_subdirectories", "kind": "integration"}],
-      "gap": "The implementation sorts each breadth-first sibling group; the existing test does not use adversarial input order."
+      "tests": [{"path": "crates/optical/hadris-iso/tests/iso_roundtrip_advanced.rs", "name": "path_table_sorts_adversarial_directory_input", "kind": "integration"}],
+      "gap": null
     },
     {
       "id": "ECMA-119-1987:6.9.2#type-l-and-m-tables",

--- a/spec/requirements/hadris-ntfs.json
+++ b/spec/requirements/hadris-ntfs.json
@@ -94,10 +94,13 @@
       "normativity": "informative",
       "summary": "The attribute sequence terminates with the value 0xFFFFFFFF.",
       "direction": "read",
-      "status": "partial",
+      "status": "verified",
       "symbols": [{"path": "crates/block/hadris-ntfs/src/attr.rs", "name": "ATTR_END"}],
-      "tests": [],
-      "gap": "The parser recognizes the marker, but no focused test covers malformed or missing termination."
+      "tests": [
+        {"path": "crates/block/hadris-ntfs/tests/compliance.rs", "name": "attributes_stop_at_end_marker", "kind": "integration"},
+        {"path": "crates/block/hadris-ntfs/tests/compliance.rs", "name": "attributes_reject_a_missing_end_marker", "kind": "integration"}
+      ],
+      "gap": null
     },
     {
       "id": "MICROSOFT-NTFS-MFT:data-streams#attributes",

--- a/spec/requirements/hadris-udf.json
+++ b/spec/requirements/hadris-udf.json
@@ -130,10 +130,10 @@
       "normativity": "shall",
       "summary": "Anchor descriptors are recorded at exactly two of sector 256, sector N minus 256, and sector N.",
       "direction": "write",
-      "status": "not_implemented",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-udf/src/write/mod.rs", "name": "Formatter::format"}],
       "tests": [{"path": "crates/optical/hadris-udf/src/write/mod.rs", "name": "test_format_empty_filesystem", "kind": "unit"}],
-      "gap": "The formatter deliberately writes all three candidate anchors."
+      "gap": null
     },
     {
       "id": "ECMA-TR-112-7-2023:2.2.3.1#vds-minimum-length",
@@ -142,10 +142,10 @@
       "normativity": "shall",
       "summary": "Main and reserve Volume Descriptor Sequence extents are each at least sixteen logical sectors.",
       "direction": "write",
-      "status": "not_implemented",
+      "status": "verified",
       "symbols": [{"path": "crates/optical/hadris-udf/src/write/mod.rs", "name": "Formatter::format"}],
-      "tests": [],
-      "gap": "The formatter records each descriptor sequence extent as six 2048-byte sectors."
+      "tests": [{"path": "crates/optical/hadris-udf/src/write/mod.rs", "name": "test_format_empty_filesystem", "kind": "unit"}],
+      "gap": null
     },
     {
       "id": "ECMA-TR-112-7-2023:2.2.4.3#domain-identifier",


### PR DESCRIPTION
## Summary

- conform UDF and CD bridge anchor/VDS layouts
- validate ISO descriptor and directory invariants
- accept aligned trailerless CPIO archives and strengthen malformed-input coverage
- verify NTFS attribute end-marker handling
- enforce FAT32 and exFAT integrity rules and add an atomic FAT/exFAT compliance catalog

## Validation

- `cargo test --workspace --all-features`
- `cargo check --workspace` with warnings denied
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- spec annotation and compliance catalog checker self-tests
- external filesystem interoperability tests