### PR TITLE
Replace GPL-licensed noalloc dependency with heapless

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,17 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  licenses:
+    name: Dependency licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.88.0"
+          command: check
+          command-arguments: licenses
+
   # Enforce annotation grammar, evidence references, and coverage-table parity.
   # See docs/spec-coverage.md#annotation-convention.
   spec-annotations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Each published package owns its version and may be released independently.
 - **hadris-fat:** Directory entries and parse results now implement `Clone`,
   allowing parsed metadata to be retained independently of directory iterators.
 
+### Fixed
+
+- **hadris-common:** Replaced the GPL-licensed `noalloc` dependency with a
+  compatibility layer backed by `heapless` while preserving the existing
+  fixed-capacity collection API.
+- **Build:** Added a `cargo-deny` CI gate that rejects dependencies outside the
+  workspace's permissive-license allowlist.
+
 ## [2.0.0] - 2026-08-09
 
 First stable release of the V2 API. This entry consolidates the changes made

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,7 +515,7 @@ dependencies = [
  "hadris-fixed",
  "hadris-io",
  "hadris-path",
- "noalloc",
+ "heapless",
  "rand",
  "static_assertions",
  "zerocopy",
@@ -737,6 +743,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,12 +861,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "noalloc"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2537501480803dd22fbd79a39ea83318caba3ba936f7554f7139f4180faa94"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1124,6 +1143,12 @@ checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"

--- a/api-snapshots/hadris-common.txt
+++ b/api-snapshots/hadris-common.txt
@@ -262,9 +262,50 @@ pub fn hadris_common::types::layout::FileLayout::with_symlink_target(self, impl 
 pub fn hadris_common::types::layout::FileLayout::with_timestamps(self, hadris_common::types::extent::Timestamps) -> Self
 pub fn hadris_common::types::layout::FileLayout::with_type(self, hadris_common::types::extent::FileType) -> Self
 pub mod hadris_common::types::no_alloc
-pub use hadris_common::types::no_alloc::ArrayVec
-pub use hadris_common::types::no_alloc::ArrayVecError
-pub use hadris_common::types::no_alloc::RingBuf
+pub enum hadris_common::types::no_alloc::ArrayVecError
+pub hadris_common::types::no_alloc::ArrayVecError::CapacityOverflow
+impl core::error::Error for hadris_common::types::no_alloc::ArrayVecError
+impl core::fmt::Display for hadris_common::types::no_alloc::ArrayVecError
+pub fn hadris_common::types::no_alloc::ArrayVecError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct hadris_common::types::no_alloc::ArrayVec<T, const N: usize>
+impl<T, const N: usize> hadris_common::types::no_alloc::ArrayVec<T, N> where T: core::marker::Copy + core::cmp::Ord
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::sort_unstable(&mut self)
+impl<T, const N: usize> hadris_common::types::no_alloc::ArrayVec<T, N> where T: core::marker::Copy + core::cmp::PartialEq
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::contains(&self, &T) -> bool
+impl<T, const N: usize> hadris_common::types::no_alloc::ArrayVec<T, N>
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::as_mut_ptr(&mut self) -> *mut T
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::as_mut_slice(&mut self) -> &mut [T]
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::as_ptr(&self) -> *const T
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::as_slice(&self) -> &[T]
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::is_empty(&self) -> bool
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::iter(&self) -> core::slice::iter::Iter<'_, T>
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::iter_mut(&mut self) -> core::slice::iter::IterMut<'_, T>
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::len(&self) -> usize
+pub const fn hadris_common::types::no_alloc::ArrayVec<T, N>::new() -> Self
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::push(&mut self, T)
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::reverse(&mut self)
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::try_push(&mut self, T) -> core::result::Result<(), hadris_common::types::no_alloc::ArrayVecError>
+impl<T, const N: usize> core::default::Default for hadris_common::types::no_alloc::ArrayVec<T, N>
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::default() -> Self
+impl<T, const N: usize> core::ops::index::Index<usize> for hadris_common::types::no_alloc::ArrayVec<T, N> where T: core::marker::Copy
+pub type hadris_common::types::no_alloc::ArrayVec<T, N>::Output = T
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::index(&self, usize) -> &Self::Output
+impl<T, const N: usize> core::ops::index::IndexMut<usize> for hadris_common::types::no_alloc::ArrayVec<T, N> where T: core::marker::Copy
+pub fn hadris_common::types::no_alloc::ArrayVec<T, N>::index_mut(&mut self, usize) -> &mut Self::Output
+pub struct hadris_common::types::no_alloc::RingBuf<T: core::marker::Copy, const N: usize>
+impl<T: core::marker::Copy, const N: usize> hadris_common::types::no_alloc::RingBuf<T, N>
+pub const hadris_common::types::no_alloc::RingBuf<T, N>::SIZE: usize
+pub const fn hadris_common::types::no_alloc::RingBuf<T, N>::is_empty(&self) -> bool
+pub const fn hadris_common::types::no_alloc::RingBuf<T, N>::is_full(&self) -> bool
+pub const fn hadris_common::types::no_alloc::RingBuf<T, N>::len(&self) -> usize
+pub const fn hadris_common::types::no_alloc::RingBuf<T, N>::max_capacity(&self) -> usize
+pub const fn hadris_common::types::no_alloc::RingBuf<T, N>::new() -> Self
+pub fn hadris_common::types::no_alloc::RingBuf<T, N>::pop(&mut self) -> core::option::Option<T>
+pub fn hadris_common::types::no_alloc::RingBuf<T, N>::push(&mut self, T)
+pub unsafe fn hadris_common::types::no_alloc::RingBuf<T, N>::push_unchecked(&mut self, T)
+pub fn hadris_common::types::no_alloc::RingBuf<T, N>::try_push(&mut self, T) -> core::result::Result<(), T>
+impl<T: core::marker::Copy, const N: usize> core::default::Default for hadris_common::types::no_alloc::RingBuf<T, N>
+pub fn hadris_common::types::no_alloc::RingBuf<T, N>::default() -> Self
 pub mod hadris_common::types::number
 pub use hadris_common::types::number::I16Be
 pub use hadris_common::types::number::I16Le

--- a/crates/core/hadris-common/Cargo.toml
+++ b/crates/core/hadris-common/Cargo.toml
@@ -27,7 +27,7 @@ zerocopy = { workspace = true }
 chrono = { workspace = true, optional = true }
 crc = { version = "3.2.1", optional = true }
 rand = { version = "0.10.2", optional = true }
-noalloc = "0.0.1"
+heapless = "0.9.3"
 hadris-io = { workspace = true }  # For I/O traits in optical module
 hadris-fixed = { workspace = true }
 hadris-path = { workspace = true }

--- a/crates/core/hadris-common/src/types/no_alloc.rs
+++ b/crates/core/hadris-common/src/types/no_alloc.rs
@@ -1,2 +1,300 @@
-pub use noalloc::ringbuf::RingBuf;
-pub use noalloc::vec::{ArrayVec, ArrayVecError};
+use core::fmt;
+use core::ops::{Index, IndexMut};
+
+/// A fixed-capacity vector.
+#[derive(Debug)]
+pub struct ArrayVec<T, const N: usize> {
+    inner: heapless::Vec<T, N>,
+}
+
+/// An error returned when an [`ArrayVec`] has no remaining capacity.
+#[derive(Debug, Clone)]
+pub enum ArrayVecError {
+    /// The vector is full.
+    CapacityOverflow,
+}
+
+impl fmt::Display for ArrayVecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CapacityOverflow => f.write_str("capacity overflow"),
+        }
+    }
+}
+
+impl core::error::Error for ArrayVecError {}
+
+impl<T, const N: usize> ArrayVec<T, N> {
+    /// Creates an empty vector.
+    pub const fn new() -> Self {
+        Self {
+            inner: heapless::Vec::new(),
+        }
+    }
+
+    /// Appends a value, returning an error when the vector is full.
+    pub fn try_push(&mut self, value: T) -> Result<(), ArrayVecError> {
+        self.inner
+            .push(value)
+            .map_err(|_| ArrayVecError::CapacityOverflow)
+    }
+
+    /// Appends a value.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the vector is full.
+    pub fn push(&mut self, value: T) {
+        self.try_push(value).expect("ArrayVec: ran out of capacity");
+    }
+
+    /// Returns the number of stored values.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns whether the vector is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the stored values as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        self.inner.as_slice()
+    }
+
+    /// Returns the stored values as a mutable slice.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.inner.as_mut_slice()
+    }
+
+    /// Returns an iterator over the stored values.
+    pub fn iter(&self) -> core::slice::Iter<'_, T> {
+        self.inner.iter()
+    }
+
+    /// Returns a mutable iterator over the stored values.
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+        self.inner.iter_mut()
+    }
+
+    /// Reverses the stored values.
+    pub fn reverse(&mut self) {
+        self.inner.reverse();
+    }
+
+    /// Returns a pointer to the vector's storage.
+    pub fn as_ptr(&self) -> *const T {
+        self.inner.as_ptr()
+    }
+
+    /// Returns a mutable pointer to the vector's storage.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.inner.as_mut_ptr()
+    }
+}
+
+impl<T, const N: usize> Default for ArrayVec<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, const N: usize> ArrayVec<T, N>
+where
+    T: Copy + PartialEq,
+{
+    /// Returns whether the vector contains the given value.
+    pub fn contains(&self, value: &T) -> bool {
+        self.inner.contains(value)
+    }
+}
+
+impl<T, const N: usize> ArrayVec<T, N>
+where
+    T: Copy + Ord,
+{
+    /// Sorts the vector without preserving the order of equal values.
+    pub fn sort_unstable(&mut self) {
+        self.inner.sort_unstable();
+    }
+}
+
+impl<T, const N: usize> Index<usize> for ArrayVec<T, N>
+where
+    T: Copy,
+{
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl<T, const N: usize> IndexMut<usize> for ArrayVec<T, N>
+where
+    T: Copy,
+{
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.inner[index]
+    }
+}
+
+/// A fixed-capacity FIFO ring buffer.
+///
+/// A buffer with storage size `N` can hold at most `N - 1` values.
+#[derive(Clone, Copy)]
+pub struct RingBuf<T: Copy, const N: usize> {
+    buf: [Option<T>; N],
+    head: usize,
+    tail: usize,
+}
+
+impl<T: Copy, const N: usize> RingBuf<T, N> {
+    /// The number of storage slots in the buffer.
+    pub const SIZE: usize = N;
+
+    /// Creates an empty ring buffer.
+    pub const fn new() -> Self {
+        Self {
+            buf: [None; N],
+            head: 0,
+            tail: 0,
+        }
+    }
+
+    /// Returns whether the buffer is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.head == self.tail
+    }
+
+    /// Returns the number of stored values.
+    pub const fn len(&self) -> usize {
+        (self.head + Self::SIZE - self.tail) % Self::SIZE
+    }
+
+    /// Returns whether the buffer is full.
+    pub const fn is_full(&self) -> bool {
+        (self.head + 1) % N == self.tail
+    }
+
+    /// Returns the maximum number of values the buffer can hold.
+    pub const fn max_capacity(&self) -> usize {
+        Self::SIZE - 1
+    }
+
+    /// Appends a value, returning it when the buffer is full.
+    pub fn try_push(&mut self, value: T) -> Result<(), T> {
+        if self.is_full() {
+            return Err(value);
+        }
+
+        // SAFETY: The buffer was checked for remaining capacity.
+        unsafe { self.push_unchecked(value) };
+        Ok(())
+    }
+
+    /// Appends a value.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the buffer is full.
+    pub fn push(&mut self, value: T) {
+        if self.try_push(value).is_err() {
+            panic!("ringbuf is full");
+        }
+    }
+
+    /// Appends a value without checking whether the buffer is full.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the buffer is not full.
+    pub unsafe fn push_unchecked(&mut self, value: T) {
+        self.buf[self.head] = Some(value);
+        self.head = (self.head + 1) % N;
+    }
+
+    /// Removes and returns the oldest value.
+    pub fn pop(&mut self) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let value = self.buf[self.tail].take();
+        self.tail = (self.tail + 1) % N;
+        value
+    }
+}
+
+impl<T: Copy, const N: usize> Default for RingBuf<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    static_assertions::assert_impl_all!(RingBuf<u8, 4>: Clone, Copy);
+
+    #[test]
+    fn array_vec_preserves_values_and_capacity_errors() {
+        let mut values = ArrayVec::<u8, 2>::new();
+        values.push(2);
+        values.push(1);
+        assert!(matches!(
+            values.try_push(3),
+            Err(ArrayVecError::CapacityOverflow)
+        ));
+        values.sort_unstable();
+        assert_eq!(values.as_slice(), &[1, 2]);
+    }
+
+    #[test]
+    fn array_vec_drops_stored_values() {
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        struct DropCounter;
+
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        DROPS.store(0, Ordering::Relaxed);
+        {
+            let mut values = ArrayVec::<DropCounter, 2>::new();
+            values.push(DropCounter);
+            values.push(DropCounter);
+        }
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn array_vec_rejects_uninitialized_index() {
+        let mut values = ArrayVec::<u8, 2>::new();
+        values.push(1);
+        let _ = values[1];
+    }
+
+    #[test]
+    fn ring_buffer_wraps_and_preserves_fifo_order() {
+        let mut values = RingBuf::<u8, 4>::new();
+        values.push(1);
+        values.push(2);
+        values.push(3);
+        assert!(values.is_full());
+        assert_eq!(values.try_push(4), Err(4));
+        assert_eq!(values.pop(), Some(1));
+        values.push(4);
+        assert_eq!(values.pop(), Some(2));
+        assert_eq!(values.pop(), Some(3));
+        assert_eq!(values.pop(), Some(4));
+        assert_eq!(values.pop(), None);
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,11 @@
+[graph]
+all-features = true
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.8
+include-dev = true


### PR DESCRIPTION
## Summary

- replace the GPL-3.0-licensed `noalloc` dependency with `heapless`
- preserve the existing `hadris-common::types::no_alloc` public API through compatibility wrappers
- keep `RingBuf` locally implemented to preserve its existing `Copy` contract and `N - 1` capacity semantics
- add a `cargo-deny` license allowlist and CI check to prevent incompatible dependency licenses from being introduced
- update the changelog and public API snapshot

This removes GPL-licensed code from the Hadris dependency graph without requiring downstream API changes.

## Validation

- `cargo test -p hadris-common --lib`
- no-default-feature checks for `hadris-common` and `hadris-iso`
- `RUSTFLAGS="-D warnings" cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo deny check licenses`
- public API snapshot check
- targeted Miri tests for the compatibility collections
- pre-commit Clippy checks

Fixes #86