### PR TITLE
feat(fat): derive Clone for FileEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+### Added
+
+- **hadris-fat:** Directory entries and parse results now implement `Clone`,
+  allowing parsed metadata to be retained independently of directory iterators.
+
 ## [2.0.0] - 2026-08-09
 
 First stable release of the V2 API. This entry consolidates the changes made

--- a/crates/block/hadris-fat/src/dir.rs
+++ b/crates/block/hadris-fat/src/dir.rs
@@ -439,7 +439,7 @@ impl<DATA: Read + Seek> FatDirIter<'_, DATA> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A parsed FAT directory record.
 pub enum DirectoryEntry {
     /// A file or directory entry
@@ -466,7 +466,7 @@ impl DirectoryEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A parsed value together with non-fatal filesystem diagnostics.
 pub struct ParseInfo<T> {
     /// Parsed value.
@@ -493,11 +493,6 @@ bitflags::bitflags! {
 
 #[derive(Debug, Clone)]
 /// Metadata for a file or subdirectory entry.
-///
-/// `Clone` lets callers keep an entry after the iterator that produced it has
-/// been dropped, which is what any path-resolving layer on top of this crate
-/// needs: it walks a path component by component and has to carry the entry
-/// out of the borrow of its parent directory.
 pub struct FileEntry {
     pub(crate) short_name: ShortFileName,
     /// Windows NT 8.3 name case flags (`DIR_NTRes`); applied to the display

--- a/crates/block/hadris-fat/src/dir.rs
+++ b/crates/block/hadris-fat/src/dir.rs
@@ -491,8 +491,13 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Metadata for a file or subdirectory entry.
+///
+/// `Clone` lets callers keep an entry after the iterator that produced it has
+/// been dropped, which is what any path-resolving layer on top of this crate
+/// needs: it walks a path component by component and has to carry the entry
+/// out of the borrow of its parent directory.
 pub struct FileEntry {
     pub(crate) short_name: ShortFileName,
     /// Windows NT 8.3 name case flags (`DIR_NTRes`); applied to the display


### PR DESCRIPTION
A path-resolving layer on top of this crate walks a path component by component and has to carry each entry out of the borrow of its parent directory's iterator, which requires an owned copy. FileEntry is plain metadata, so the clone is cheap; the staleness caveats of holding on to an entry are the same as for the borrowed original.