### PR TITLE
fix(fat): stop leaking the old cluster chain when overwriting a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Each published package owns its version and may be released independently.
   seeking in both the synchronous and asynchronous APIs, including buffered
   and cached-chain readers.
 
+### Fixed
+
+- **hadris-fat:** Overwriting an existing file through `write_file` no longer
+  leaks the file's previous cluster chain. The writer now follows and reuses
+  the existing chain, and `finish()` frees any tail clusters left over when
+  the new contents are shorter than the old, keeping the FAT and the FSInfo
+  free-cluster count consistent. Previously every overwrite of a multi-cluster
+  file orphaned all but its first cluster, eventually failing with
+  `NoFreeSpace` (#90).
+
 ## [2.1.0] - 2026-08-18
 
 ### Added

--- a/crates/block/hadris-fat/src/write.rs
+++ b/crates/block/hadris-fat/src/write.rs
@@ -200,20 +200,35 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
         while written < buf.len() {
             // Check if we need a new cluster
             if self.current_cluster.is_none() || self.offset_in_cluster >= cluster_size {
-                // Allocate via the routed helper so the FAT cache (when
-                // installed) sees the mutation. The helper acquires both
-                // cache+data locks internally in canonical order.
-                let hint = self.current_cluster.map(|c| c.0 as u32 + 1).unwrap_or(2);
-                let new_cluster = self.fs.allocate_cluster_routed(hint).await?;
+                // Reuse the file's existing chain before allocating: an
+                // overwrite must not orphan the old clusters (issue #90).
+                let existing_next = match self.current_cluster {
+                    Some(cur) => self.fs.next_cluster_routed(cur.0).await?,
+                    None => None,
+                };
 
-                // Update FSInfo tracking (FAT32 only)
-                self.fs.decrement_free_count();
-                self.fs.update_next_free_hint(new_cluster);
+                let new_cluster = match existing_next {
+                    Some(next) => next,
+                    None => {
+                        // Allocate via the routed helper so the FAT cache
+                        // (when installed) sees the mutation. The helper
+                        // acquires both cache+data locks internally in
+                        // canonical order.
+                        let hint = self.current_cluster.map(|c| c.0 as u32 + 1).unwrap_or(2);
+                        let new_cluster = self.fs.allocate_cluster_routed(hint).await?;
 
-                // Link previous cluster to the new one (also routed).
-                if let Some(prev) = self.current_cluster {
-                    self.fs.write_clus_routed(prev.0, new_cluster).await?;
-                }
+                        // Update FSInfo tracking (FAT32 only)
+                        self.fs.decrement_free_count();
+                        self.fs.update_next_free_hint(new_cluster);
+
+                        // Link previous cluster to the new one (also routed).
+                        if let Some(prev) = self.current_cluster {
+                            self.fs.write_clus_routed(prev.0, new_cluster).await?;
+                        }
+
+                        new_cluster
+                    }
+                };
 
                 // Update first cluster if this is the first allocation
                 if self.first_cluster.is_none() {
@@ -290,6 +305,20 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
     /// without calling `finish` panics — the most common cause of "the file
     /// I just wrote shows up as zero bytes" bugs.
     pub async fn finish(mut self) -> Result<()> {
+        // Release clusters the rewrite no longer needs and terminate the
+        // chain at the last written cluster. Must run before the data lock
+        // below — the routed helpers acquire their own locks.
+        if self.total_written == 0 {
+            if let Some(first) = self.first_cluster.take() {
+                let freed_count = self.fs.free_chain_routed(first.0 as u32).await?;
+                self.fs.increment_free_count(freed_count);
+                self.current_cluster = None;
+            }
+        } else if let Some(last) = self.current_cluster {
+            let freed_count = self.fs.truncate_chain_routed(last.0 as u32).await?;
+            self.fs.increment_free_count(freed_count);
+        }
+
         {
             let mut data = self.fs.data.lock();
             let cluster_size = data.cluster_size;

--- a/crates/block/hadris-fat/tests/test_write.rs
+++ b/crates/block/hadris-fat/tests/test_write.rs
@@ -1123,6 +1123,196 @@ mod integration_tests {
         let content = reader.read_to_vec().expect("Read failed");
         assert_eq!(&content, b"First part. ");
     }
+
+    /// Regression test for issue #90: overwriting an existing multi-cluster
+    /// file must reuse the old chain instead of allocating fresh clusters and
+    /// orphaning the old ones. The test image has 256 data clusters; with the
+    /// historical leak of (file_clusters - 1) per pass, 100 passes exhausted
+    /// the volume with `NoFreeSpace`.
+    #[test]
+    fn test_overwrite_file_does_not_leak_clusters() {
+        let image = create_fat32_image();
+        let fs = FatVolume::open(image).expect("Failed to open FAT32 image");
+
+        let root = fs.root_dir();
+        let entry = fs
+            .create_file(&root, "DATA.BIN")
+            .expect("Failed to create file");
+
+        let content_len = cluster_size() * 4;
+        let pattern = |seed: u8| -> Vec<u8> {
+            (0..content_len)
+                .map(|i| (i as u8).wrapping_mul(31).wrapping_add(seed))
+                .collect()
+        };
+
+        {
+            let mut writer = fs.write_file(&entry).expect("Failed to get writer");
+            writer.write(&pattern(0)).expect("Failed to write");
+            writer.finish().expect("Failed to finish");
+        }
+        let baseline_free = fs.free_cluster_count().expect("FAT32 free count");
+
+        for pass in 0..100u8 {
+            let entry = fs
+                .root_dir()
+                .find("DATA.BIN")
+                .expect("Find failed")
+                .expect("File not found");
+            let contents = pattern(pass.wrapping_add(1));
+            let mut writer = fs.write_file(&entry).expect("Failed to get writer");
+            writer
+                .write(&contents)
+                .unwrap_or_else(|e| panic!("write failed on pass {pass}: {e:?}"));
+            writer.finish().expect("Failed to finish");
+
+            assert_eq!(
+                fs.free_cluster_count().expect("FAT32 free count"),
+                baseline_free,
+                "overwrite leaked clusters on pass {pass}",
+            );
+        }
+
+        let entry = fs
+            .root_dir()
+            .find("DATA.BIN")
+            .expect("Find failed")
+            .expect("File not found");
+        assert_eq!(entry.len() as usize, content_len);
+        use hadris_fat::FatVolumeReadExt;
+        let mut reader = fs.read_file(&entry).expect("Failed to get reader");
+        assert_eq!(reader.read_to_vec().expect("Read failed"), pattern(100));
+
+        // FSInfo must agree with the FAT itself, so a fudged free count
+        // cannot mask a real leak.
+        let free_count = fs.free_cluster_count().expect("FAT32 free count");
+        let image = fs.into_inner().into_inner();
+        let fat_start = super::fat32_image::fat_start_bytes();
+        let fat_free = (2..2 + 256usize)
+            .filter(|&c| {
+                let off = fat_start + c * 4;
+                let entry = u32::from_le_bytes(image[off..off + 4].try_into().unwrap());
+                entry & 0x0FFF_FFFF == 0
+            })
+            .count() as u32;
+        assert_eq!(
+            fat_free, free_count,
+            "FSInfo free count disagrees with the FAT"
+        );
+    }
+
+    /// Overwriting with less data than before must terminate the chain at the
+    /// new last cluster and free the tail clusters.
+    #[test]
+    fn test_overwrite_shrinking_file_frees_tail_clusters() {
+        let image = create_fat32_image();
+        let fs = FatVolume::open(image).expect("Failed to open FAT32 image");
+
+        let root = fs.root_dir();
+        let entry = fs
+            .create_file(&root, "SHRINK.BIN")
+            .expect("Failed to create file");
+
+        {
+            let mut writer = fs.write_file(&entry).expect("Failed to get writer");
+            writer
+                .write(&vec![0xAAu8; cluster_size() * 4])
+                .expect("Failed to write");
+            writer.finish().expect("Failed to finish");
+        }
+        let free_after_big = fs.free_cluster_count().expect("FAT32 free count");
+
+        let entry = fs
+            .root_dir()
+            .find("SHRINK.BIN")
+            .expect("Find failed")
+            .expect("File not found");
+        let small = b"tiny";
+        {
+            let mut writer = fs.write_file(&entry).expect("Failed to get writer");
+            writer.write(small).expect("Failed to write");
+            writer.finish().expect("Failed to finish");
+        }
+
+        assert_eq!(
+            fs.free_cluster_count().expect("FAT32 free count"),
+            free_after_big + 3,
+            "tail clusters were not freed on shrinking overwrite",
+        );
+
+        let entry = fs
+            .root_dir()
+            .find("SHRINK.BIN")
+            .expect("Find failed")
+            .expect("File not found");
+        assert_eq!(entry.len(), small.len() as u64);
+        use hadris_fat::FatVolumeReadExt;
+        let mut reader = fs.read_file(&entry).expect("Failed to get reader");
+        assert_eq!(reader.read_to_vec().expect("Read failed"), small);
+
+        // The chain must be exactly one cluster, terminated with EOC.
+        let first = entry.cluster().0;
+        let image = fs.into_inner().into_inner();
+        let fat_start = super::fat32_image::fat_start_bytes();
+        let off = fat_start + first * 4;
+        let fat_entry = u32::from_le_bytes(image[off..off + 4].try_into().unwrap()) & 0x0FFF_FFFF;
+        assert!(
+            fat_entry >= 0x0FFF_FFF8,
+            "first cluster does not terminate the chain: FAT[{first}] = {fat_entry:#x}",
+        );
+    }
+
+    /// Deleting a file must return every cluster of its chain to the free
+    /// pool, in both the FSInfo count and the FAT itself.
+    #[test]
+    fn test_delete_file_frees_all_clusters() {
+        let image = create_fat32_image();
+        let fs = FatVolume::open(image).expect("Failed to open FAT32 image");
+
+        let free_before = fs.free_cluster_count().expect("FAT32 free count");
+
+        let root = fs.root_dir();
+        let entry = fs
+            .create_file(&root, "DOOMED.BIN")
+            .expect("Failed to create file");
+        {
+            let mut writer = fs.write_file(&entry).expect("Failed to get writer");
+            writer
+                .write(&vec![0x55u8; cluster_size() * 4])
+                .expect("Failed to write");
+            writer.finish().expect("Failed to finish");
+        }
+        let entry = fs
+            .root_dir()
+            .find("DOOMED.BIN")
+            .expect("Find failed")
+            .expect("File not found");
+        let first = entry.cluster().0;
+
+        fs.delete(&entry).expect("Failed to delete");
+
+        assert_eq!(
+            fs.free_cluster_count().expect("FAT32 free count"),
+            free_before,
+            "delete did not return all clusters to the free pool",
+        );
+        assert!(
+            fs.root_dir()
+                .find("DOOMED.BIN")
+                .expect("Find failed")
+                .is_none(),
+            "deleted file still resolvable",
+        );
+
+        let image = fs.into_inner().into_inner();
+        let fat_start = super::fat32_image::fat_start_bytes();
+        let off = fat_start + first * 4;
+        let fat_entry = u32::from_le_bytes(image[off..off + 4].try_into().unwrap()) & 0x0FFF_FFFF;
+        assert_eq!(
+            fat_entry, 0,
+            "first cluster of deleted file still allocated"
+        );
+    }
 }
 
 /// Integration tests using in-memory FAT16 images


### PR DESCRIPTION
Fixes #90. 

Repeatedly overwriting a file via `write_file` eventually failed with `NoFreeSpace` even though the volume had plenty of room for the file.

`FileWriter` reused only the *first* cluster of an existing file: whenever a cluster filled, it unconditionally allocated a fresh cluster and relinked, orphaning the remainder of the old chain. Every overwrite of an N-cluster file leaked N−1 clusters.