### PR TITLE
feat(fat): bound TimeProvider and OemCpConverter on Sync

### DIFF
--- a/api-snapshots/hadris-fat.txt
+++ b/api-snapshots/hadris-fat.txt
@@ -1217,7 +1217,7 @@ impl hadris_fat::oem::OemCpConverter for hadris_fat::oem::LossyAsciiOemCpConvert
 pub fn hadris_fat::oem::LossyAsciiOemCpConverter::decode(&self, u8) -> char
 pub fn hadris_fat::oem::LossyAsciiOemCpConverter::encode(&self, char) -> core::option::Option<u8>
 pub static hadris_fat::oem::DEFAULT_OEM_CONVERTER: hadris_fat::oem::LossyAsciiOemCpConverter
-pub trait hadris_fat::oem::OemCpConverter: core::fmt::Debug
+pub trait hadris_fat::oem::OemCpConverter: core::fmt::Debug + core::marker::Sync
 pub fn hadris_fat::oem::OemCpConverter::decode(&self, u8) -> char
 pub fn hadris_fat::oem::OemCpConverter::encode(&self, char) -> core::option::Option<u8>
 impl hadris_fat::oem::OemCpConverter for hadris_fat::oem::Cp437OemCpConverter
@@ -2387,7 +2387,7 @@ pub struct hadris_fat::time::StaticTimeProvider(pub hadris_fat::time::FatDateTim
 impl hadris_fat::time::TimeProvider for hadris_fat::time::StaticTimeProvider
 pub fn hadris_fat::time::StaticTimeProvider::now(&self) -> hadris_fat::time::FatDateTime
 pub static hadris_fat::time::DEFAULT_TIME_PROVIDER: hadris_fat::time::ChronoTimeProvider
-pub trait hadris_fat::time::TimeProvider: core::fmt::Debug
+pub trait hadris_fat::time::TimeProvider: core::fmt::Debug + core::marker::Sync
 pub fn hadris_fat::time::TimeProvider::now(&self) -> hadris_fat::time::FatDateTime
 impl hadris_fat::time::TimeProvider for hadris_fat::time::ChronoTimeProvider
 pub fn hadris_fat::time::ChronoTimeProvider::now(&self) -> hadris_fat::time::FatDateTime

--- a/crates/block/hadris-fat/README.md
+++ b/crates/block/hadris-fat/README.md
@@ -81,6 +81,39 @@ let options = FatFormatOptions::new(64 * 1024 * 1024)
 # }
 ```
 
+### Sharing a Volume Between Threads
+
+`FatVolume` is `Send` when its backing storage is `Send`. Put it behind a
+mutex to share it safely between worker threads. Custom time providers and OEM
+code-page converters must implement `Sync`.
+
+```rust,no_run
+use hadris_fat::FatVolume;
+use std::{fs::File, sync::{Arc, Mutex}, thread};
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let volume = FatVolume::open(File::options()
+    .read(true)
+    .write(true)
+    .open("disk.img")?)?;
+let volume = Arc::new(Mutex::new(volume));
+
+let worker_volume = Arc::clone(&volume);
+let fat_type = thread::spawn(move || worker_volume.lock().unwrap().fat_type())
+    .join()
+    .expect("volume worker panicked");
+
+println!("mounted {fat_type}");
+# Ok(())
+# }
+```
+
+See the runnable `shared_volume` example for configuring a custom clock:
+
+```console
+cargo run -p hadris-fat --example shared_volume -- disk.img
+```
+
 ## Feature Flags
 
 | Feature | Description | Dependencies |

--- a/crates/block/hadris-fat/examples/shared_volume.rs
+++ b/crates/block/hadris-fat/examples/shared_volume.rs
@@ -1,0 +1,34 @@
+use hadris_fat::time::TimeProvider;
+use hadris_fat::{FatDateTime, FatVolume, FatVolumeBuilder};
+use std::fs::File;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+struct SystemClock;
+
+impl TimeProvider for SystemClock {
+    fn now(&self) -> FatDateTime {
+        FatDateTime::now()
+    }
+}
+
+static CLOCK: SystemClock = SystemClock;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "disk.img".to_owned());
+    let file = File::options().read(true).write(true).open(path)?;
+    let volume: FatVolume<_> = FatVolumeBuilder::new(file).time_provider(&CLOCK).open()?;
+
+    // FatVolume is Send when its backing storage is Send. A mutex provides
+    // exclusive access while Arc lets workers share ownership of the handle.
+    let volume = Arc::new(Mutex::new(volume));
+    let worker_volume = Arc::clone(&volume);
+    let fat_type = std::thread::spawn(move || worker_volume.lock().unwrap().fat_type())
+        .join()
+        .expect("volume worker panicked");
+
+    println!("mounted {fat_type}");
+    Ok(())
+}

--- a/crates/block/hadris-fat/src/oem.rs
+++ b/crates/block/hadris-fat/src/oem.rs
@@ -10,7 +10,10 @@
 //! per-`FatVolume` instance and used freely from any thread.
 
 /// Pluggable OEM code page used to encode/decode short (8.3) filename bytes.
-pub trait OemCpConverter: core::fmt::Debug {
+/// See [`crate::time::TimeProvider`] for why this is `Sync`: `FatVolume` keeps
+/// the converter as a `&'static dyn OemCpConverter` and would otherwise not be
+/// `Send`.
+pub trait OemCpConverter: core::fmt::Debug + Sync {
     /// Encode a Unicode scalar to a single OEM byte, or `None` if the
     /// character is not representable.
     ///

--- a/crates/block/hadris-fat/src/time.rs
+++ b/crates/block/hadris-fat/src/time.rs
@@ -93,7 +93,11 @@ impl Default for FatDateTime {
 /// The type is intentionally trait-object friendly: the writer holds it as
 /// `&dyn TimeProvider` so callers can switch providers per-`FatVolume` instance
 /// without leaking generics through the public API.
-pub trait TimeProvider: core::fmt::Debug {
+/// The bound on `Sync` lets `FatVolume` stay `Send`: the volume holds the
+/// provider as a `&'static dyn TimeProvider`, and a shared reference is only
+/// `Send` if what it points at is `Sync`. Without it a volume cannot be moved
+/// into a mutex and shared across threads, which rules out kernel use.
+pub trait TimeProvider: core::fmt::Debug + Sync {
     /// Return the current FAT-encoded date/time.
     fn now(&self) -> FatDateTime;
 }

--- a/crates/block/hadris-fat/tests/v2_api.rs
+++ b/crates/block/hadris-fat/tests/v2_api.rs
@@ -1,5 +1,11 @@
 use hadris_fat::format::{FatFormatOptions, FatTypeSelection, FatVolumeFormatter};
 use hadris_fat::sync::{FatVolume, FatVolumeBuilder};
+use static_assertions::assert_impl_all;
+use std::io::Cursor;
+
+assert_impl_all!(FatVolume<Cursor<Vec<u8>>>: Send);
+assert_impl_all!(FatVolumeBuilder<Cursor<Vec<u8>>>: Send);
+assert_impl_all!(std::sync::Mutex<FatVolume<Cursor<Vec<u8>>>>: Send, Sync);
 
 #[test]
 fn canonical_v2_names_open_a_formatted_volume() {
@@ -26,4 +32,23 @@ fn file_entry_uses_len_vocabulary() {
     }
 
     let _ = accepts_entry;
+}
+
+#[test]
+fn volume_can_be_moved_into_a_mutex_and_shared_between_threads() {
+    let mut image = vec![0_u8; 2 * 1024 * 1024];
+    let options = FatFormatOptions::new(image.len() as u64)
+        .fat_type(FatTypeSelection::Fat12)
+        .volume_id(42);
+    let _ = FatVolumeFormatter::format(Cursor::new(&mut image[..]), options).unwrap();
+
+    let volume = FatVolume::open(Cursor::new(image)).unwrap();
+    let volume = std::sync::Arc::new(std::sync::Mutex::new(volume));
+    let worker_volume = std::sync::Arc::clone(&volume);
+
+    let fat_type = std::thread::spawn(move || worker_volume.lock().unwrap().fat_type())
+        .join()
+        .unwrap();
+
+    assert_eq!(fat_type, hadris_fat::FatType::Fat12);
 }


### PR DESCRIPTION
FatVolume stores both providers as &'static dyn references. A shared reference is only Send when its target is Sync, so without the bounds a volume cannot be moved into a mutex and shared across threads.