### PR TITLE
feat(fat): add FileReader::seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+### Added
+
+- **hadris-fat:** `FileReader` now supports start-, current-, and end-relative
+  seeking in both the synchronous and asynchronous APIs, including buffered
+  and cached-chain readers.
+
 ## [2.1.0] - 2026-08-18
 
 ### Added

--- a/api-snapshots/hadris-fat.txt
+++ b/api-snapshots/hadris-fat.txt
@@ -440,9 +440,11 @@ pub mod hadris_fat::async::read
 pub struct hadris_fat::async::read::FileReader<'a, DATA: hadris_io::async_api::Read + hadris_io::async_api::Seek>
 impl<'a, DATA: hadris_io::async_api::Read + hadris_io::async_api::Seek> hadris_fat::async::read::FileReader<'a, DATA>
 pub fn hadris_fat::async::read::FileReader<'a, DATA>::new(&'a hadris_fat::async::fs::FatVolume<DATA>, &hadris_fat::async::dir::FileEntry) -> hadris_fat::error::Result<Self>
+pub fn hadris_fat::async::read::FileReader<'a, DATA>::position(&self) -> u64
 pub async fn hadris_fat::async::read::FileReader<'a, DATA>::read(&mut self, &mut [u8]) -> hadris_fat::error::Result<usize>
 pub async fn hadris_fat::async::read::FileReader<'a, DATA>::read_to_vec(&mut self) -> hadris_fat::error::Result<alloc::vec::Vec<u8>>
 pub fn hadris_fat::async::read::FileReader<'a, DATA>::remaining(&self) -> usize
+pub async fn hadris_fat::async::read::FileReader<'a, DATA>::seek(&mut self, embedded_io::SeekFrom) -> hadris_fat::error::Result<u64>
 pub fn hadris_fat::async::read::FileReader<'a, DATA>::size(&self) -> usize
 pub fn hadris_fat::async::read::FileReader<'a, DATA>::with_buffer(self) -> Self
 pub async fn hadris_fat::async::read::FileReader<'a, DATA>::with_cached_chain(self) -> hadris_fat::error::Result<Self>
@@ -1485,9 +1487,11 @@ pub mod hadris_fat::read
 pub struct hadris_fat::read::FileReader<'a, DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<'a, DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_fat::read::FileReader<'a, DATA>
 pub fn hadris_fat::read::FileReader<'a, DATA>::new(&'a hadris_fat::fs::FatVolume<DATA>, &hadris_fat::dir::FileEntry) -> hadris_fat::error::Result<Self>
+pub fn hadris_fat::read::FileReader<'a, DATA>::position(&self) -> u64
 pub fn hadris_fat::read::FileReader<'a, DATA>::read(&mut self, &mut [u8]) -> hadris_fat::error::Result<usize>
 pub fn hadris_fat::read::FileReader<'a, DATA>::read_to_vec(&mut self) -> hadris_fat::error::Result<alloc::vec::Vec<u8>>
 pub fn hadris_fat::read::FileReader<'a, DATA>::remaining(&self) -> usize
+pub fn hadris_fat::read::FileReader<'a, DATA>::seek(&mut self, embedded_io::SeekFrom) -> hadris_fat::error::Result<u64>
 pub fn hadris_fat::read::FileReader<'a, DATA>::size(&self) -> usize
 pub fn hadris_fat::read::FileReader<'a, DATA>::with_buffer(self) -> Self
 pub fn hadris_fat::read::FileReader<'a, DATA>::with_cached_chain(self) -> hadris_fat::error::Result<Self>
@@ -1979,9 +1983,11 @@ pub mod hadris_fat::sync::read
 pub struct hadris_fat::sync::read::FileReader<'a, DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek>
 impl<'a, DATA: hadris_io::sync_api::Read + hadris_io::sync_api::Seek> hadris_fat::read::FileReader<'a, DATA>
 pub fn hadris_fat::read::FileReader<'a, DATA>::new(&'a hadris_fat::fs::FatVolume<DATA>, &hadris_fat::dir::FileEntry) -> hadris_fat::error::Result<Self>
+pub fn hadris_fat::read::FileReader<'a, DATA>::position(&self) -> u64
 pub fn hadris_fat::read::FileReader<'a, DATA>::read(&mut self, &mut [u8]) -> hadris_fat::error::Result<usize>
 pub fn hadris_fat::read::FileReader<'a, DATA>::read_to_vec(&mut self) -> hadris_fat::error::Result<alloc::vec::Vec<u8>>
 pub fn hadris_fat::read::FileReader<'a, DATA>::remaining(&self) -> usize
+pub fn hadris_fat::read::FileReader<'a, DATA>::seek(&mut self, embedded_io::SeekFrom) -> hadris_fat::error::Result<u64>
 pub fn hadris_fat::read::FileReader<'a, DATA>::size(&self) -> usize
 pub fn hadris_fat::read::FileReader<'a, DATA>::with_buffer(self) -> Self
 pub fn hadris_fat::read::FileReader<'a, DATA>::with_cached_chain(self) -> hadris_fat::error::Result<Self>

--- a/crates/block/hadris-fat/README.md
+++ b/crates/block/hadris-fat/README.md
@@ -32,9 +32,21 @@ let mut iter = root.entries();
 while let Some(Ok(entry)) = iter.next_entry() {
     println!("{}", entry.name());
 }
+
+if let Some(entry) = root.find("README.TXT")? {
+    let mut reader = fs.read_file(&entry)?;
+    reader.seek(hadris_fat::SeekFrom::Start(128))?;
+    let mut buffer = [0_u8; 64];
+    let read = reader.read(&mut buffer)?;
+    println!("{}", String::from_utf8_lossy(&buffer[..read]));
+}
 # Ok(())
 # }
 ```
+
+`FileReader::seek` accepts start-, current-, and end-relative positions. As
+with `std::io::Seek`, positions past the end are valid and reads there return
+zero bytes.
 
 ### Writing to a FAT Filesystem
 

--- a/crates/block/hadris-fat/src/read.rs
+++ b/crates/block/hadris-fat/src/read.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 use crate::error::{Error, Result};
 use super::{
     fs::FatVolume, dir::FileEntry,
-    io::{Cluster, ClusterLike, Read, Seek, SeekFrom},
+    io::{Cluster, ClusterLike, ErrorKind, Read, Seek, SeekFrom},
 };
 
 /// A reader for file content in a FAT filesystem.
@@ -31,11 +31,13 @@ use super::{
 ///   This is useful for small files where you want to avoid repeated FAT lookups.
 pub struct FileReader<'a, DATA: Read + Seek> {
     fs: &'a FatVolume<DATA>,
+    /// First cluster of the file, as recorded in the directory entry.
+    first_cluster: Cluster<usize>,
     cluster: Cluster<usize>,
     /// Offset within the current cluster
     offset_in_cluster: usize,
-    /// Total bytes read so far
-    total_read: usize,
+    /// Current logical position in the file
+    position: u64,
     /// Total size of the file
     size: usize,
     /// Cluster transitions taken so far. Bounded by `Fat::max_cluster()` so a
@@ -64,9 +66,10 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
 
         Ok(Self {
             fs,
+            first_cluster: entry.cluster(),
             cluster: entry.cluster(),
             offset_in_cluster: 0,
-            total_read: 0,
+            position: 0,
             size: entry.len() as usize,
             cluster_steps: 0,
             #[cfg(feature = "alloc")]
@@ -83,9 +86,14 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
         self.size
     }
 
+    /// Returns the current logical position in the file.
+    pub fn position(&self) -> u64 {
+        self.position
+    }
+
     /// Returns the number of bytes remaining to be read.
     pub fn remaining(&self) -> usize {
-        self.size.saturating_sub(self.total_read)
+        (self.size as u64).saturating_sub(self.position) as usize
     }
 
     /// Enable cluster-level buffering.
@@ -105,12 +113,13 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
     ///
     /// This reads the entire FAT chain for the file into memory, eliminating
     /// the need for FAT lookups during sequential reads. This is most beneficial
-    /// for fragmented files or when performing many random seeks.
+    /// for fragmented files or when performing many random seeks. The current
+    /// logical position is preserved.
     ///
     /// Memory usage: 4 bytes per cluster in the file.
     #[cfg(feature = "alloc")]
     pub async fn with_cached_chain(mut self) -> Result<Self> {
-        if self.cluster.0 < 2 {
+        if self.first_cluster.0 < 2 {
             // Empty file, no chain to cache
             self.cached_chain = Some(Vec::new());
             return Ok(self);
@@ -118,15 +127,34 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
 
         let max_clusters = self.fs.info.max_cluster as usize;
         let mut data = self.fs.data.lock();
+        let cluster_size = data.cluster_size;
         let chain = self
             .fs
             .fat
-            .read_chain(data.deref_mut(), self.cluster.0 as u32, max_clusters)
+            .read_chain(
+                data.deref_mut(),
+                self.first_cluster.0 as u32,
+                max_clusters,
+            )
             .await?;
         drop(data);
 
+        if self.position < self.size as u64 {
+            let chain_index = self.position as usize / cluster_size;
+            let cluster = chain
+                .get(chain_index)
+                .copied()
+                .ok_or(Error::UnexpectedEndOfChain {
+                    cluster: chain
+                        .last()
+                        .copied()
+                        .unwrap_or(self.first_cluster.0 as u32),
+                })?;
+            self.cluster.0 = cluster as usize;
+            self.offset_in_cluster = self.position as usize % cluster_size;
+            self.chain_index = chain_index;
+        }
         self.cached_chain = Some(chain);
-        self.chain_index = 0;
         Ok(self)
     }
 
@@ -204,7 +232,7 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
                     data.read_exact(&mut buf[total..total + to_read]).await?;
 
                     total += to_read;
-                    self.total_read += to_read;
+                    self.position += to_read as u64;
 
                     // Advance by clusters we consumed
                     let new_offset = offset_in_cluster + to_read;
@@ -242,7 +270,7 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
     /// cached; advances to the next FAT cluster when the current one is exhausted.
     async fn read_one_chunk(&mut self, buf: &mut [u8]) -> Result<usize> {
         // End of logical file
-        if self.total_read >= self.size {
+        if self.position >= self.size as u64 {
             return Ok(0);
         }
 
@@ -323,7 +351,7 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
 
         // How much we can copy from the current cluster in this step.
         let bytes_left_in_cluster = cluster_size - self.offset_in_cluster;
-        let bytes_left_in_file = self.size - self.total_read;
+        let bytes_left_in_file = (self.size as u64 - self.position) as usize;
         let read_max = buf.len().min(bytes_left_in_cluster).min(bytes_left_in_file);
 
         if read_max == 0 {
@@ -361,9 +389,98 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
         };
 
         self.offset_in_cluster += bytes_read;
-        self.total_read += bytes_read;
+        self.position += bytes_read as u64;
 
         Ok(bytes_read)
+    }
+
+    /// Reposition the reader within the file.
+    ///
+    /// Follows `std::io::Seek` semantics: `Start`/`Current`/`End` are all
+    /// supported, seeking beyond the end of the file is allowed (subsequent
+    /// reads return 0), and seeking before the start is an error. Returns the
+    /// new position from the start of the file.
+    pub async fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        fn invalid(message: &'static str) -> Error {
+            Error::Io(hadris_io::Error::new(ErrorKind::InvalidInput, message))
+        }
+
+        let target = match pos {
+            SeekFrom::Start(position) => Some(position),
+            SeekFrom::Current(offset) => self.position.checked_add_signed(offset),
+            SeekFrom::End(offset) => (self.size as u64).checked_add_signed(offset),
+        }
+        .ok_or_else(|| invalid("invalid seek position"))?;
+
+        if target >= self.size as u64 || self.first_cluster.0 < 2 {
+            self.position = target;
+            return Ok(target);
+        }
+
+        let target_usize = target as usize;
+        let cluster_size = self.fs.data.lock().cluster_size;
+        let target_cluster = target_usize / cluster_size;
+        let target_offset = target_usize % cluster_size;
+
+        #[cfg(feature = "alloc")]
+        if let Some(ref chain) = self.cached_chain {
+            let cluster = *chain
+                .get(target_cluster)
+                .ok_or(Error::UnexpectedEndOfChain {
+                    cluster: chain.last().copied().unwrap_or(self.first_cluster.0 as u32),
+                })?;
+            if let Some(ref mut buffer) = self.cluster_buffer {
+                buffer.clear();
+            }
+            self.chain_index = target_cluster;
+            self.cluster.0 = cluster as usize;
+            self.offset_in_cluster = target_offset;
+            self.position = target;
+            return Ok(target);
+        }
+
+        let current_cluster = (self.position as usize).saturating_sub(self.offset_in_cluster)
+            / cluster_size;
+
+        let (mut cluster, mut hops, mut cluster_steps) = if self.position >= self.size as u64 {
+            (self.first_cluster.0, target_cluster, 0)
+        } else if target_cluster >= current_cluster {
+            (
+                self.cluster.0,
+                target_cluster - current_cluster,
+                self.cluster_steps,
+            )
+        } else {
+            (self.first_cluster.0, target_cluster, 0)
+        };
+
+        while hops > 0 {
+            cluster_steps = cluster_steps.saturating_add(1);
+            if cluster_steps > self.fs.fat.max_cluster() {
+                return Err(Error::ClusterLoop {
+                    cluster: cluster as u32,
+                });
+            }
+            cluster = self
+                .fs
+                .next_cluster_routed(cluster)
+                .await?
+                .ok_or(Error::UnexpectedEndOfChain {
+                    cluster: cluster as u32,
+                })? as usize;
+            hops -= 1;
+        }
+
+        #[cfg(feature = "alloc")]
+        if let Some(ref mut buffer) = self.cluster_buffer {
+            buffer.clear();
+        }
+        self.cluster_steps = cluster_steps;
+        self.cluster.0 = cluster;
+        self.offset_in_cluster = target_offset;
+        self.position = target;
+
+        Ok(target)
     }
 
     /// Read all bytes from the current read position through the end of the file.

--- a/crates/block/hadris-fat/tests/async_roundtrip.rs
+++ b/crates/block/hadris-fat/tests/async_roundtrip.rs
@@ -12,6 +12,7 @@ use std::task::{Wake, Waker};
 
 use hadris_fat::r#async::FatVolume;
 use hadris_fat::sync::FatVolumeWriteExt;
+use hadris_io::SeekFrom;
 
 struct ThreadWaker(std::thread::Thread);
 
@@ -56,8 +57,33 @@ fn async_leaf_open_traverse_and_read_multicluster_file() {
         let nested = volume.open_dir_path("./NESTED").await.unwrap();
         assert!(nested.find("PAYLOAD.BIN").await.unwrap().is_some());
 
-        let mut reader = volume.open_file_path("NESTED//PAYLOAD.BIN").await.unwrap();
+        let mut reader = volume
+            .open_file_path("NESTED//PAYLOAD.BIN")
+            .await
+            .unwrap()
+            .with_buffer()
+            .with_cached_chain()
+            .await
+            .unwrap();
+        let mut chunk = [0_u8; 41];
+        assert_eq!(reader.seek(SeekFrom::Start(700)).await.unwrap(), 700);
+        assert_eq!(reader.read(&mut chunk).await.unwrap(), chunk.len());
+        assert_eq!(&chunk, &payload[700..741]);
+        assert_eq!(reader.seek(SeekFrom::Current(-50)).await.unwrap(), 691);
+        assert_eq!(reader.read(&mut chunk[..9]).await.unwrap(), 9);
+        assert_eq!(&chunk[..9], &payload[691..700]);
+        assert_eq!(reader.seek(SeekFrom::End(-7)).await.unwrap(), 1530);
+        assert_eq!(reader.read(&mut chunk).await.unwrap(), 7);
+        assert_eq!(&chunk[..7], &payload[1530..]);
+        assert_eq!(reader.seek(SeekFrom::Start(0)).await.unwrap(), 0);
         assert_eq!(reader.read_to_vec().await.unwrap(), payload);
+
+        let mut late_cached = volume.open_file_path("NESTED/PAYLOAD.BIN").await.unwrap();
+        late_cached.seek(SeekFrom::Start(700)).await.unwrap();
+        let mut late_cached = late_cached.with_cached_chain().await.unwrap();
+        late_cached.seek(SeekFrom::Start(0)).await.unwrap();
+        assert_eq!(late_cached.read(&mut chunk[..1]).await.unwrap(), 1);
+        assert_eq!(chunk[0], payload[0]);
         assert!(volume.open_path("../PAYLOAD.BIN").await.is_err());
     });
 }

--- a/crates/block/hadris-fat/tests/fat_roundtrip.rs
+++ b/crates/block/hadris-fat/tests/fat_roundtrip.rs
@@ -18,6 +18,7 @@ use tempfile::TempDir;
 
 use hadris_fat::format::{FatFormatOptions, FatTypeSelection, FatVolumeFormatter};
 use hadris_fat::{FatType, FatVolume, FatVolumeReadExt, FatVolumeWriteExt};
+use hadris_io::SeekFrom;
 
 #[path = "common/fat.rs"]
 mod fat_helpers;
@@ -143,6 +144,50 @@ fn assert_fat_type(image_path: &Path, expected: FatType) {
     assert_eq!(fs.fat_type(), expected, "unexpected FAT type on disk");
 }
 
+fn assert_seek_behavior<DATA>(reader: &mut hadris_fat::read::FileReader<'_, DATA>, payload: &[u8])
+where
+    DATA: hadris_fat::Read + hadris_fat::Seek,
+{
+    let mut buf = [0_u8; 37];
+
+    assert_eq!(reader.position(), 0);
+    assert_eq!(reader.seek(SeekFrom::Start(12_345)).unwrap(), 12_345);
+    assert_eq!(reader.read(&mut buf).unwrap(), buf.len());
+    assert_eq!(&buf, &payload[12_345..12_345 + buf.len()]);
+
+    assert_eq!(reader.seek(SeekFrom::Current(-20)).unwrap(), 12_362);
+    assert_eq!(reader.read(&mut buf[..20]).unwrap(), 20);
+    assert_eq!(&buf[..20], &payload[12_362..12_382]);
+
+    assert_eq!(
+        reader.seek(SeekFrom::End(-64)).unwrap(),
+        payload.len() as u64 - 64
+    );
+    assert_eq!(reader.read(&mut buf).unwrap(), buf.len());
+    assert_eq!(&buf, &payload[payload.len() - 64..payload.len() - 27]);
+
+    let past_end = payload.len() as u64 + 17;
+    assert_eq!(reader.seek(SeekFrom::Start(past_end)).unwrap(), past_end);
+    assert_eq!(reader.remaining(), 0);
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    assert_eq!(
+        reader.seek(SeekFrom::Current(-18)).unwrap(),
+        payload.len() as u64 - 1
+    );
+    assert_eq!(reader.read(&mut buf).unwrap(), 1);
+    assert_eq!(buf[0], payload[payload.len() - 1]);
+
+    assert_eq!(reader.seek(SeekFrom::Start(u64::MAX)).unwrap(), u64::MAX);
+    assert_eq!(reader.seek(SeekFrom::Current(-1)).unwrap(), u64::MAX - 1);
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+
+    assert_eq!(reader.seek(SeekFrom::Start(10)).unwrap(), 10);
+    assert!(reader.seek(SeekFrom::Current(-11)).is_err());
+    assert_eq!(reader.position(), 10);
+    assert_eq!(reader.read(&mut buf[..1]).unwrap(), 1);
+    assert_eq!(buf[0], payload[10]);
+}
+
 // =============================================================================
 // FAT12 — small volume (~2 MB)
 // =============================================================================
@@ -188,6 +233,45 @@ fn fat12_roundtrip_multi_cluster_file() {
     let got = read_root_file(&img, "BLOB.BIN");
     assert_eq!(got.len(), payload.len(), "FAT12 size mismatch");
     assert_eq!(got, payload, "FAT12 content mismatch");
+}
+
+#[test]
+fn fat12_file_reader_seek() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("fat12_seek.img");
+    make_image(&img, FAT12_SIZE, FatTypeSelection::Fat12, "FAT12SEEK");
+
+    let payload: Vec<u8> = (0..(32 * 1024)).map(|i| (i * 31 + 7) as u8).collect();
+    write_root_file(&img, "SEEK.BIN", &payload);
+
+    let file = open_image(&img);
+    let fs = FatVolume::open(file).expect("open FAT");
+    let entry = fs
+        .root_dir()
+        .find("SEEK.BIN")
+        .expect("find")
+        .expect("present");
+
+    let mut reader = fs.read_file(&entry).expect("read_file");
+    assert_seek_behavior(&mut reader, &payload);
+
+    let mut buffered = fs.read_file(&entry).expect("read_file").with_buffer();
+    assert_seek_behavior(&mut buffered, &payload);
+
+    let mut cached = fs
+        .read_file(&entry)
+        .expect("read_file")
+        .with_buffer()
+        .with_cached_chain()
+        .expect("cache chain");
+    assert_seek_behavior(&mut cached, &payload);
+
+    let empty = fs.create_file(&fs.root_dir(), "EMPTY.BIN").unwrap();
+    let mut empty_reader = fs.read_file(&empty).unwrap();
+    assert_eq!(empty_reader.seek(SeekFrom::End(17)).unwrap(), 17);
+    assert_eq!(empty_reader.seek(SeekFrom::Current(-17)).unwrap(), 0);
+    assert!(empty_reader.seek(SeekFrom::End(-1)).is_err());
+    assert_eq!(empty_reader.position(), 0);
 }
 
 // =============================================================================

--- a/crates/block/hadris-fat/tests/poc_seek.rs
+++ b/crates/block/hadris-fat/tests/poc_seek.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "write")]
+//! Regression POCs for the original PR #89 implementation (`bdb46ce`).
+//! The first returned `InvalidInput`; the second read from the cluster where
+//! caching was enabled instead of the file's first cluster.
+
+use std::fs::{File, OpenOptions};
+use std::io::Read as _;
+use std::path::PathBuf;
+
+use hadris_fat::format::{FatFormatOptions, FatTypeSelection, FatVolumeFormatter};
+use hadris_fat::{FatVolume, FatVolumeReadExt, FatVolumeWriteExt};
+use hadris_io::SeekFrom;
+use tempfile::TempDir;
+
+const IMAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+fn fixture() -> (TempDir, PathBuf, Vec<u8>, usize) {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("seek-poc.img");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap();
+    file.set_len(IMAGE_SIZE).unwrap();
+    FatVolumeFormatter::format(
+        file,
+        FatFormatOptions::new(IMAGE_SIZE).fat_type(FatTypeSelection::Fat12),
+    )
+    .unwrap();
+
+    let mut boot = [0_u8; 64];
+    File::open(&path).unwrap().read_exact(&mut boot).unwrap();
+    let cluster_size = u16::from_le_bytes([boot[11], boot[12]]) as usize * boot[13] as usize;
+    let payload: Vec<u8> = (0..cluster_size * 4)
+        .map(|offset| (offset / cluster_size) as u8)
+        .collect();
+
+    let fs = FatVolume::open(
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap(),
+    )
+    .unwrap();
+    let entry = fs.create_file(&fs.root_dir(), "SEEK.BIN").unwrap();
+    let mut writer = fs.write_file(&entry).unwrap();
+    writer.write(&payload).unwrap();
+    writer.finish().unwrap();
+    drop(fs);
+
+    (tmp, path, payload, cluster_size)
+}
+
+#[test]
+fn relative_seek_after_large_absolute_seek() {
+    let (_tmp, path, _payload, _cluster_size) = fixture();
+    let fs = FatVolume::open(OpenOptions::new().read(true).open(path).unwrap()).unwrap();
+    let entry = fs.root_dir().find("SEEK.BIN").unwrap().unwrap();
+    let mut reader = fs.read_file(&entry).unwrap();
+
+    assert_eq!(reader.seek(SeekFrom::Start(u64::MAX)).unwrap(), u64::MAX);
+    assert_eq!(reader.seek(SeekFrom::Current(-1)).unwrap(), u64::MAX - 1);
+}
+
+#[test]
+fn cache_enabled_after_seek_keeps_absolute_chain_origin() {
+    let (_tmp, path, payload, cluster_size) = fixture();
+    let fs = FatVolume::open(OpenOptions::new().read(true).open(path).unwrap()).unwrap();
+    let entry = fs.root_dir().find("SEEK.BIN").unwrap().unwrap();
+    let mut reader = fs.read_file(&entry).unwrap();
+
+    reader
+        .seek(SeekFrom::Start(cluster_size as u64 + 7))
+        .unwrap();
+    let mut reader = reader.with_cached_chain().unwrap();
+    reader.seek(SeekFrom::Start(0)).unwrap();
+
+    let mut byte = [0_u8; 1];
+    assert_eq!(reader.read(&mut byte).unwrap(), 1);
+    assert_eq!(byte[0], payload[0]);
+}


### PR DESCRIPTION
FileReader was strictly sequential: a positioned read had to consume the offset by reading and discarding, costing O(offset) in data I/O.

seek() follows std::io::Seek semantics: Start/Current/End, positions past EOF are allowed (subsequent reads return 0), positions before the start are an error. It never touches file data. Within the current cluster it only adjusts offsets; forward it walks the FAT chain from the current cluster; backward it re-walks from the file's first cluster, which the reader now records, since FAT chains are singly linked. With a cached chain any position is O(1). 