### PR TITLE
fix(iso-cli): display Rock Ridge and Joliet filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ version = "2.0.0-rc.4"
 dependencies = [
  "clap",
  "hadris-iso",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/tools/hadris-iso-cli/Cargo.toml
+++ b/crates/tools/hadris-iso-cli/Cargo.toml
@@ -28,3 +28,6 @@ clap.workspace = true
 hadris-iso = { workspace = true, features = ["std", "sync", "write", "joliet"] }
 tracing.workspace = true
 tracing-subscriber = "0.3.20"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/tools/hadris-iso-cli/src/commands/cat.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/cat.rs
@@ -5,7 +5,7 @@ use hadris_iso::read::IsoImage;
 
 use super::super::args::CatArgs;
 
-use super::{Result, clean_name, navigate_to_path};
+use super::{Result, navigate_to_path};
 
 /// Print file contents to stdout
 pub fn cat(args: CatArgs) -> Result<()> {
@@ -27,13 +27,7 @@ pub fn cat(args: CatArgs) -> Result<()> {
     let file_entry = dir
         .entries()
         .filter_map(|e| e.ok())
-        .find(|e| {
-            if e.is_special() || e.is_directory() {
-                return false;
-            }
-            let name = clean_name(e.name());
-            name.eq_ignore_ascii_case(filename)
-        })
+        .find(|e| !e.is_special() && !e.is_directory() && e.matches_name(filename))
         .ok_or_else(|| -> Box<dyn std::error::Error> {
             format!("File not found: {}", args.path).into()
         })?;

--- a/crates/tools/hadris-iso-cli/src/commands/extract.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/extract.rs
@@ -1,19 +1,20 @@
 use std::fs::{self, File};
-use std::io::{BufReader, Read, Seek, Write};
-use std::path::Path;
+use std::io::{self, BufReader, Read, Seek, Write};
+use std::path::{Component, Path, PathBuf};
 
 use hadris_iso::directory::{DirectoryRef, FileFlags};
 use hadris_iso::read::IsoImage;
 
 use super::super::args::ExtractArgs;
 
-use super::{Result, clean_name, navigate_to_path};
+use super::{Result, display_name, navigate_to_path};
 
 /// Extract files from an ISO image
 pub fn extract(args: ExtractArgs) -> Result<()> {
     let file = File::open(&args.input)?;
     let reader = BufReader::new(file);
     let iso = IsoImage::open(reader)?;
+    let entry_type = iso.root_dir().entry_type();
 
     // Create output directory
     fs::create_dir_all(&args.output)?;
@@ -28,6 +29,7 @@ pub fn extract(args: ExtractArgs) -> Result<()> {
     extract_dir(
         &iso,
         start_ref,
+        entry_type,
         &args.output,
         args.verbose,
         &mut extracted_count,
@@ -44,6 +46,7 @@ pub fn extract(args: ExtractArgs) -> Result<()> {
 fn extract_dir<R: Read + Seek>(
     iso: &IsoImage<R>,
     dir_ref: DirectoryRef,
+    entry_type: hadris_iso::file::EntryType,
     output_path: &Path,
     verbose: bool,
     count: &mut usize,
@@ -52,41 +55,38 @@ fn extract_dir<R: Read + Seek>(
 
     for entry in dir.entries() {
         let entry = entry?;
-        let name_bytes = entry.name();
-
         // Skip . and ..
         if entry.is_special() {
             continue;
         }
 
-        let display_name = clean_name(name_bytes);
+        let display_name = display_name(&entry, entry_type);
+        let entry_path = safe_entry_path(output_path, &display_name)?;
         let flags = FileFlags::from_bits_truncate(entry.header().flags);
 
         if flags.contains(FileFlags::DIRECTORY) {
-            let child_path = output_path.join(&display_name);
-            fs::create_dir_all(&child_path)?;
+            fs::create_dir_all(&entry_path)?;
             if verbose {
-                println!("Creating directory: {}", child_path.display());
+                println!("Creating directory: {}", entry_path.display());
             }
             let child_ref = entry.as_dir_ref(iso)?;
-            extract_dir(iso, child_ref, &child_path, verbose, count)?;
+            extract_dir(iso, child_ref, entry_type, &entry_path, verbose, count)?;
         } else {
             let extent = entry.header().extent.read() as u64;
             let size = entry.header().data_len.read() as usize;
 
-            let file_path = output_path.join(&display_name);
             if verbose {
-                println!("Extracting: {} ({} bytes)", file_path.display(), size);
+                println!("Extracting: {} ({} bytes)", entry_path.display(), size);
             }
 
             if size > 0 {
                 let mut buffer = vec![0u8; size];
                 iso.read_bytes_at(extent * 2048, &mut buffer)?;
-                let mut output_file = File::create(&file_path)?;
+                let mut output_file = File::create(&entry_path)?;
                 output_file.write_all(&buffer)?;
             } else {
                 // Create empty file
-                File::create(&file_path)?;
+                File::create(&entry_path)?;
             }
 
             *count += 1;
@@ -94,4 +94,19 @@ fn extract_dir<R: Read + Seek>(
     }
 
     Ok(())
+}
+
+fn safe_entry_path(output_path: &Path, name: &str) -> Result<PathBuf> {
+    let path = Path::new(name);
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(component)), None) if component == std::ffi::OsStr::new(name) => {
+            Ok(output_path.join(path))
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsafe filename in ISO image: {name:?}"),
+        )
+        .into()),
+    }
 }

--- a/crates/tools/hadris-iso-cli/src/commands/ls.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/ls.rs
@@ -6,24 +6,22 @@ use hadris_iso::read::IsoImage;
 
 use super::super::args::LsArgs;
 
-use super::{Result, navigate_to_path};
+use super::{Result, display_name, navigate_to_path};
 
 /// List directory contents
 pub fn ls(args: LsArgs) -> Result<()> {
     let file = File::open(&args.input)?;
     let reader = BufReader::new(file);
     let iso = IsoImage::open(reader)?;
+    let entry_type = iso.root_dir().entry_type();
 
     let target = navigate_to_path(&iso, &args.path)?;
     let dir = iso.open_dir(target);
 
     for entry in dir.entries() {
         let entry = entry?;
-        let name_bytes = entry.name();
-        let name = String::from_utf8_lossy(name_bytes);
-
         // Handle special entries
-        let display_name = match name_bytes {
+        let display_name = match entry.name() {
             [0x00] => {
                 if !args.all {
                     continue;
@@ -36,15 +34,7 @@ pub fn ls(args: LsArgs) -> Result<()> {
                 }
                 "..".to_string()
             }
-            _ => {
-                // Strip version number (;1) if present
-                let name_str = name.to_string();
-                if let Some(pos) = name_str.rfind(';') {
-                    name_str[..pos].to_string()
-                } else {
-                    name_str
-                }
-            }
+            _ => display_name(&entry, entry_type),
         };
 
         let flags = FileFlags::from_bits_truncate(entry.header().flags);

--- a/crates/tools/hadris-iso-cli/src/commands/mod.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/mod.rs
@@ -28,25 +28,38 @@ use hadris_iso::write::{InputEntry, InputEntryKind, InputTree, estimator};
 
 pub(super) type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-/// Return the most capable name exposed by the image, without an ISO version suffix.
+/// Return the most capable name exposed by the image.
 fn display_name(entry: &DirEntry, entry_type: EntryType) -> String {
-    let name = if matches!(entry_type, EntryType::Joliet { .. }) && entry.rrip.is_none() {
+    if let Some(name) = entry
+        .rrip
+        .as_ref()
+        .and_then(|metadata| metadata.alternate_name.as_deref())
+    {
+        // RRIP NM names are POSIX names, not ISO identifiers. In particular,
+        // a trailing `;digits` sequence is part of the name and must be kept.
+        return name.to_string();
+    }
+
+    let name = if matches!(entry_type, EntryType::Joliet { .. }) {
         let units: Vec<u16> = entry
             .name()
             .chunks_exact(2)
             .map(|bytes| u16::from_be_bytes([bytes[0], bytes[1]]))
             .collect();
-        std::borrow::Cow::Owned(String::from_utf16_lossy(&units))
+        String::from_utf16_lossy(&units)
     } else {
-        entry.display_name()
+        String::from_utf8_lossy(entry.name()).into_owned()
     };
+
+    // Version suffixes belong to ISO 9660 identifiers (including identifiers
+    // encoded in a Joliet tree), never to Rock Ridge NM alternate names.
     match name.rsplit_once(';') {
         Some((base, version))
             if !version.is_empty() && version.bytes().all(|byte| byte.is_ascii_digit()) =>
         {
             base.to_string()
         }
-        _ => name.into_owned(),
+        _ => name,
     }
 }
 
@@ -90,4 +103,61 @@ fn count_files(input: &InputTree) -> usize {
             .sum()
     }
     count_recursive(&input.entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::display_name;
+    use hadris_iso::directory::{DirectoryRecord, DirectoryRef, FileFlags};
+    use hadris_iso::file::EntryType;
+    use hadris_iso::io::LogicalSector;
+    use hadris_iso::joliet::JolietLevel;
+    use hadris_iso::read::{DirEntry, RripMetadata};
+
+    fn entry(name: &[u8], rrip: Option<RripMetadata>) -> DirEntry {
+        DirEntry {
+            record: DirectoryRecord::new(
+                name,
+                &[],
+                DirectoryRef {
+                    extent: LogicalSector(0),
+                    size: 0,
+                },
+                FileFlags::empty(),
+            ),
+            rrip,
+            additional_extents: Vec::new(),
+            associated_file: None,
+        }
+    }
+
+    #[test]
+    fn joliet_name_is_decoded_when_rrip_metadata_has_no_nm_name() {
+        let encoded: Vec<u8> = "lowercase.txt;1"
+            .encode_utf16()
+            .flat_map(u16::to_be_bytes)
+            .collect();
+        let entry = entry(&encoded, Some(RripMetadata::default()));
+        let entry_type = EntryType::Joliet {
+            level: JolietLevel::Level3,
+            supports_rrip: false,
+        };
+
+        assert_eq!(display_name(&entry, entry_type), "lowercase.txt");
+    }
+
+    #[test]
+    fn rrip_nm_name_preserves_trailing_semicolon_digits() {
+        let rrip = RripMetadata {
+            alternate_name: Some("report;1".to_string()),
+            ..RripMetadata::default()
+        };
+        let entry = entry(b"REPORT;1", Some(rrip));
+        let entry_type = EntryType::Level1 {
+            supports_lowercase: false,
+            supports_rrip: true,
+        };
+
+        assert_eq!(display_name(&entry, entry_type), "report;1");
+    }
 }

--- a/crates/tools/hadris-iso-cli/src/commands/mod.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/mod.rs
@@ -21,19 +21,32 @@ pub use verify::verify;
 use std::io::{Read, Seek};
 
 use hadris_iso::directory::DirectoryRef;
-use hadris_iso::read::IsoImage;
+use hadris_iso::file::EntryType;
+use hadris_iso::read::{DirEntry, IsoImage};
 use hadris_iso::write::options::IsoFormatOptions;
 use hadris_iso::write::{InputEntry, InputEntryKind, InputTree, estimator};
 
 pub(super) type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-/// Strip the ";1" version suffix from an ISO filename.
-fn clean_name(name_bytes: &[u8]) -> String {
-    let name = String::from_utf8_lossy(name_bytes);
-    if let Some(pos) = name.rfind(';') {
-        name[..pos].to_string()
+/// Return the most capable name exposed by the image, without an ISO version suffix.
+fn display_name(entry: &DirEntry, entry_type: EntryType) -> String {
+    let name = if matches!(entry_type, EntryType::Joliet { .. }) && entry.rrip.is_none() {
+        let units: Vec<u16> = entry
+            .name()
+            .chunks_exact(2)
+            .map(|bytes| u16::from_be_bytes([bytes[0], bytes[1]]))
+            .collect();
+        std::borrow::Cow::Owned(String::from_utf16_lossy(&units))
     } else {
-        name.to_string()
+        entry.display_name()
+    };
+    match name.rsplit_once(';') {
+        Some((base, version))
+            if !version.is_empty() && version.bytes().all(|byte| byte.is_ascii_digit()) =>
+        {
+            base.to_string()
+        }
+        _ => name.into_owned(),
     }
 }
 
@@ -46,10 +59,7 @@ fn navigate_to_path<R: Read + Seek>(iso: &IsoImage<R>, path: &str) -> Result<Dir
         let found = dir
             .entries()
             .filter_map(|e| e.ok())
-            .find(|e| {
-                let name = clean_name(e.name());
-                name.eq_ignore_ascii_case(component) && e.is_directory()
-            })
+            .find(|e| e.is_directory() && e.matches_name(component))
             .ok_or_else(|| -> Box<dyn std::error::Error> {
                 format!("Directory not found: {component}").into()
             })?;

--- a/crates/tools/hadris-iso-cli/src/commands/tree.rs
+++ b/crates/tools/hadris-iso-cli/src/commands/tree.rs
@@ -6,20 +6,21 @@ use hadris_iso::read::IsoImage;
 
 use super::super::args::TreeArgs;
 
-use super::{Result, clean_name, navigate_to_path};
+use super::{Result, display_name, navigate_to_path};
 
 /// Display directory tree
 pub fn tree(args: TreeArgs) -> Result<()> {
     let file = File::open(&args.input)?;
     let reader = BufReader::new(file);
     let iso = IsoImage::open(reader)?;
+    let entry_type = iso.root_dir().entry_type();
 
     println!("{}", args.path);
 
     let target = navigate_to_path(&iso, &args.path)?;
     let max_depth = args.depth.unwrap_or(usize::MAX);
 
-    print_tree_recursive(&iso, target, "", 0, max_depth)?;
+    print_tree_recursive(&iso, target, entry_type, "", 0, max_depth)?;
 
     Ok(())
 }
@@ -27,6 +28,7 @@ pub fn tree(args: TreeArgs) -> Result<()> {
 fn print_tree_recursive<R: Read + Seek>(
     iso: &IsoImage<R>,
     dir_ref: DirectoryRef,
+    entry_type: hadris_iso::file::EntryType,
     prefix: &str,
     depth: usize,
     max_depth: usize,
@@ -49,7 +51,7 @@ fn print_tree_recursive<R: Read + Seek>(
         } else {
             "\u{251c}\u{2500}\u{2500} "
         };
-        let display_name = clean_name(entry.name());
+        let display_name = display_name(entry, entry_type);
 
         let flags = FileFlags::from_bits_truncate(entry.header().flags);
         let suffix = if flags.contains(FileFlags::DIRECTORY) {
@@ -68,7 +70,14 @@ fn print_tree_recursive<R: Read + Seek>(
             } else {
                 format!("{prefix}\u{2502}   ")
             };
-            print_tree_recursive(iso, child_ref, &new_prefix, depth + 1, max_depth)?;
+            print_tree_recursive(
+                iso,
+                child_ref,
+                entry_type,
+                &new_prefix,
+                depth + 1,
+                max_depth,
+            )?;
         }
     }
 

--- a/crates/tools/hadris-iso-cli/tests/cli_smoke.rs
+++ b/crates/tools/hadris-iso-cli/tests/cli_smoke.rs
@@ -26,3 +26,79 @@ fn version_succeeds() {
         .expect("run --version");
     assert!(status.success());
 }
+
+#[test]
+fn rock_ridge_names_are_used_by_listing_commands() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("cidata");
+    let image = temp.path().join("cidata.iso");
+    std::fs::create_dir(&source).unwrap();
+    std::fs::write(source.join("user-data"), "#user-data\n").unwrap();
+    std::fs::write(source.join("meta-data"), "#meta-data\n").unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_hadris-iso-cli");
+    let create = std::process::Command::new(bin)
+        .args(["create", "--joliet", "--rock-ridge", "--output"])
+        .arg(&image)
+        .arg(&source)
+        .output()
+        .expect("create test ISO");
+    assert!(
+        create.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    for command in [["tree"], ["ls"]] {
+        let output = std::process::Command::new(bin)
+            .args(command)
+            .arg(&image)
+            .output()
+            .expect("list test ISO");
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("meta-data"), "stdout: {stdout}");
+        assert!(stdout.contains("user-data"), "stdout: {stdout}");
+        assert!(!stdout.contains("META_DAT"), "stdout: {stdout}");
+        assert!(!stdout.contains("USER_DAT"), "stdout: {stdout}");
+    }
+}
+
+#[test]
+fn joliet_names_are_decoded_by_listing_commands() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("source");
+    let image = temp.path().join("joliet.iso");
+    std::fs::create_dir(&source).unwrap();
+    std::fs::write(source.join("lowercase-long-name.txt"), "payload").unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_hadris-iso-cli");
+    let create = std::process::Command::new(bin)
+        .args(["create", "--joliet", "--output"])
+        .arg(&image)
+        .arg(&source)
+        .output()
+        .expect("create Joliet test ISO");
+    assert!(
+        create.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let output = std::process::Command::new(bin)
+        .arg("tree")
+        .arg(&image)
+        .output()
+        .expect("list Joliet test ISO");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("lowercase-long-name.txt"),
+        "stdout: {stdout}"
+    );
+    assert!(!stdout.contains('\0'), "stdout contains NULs: {stdout:?}");
+}


### PR DESCRIPTION
## Summary

- display Rock Ridge NM alternate names in tree, ls, and extraction
- decode Joliet UTF-16 filenames instead of printing raw directory-record bytes
- use extension-aware names for path navigation and cat
- reject unsafe extraction path components
- add end-to-end Rock Ridge and Joliet CLI regression tests

## Why

The uppercase names such as META_DAT are the restricted ISO 9660 Level 1 identifiers. The original lowercase names are preserved in Rock Ridge and Joliet, but the CLI was reading the raw primary identifier instead of the extension name.

## Verification

- cargo test -p hadris-iso-cli
- cargo clippy -p hadris-iso-cli --all-targets -- -D warnings

Fixes #80