### PR TITLE
fix(fat): harden the FAT and exFAT write paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Each published package owns its version and may be released independently.
 - **hadris-fat:** `FileReader` now supports start-, current-, and end-relative
   seeking in both the synchronous and asynchronous APIs, including buffered
   and cached-chain readers.
+- **hadris-fat:** New `Error::StaleEntry` (with the `write` feature) reported by
+  the mutating APIs and `FileReader` when a `FileEntry` handle no longer refers
+  to the same on-disk directory entry (see below).
+- **hadris-fat:** New `Error::WriterConflict` (with the `write` feature) returned
+  when a second `FileWriter` is opened for a directory entry that already has one
+  open (see below).
 
 ### Fixed
 
@@ -23,6 +29,47 @@ Each published package owns its version and may be released independently.
   free-cluster count consistent. Previously every overwrite of a multi-cluster
   file orphaned all but its first cluster, eventually failing with
   `NoFreeSpace` (#90).
+- **hadris-fat:** `create_dir` no longer leaks a cluster when it fails after
+  allocating the directory's data cluster (e.g. `DirectoryFull` on a full
+  fixed root, or an over-long name). The data cluster is now allocated only
+  after the fallible name/slot steps succeed, matching `create_file`.
+- **hadris-fat:** `FileWriter::new_append` no longer overwrites the last
+  cluster of a file whose size is an exact multiple of the cluster size. The
+  writer now positions past the full final cluster so appended data extends
+  the file instead of clobbering its tail.
+- **hadris-fat:** Stale `FileEntry` handles can no longer corrupt an unrelated
+  file. If a file is deleted and its directory slot reused, operating through
+  the old handle previously freed the new file's chain, cleared its
+  `DIRECTORY` bit, moved it, or clobbered its entry. `delete`, `rename`,
+  `truncate`, `set_attributes`, `set_times`, and `FileWriter::finish` now
+  revalidate the slot's on-disk short name, creation timestamp, and
+  not-deleted marker before acting and return `Error::StaleEntry` on mismatch.
+  FAT carries no per-entry identity, so this is best-effort: a slot re-taken by
+  a same-named file is distinguished only by the creation timestamp, which has
+  10 ms resolution and is constant under the `no_std` `EpochTimeProvider`.
+  Passing `created` to `set_times` rewrites that field and therefore
+  invalidates other handles to the same file. `delete` also marks the
+  entry deleted before freeing its chain so a mid-operation error cannot leave
+  a live entry pointing at freed clusters.
+- **hadris-fat:** A `FileReader` held across a delete and cluster reuse no
+  longer discloses the reusing file's data. The reader revalidates its
+  directory slot before serving bytes and returns `Error::StaleEntry` instead.
+- **hadris-fat:** `create_file` and `create_dir` through a stale `FatDir` (its
+  directory was deleted and the cluster reused) no longer write directory
+  entries into an unrelated file's data. Both revalidate the directory's own
+  entry first and return `Error::StaleEntry` on mismatch. The root directory,
+  which cannot be deleted, is always accepted.
+- **hadris-fat:** `FileWriter::finish` now reports I/O and FAT-update failures
+  instead of masking them. With the `dirty-file-panic` feature, an error
+  returned part-way through `finish` used to trip the drop guard on the way
+  out, panicking about a writer that had in fact been finished. The guard now
+  fires only for a genuinely forgotten `finish()`.
+- **hadris-fat:** Opening two `FileWriter`s for the same file no longer lets
+  them independently allocate and cross-link one cluster chain (the last
+  `finish()` won and orphaned the other writer's clusters). The volume now
+  tracks the directory slot of each open writer and returns
+  `Error::WriterConflict` for a second writer on the same entry; the slot is
+  released when the writer is finished or dropped.
 
 ## [2.1.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,38 @@ Each published package owns its version and may be released independently.
   tracks the directory slot of each open writer and returns
   `Error::WriterConflict` for a second writer on the same entry; the slot is
   released when the writer is finished or dropped.
+- **hadris-fat (`unstable-exfat`):** Extending a file across a cluster boundary
+  onto a fragmented layout now writes the FAT chain links, so data past the
+  first cluster is reachable on read-back. The writer linearizes a contiguous
+  file's prefix into the FAT when it first becomes fragmented and links each
+  appended cluster onto the tail.
+- **hadris-fat (`unstable-exfat`):** `allocate_clusters` is now authoritative
+  against the allocation bitmap. Its fragmented fallback previously scanned the
+  FAT for zero entries and re-handed-out clusters the contiguous (bitmap-only)
+  path had already allocated; it now reserves clusters from the bitmap and
+  links them in the FAT, rolling the reservations back if either step fails
+  and returning `NoFreeSpace` when the volume is full.
+- **hadris-fat (`unstable-exfat`):** `create_dir`, `delete`, and `truncate` now
+  flush the allocation bitmap. Previously only the file writer persisted it, so
+  a directory's allocation or a freed chain was lost on remount.
+- **hadris-fat (`unstable-exfat`):** Truncating a fragmented file now frees the
+  dropped tail clusters in the allocation bitmap, not only in the FAT, so the
+  space is reclaimed and the bitmap and FAT stay consistent.
+- **hadris-fat (`unstable-exfat`):** Directory entry sets are no longer placed
+  across a cluster boundary (they were written linearly, which is wrong for a
+  fragmented directory), and scanning a directory with an unknown size no longer
+  walks past its allocation into unrelated data.
+- **hadris-fat (`unstable-exfat`):** Overwriting a contiguous, multi-cluster
+  file in place now reuses the file's own already-allocated clusters. Crossing a
+  cluster boundary during an overwrite previously saw the file's next cluster as
+  "already allocated" and allocated a brand-new cluster instead, orphaning the
+  old one in the bitmap and needlessly fragmenting the file (the #90 pattern for
+  the exFAT path).
+- **hadris-fat (`unstable-exfat`):** exFAT formatting computes its cluster-heap
+  geometry in 64-bit arithmetic and range-checks the results. A volume larger
+  than ~2 TiB previously truncated the sector count to `u32`, silently sizing
+  the filesystem to a fraction of the device; oversized geometry now returns
+  `VolumeTooLarge` instead of corrupting the layout.
 
 ## [2.1.0] - 2026-08-18
 

--- a/api-snapshots/hadris-fat.txt
+++ b/api-snapshots/hadris-fat.txt
@@ -884,6 +884,7 @@ pub hadris_fat::error::Error::IoContext::source: hadris_io::error::Error
 pub hadris_fat::error::Error::NoFreeSpace
 pub hadris_fat::error::Error::NotADirectory
 pub hadris_fat::error::Error::NotAFile
+pub hadris_fat::error::Error::StaleEntry
 pub hadris_fat::error::Error::UnexpectedEndOfChain
 pub hadris_fat::error::Error::UnexpectedEndOfChain::cluster: u32
 pub hadris_fat::error::Error::UnsupportedFatType(&'static str)
@@ -893,6 +894,7 @@ pub hadris_fat::error::Error::VolumeTooLarge::size: u64
 pub hadris_fat::error::Error::VolumeTooSmall
 pub hadris_fat::error::Error::VolumeTooSmall::min_size: u64
 pub hadris_fat::error::Error::VolumeTooSmall::size: u64
+pub hadris_fat::error::Error::WriterConflict
 impl core::error::Error for hadris_fat::error::Error
 impl core::fmt::Display for hadris_fat::error::Error
 pub fn hadris_fat::error::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -2631,6 +2633,7 @@ pub hadris_fat::Error::IoContext::source: hadris_io::error::Error
 pub hadris_fat::Error::NoFreeSpace
 pub hadris_fat::Error::NotADirectory
 pub hadris_fat::Error::NotAFile
+pub hadris_fat::Error::StaleEntry
 pub hadris_fat::Error::UnexpectedEndOfChain
 pub hadris_fat::Error::UnexpectedEndOfChain::cluster: u32
 pub hadris_fat::Error::UnsupportedFatType(&'static str)
@@ -2640,6 +2643,7 @@ pub hadris_fat::Error::VolumeTooLarge::size: u64
 pub hadris_fat::Error::VolumeTooSmall
 pub hadris_fat::Error::VolumeTooSmall::min_size: u64
 pub hadris_fat::Error::VolumeTooSmall::size: u64
+pub hadris_fat::Error::WriterConflict
 impl core::error::Error for hadris_fat::error::Error
 impl core::fmt::Display for hadris_fat::error::Error
 pub fn hadris_fat::error::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/crates/block/hadris-fat/src/dir.rs
+++ b/crates/block/hadris-fat/src/dir.rs
@@ -46,6 +46,34 @@ fn short_name_display(short: &ShortFileName, flags: NtCaseFlags) -> alloc::strin
     name
 }
 
+/// Directory-slot coordinates of a subdirectory's own entry in its parent,
+/// captured so write operations can confirm the directory still exists before
+/// writing entries into its clusters (a stale `FatDir` whose directory was
+/// deleted and whose cluster was reused would otherwise corrupt another file).
+/// `None` for the root directory, which can never be deleted.
+#[cfg(feature = "write")]
+#[derive(Clone, Copy)]
+pub(crate) struct DirSlot {
+    pub(crate) parent_clus: Cluster<usize>,
+    pub(crate) offset_within_cluster: usize,
+    pub(crate) short_name: ShortFileName,
+    /// Creation timestamp captured at lookup, used alongside the short name to
+    /// tell a live handle from one whose slot was reused by a same-named file.
+    pub(crate) created: FatDateTime,
+}
+
+#[cfg(feature = "write")]
+impl DirSlot {
+    pub(crate) fn from_entry(entry: &FileEntry) -> Self {
+        Self {
+            parent_clus: entry.parent_clus,
+            offset_within_cluster: entry.offset_within_cluster,
+            short_name: entry.short_name,
+            created: entry.created,
+        }
+    }
+}
+
 /// A directory within a mounted FAT filesystem.
 pub struct FatDir<'a, DATA: Read + Seek> {
     pub(crate) data: &'a FatVolume<DATA>,
@@ -53,6 +81,10 @@ pub struct FatDir<'a, DATA: Read + Seek> {
     pub(crate) cluster: Cluster,
     /// For FAT12/16 root: (start_byte, size_bytes), None for cluster-based dirs
     pub(crate) fixed_root: Option<(usize, usize)>,
+    /// Slot of this directory's own entry in its parent, for stale-handle
+    /// revalidation on write. `None` for the root.
+    #[cfg(feature = "write")]
+    pub(crate) dir_entry: Option<DirSlot>,
 }
 
 impl<'a, DATA: Read + Seek> FatDir<'a, DATA> {
@@ -110,6 +142,8 @@ impl<'a, DATA: Read + Seek> FatDir<'a, DATA> {
             data: self.data,
             cluster: entry.cluster(),
             fixed_root: None, // Subdirectories are never fixed root
+            #[cfg(feature = "write")]
+            dir_entry: Some(DirSlot::from_entry(entry)),
         })
     }
 
@@ -159,6 +193,8 @@ impl<'a, DATA: Read + Seek> FatDir<'a, DATA> {
             data: self.data,
             cluster: entry.cluster(),
             fixed_root: None,
+            #[cfg(feature = "write")]
+            dir_entry: Some(DirSlot::from_entry(&entry)),
         })
     }
 

--- a/crates/block/hadris-fat/src/error.rs
+++ b/crates/block/hadris-fat/src/error.rs
@@ -107,6 +107,23 @@ pub enum Error {
         bit: &'static str,
     },
 
+    /// A [`crate::dir::FileEntry`] handle no longer matches what is on disk at
+    /// the location it was looked up from: the slot was deleted, or reused by
+    /// a different file. Mutating through such a stale handle would corrupt an
+    /// unrelated entry, so the mutating APIs (`delete`, `rename`,
+    /// `set_attributes`, `set_times`, `truncate`, and `FileWriter::finish`)
+    /// revalidate the on-disk short name first and return this instead.
+    #[cfg(feature = "write")]
+    StaleEntry,
+
+    /// A second [`crate::write::FileWriter`] was requested for a directory entry
+    /// that already has one open. Two concurrent writers would independently
+    /// allocate and cross-link the file's cluster chain, leaking the loser's
+    /// clusters when the last `finish()` wins. Drop or `finish()` the existing
+    /// writer before opening another for the same file.
+    #[cfg(feature = "write")]
+    WriterConflict,
+
     /// A read-only [`crate::cache::FatSectorCache`] operation needed to evict
     /// a sector to make room for a new one, but every cached sector is
     /// dirty. The caller must call [`crate::cache::FatSectorCache::flush`]
@@ -259,6 +276,17 @@ impl fmt::Display for Error {
             Self::InvalidAttributeChange { bit } => {
                 write!(f, "cannot change immutable attribute bit `{bit}` in place")
             }
+            #[cfg(feature = "write")]
+            Self::StaleEntry => {
+                write!(
+                    f,
+                    "directory entry handle is stale (its on-disk slot was deleted or reused)"
+                )
+            }
+            #[cfg(feature = "write")]
+            Self::WriterConflict => {
+                write!(f, "a FileWriter is already open for this directory entry")
+            }
             #[cfg(feature = "cache")]
             Self::CacheDirtyEviction { sector } => {
                 write!(
@@ -392,6 +420,14 @@ impl defmt::Format for Error {
             #[cfg(feature = "write")]
             Self::InvalidAttributeChange { bit } => {
                 defmt::write!(f, "cannot change immutable attribute bit `{=str}`", *bit)
+            }
+            #[cfg(feature = "write")]
+            Self::StaleEntry => {
+                defmt::write!(f, "directory entry handle is stale (deleted or reused)")
+            }
+            #[cfg(feature = "write")]
+            Self::WriterConflict => {
+                defmt::write!(f, "a FileWriter is already open for this directory entry")
             }
             #[cfg(feature = "cache")]
             Self::CacheDirtyEviction { sector } => defmt::write!(

--- a/crates/block/hadris-fat/src/exfat/file.rs
+++ b/crates/block/hadris-fat/src/exfat/file.rs
@@ -271,24 +271,43 @@ impl<'a, DATA: Read + Write + Seek> ExFatFileWriter<'a, DATA> {
         self.new_length
     }
 
-    /// Allocate a new cluster, linking it to the previous one if needed.
+    /// Allocate a new cluster and link it onto the current tail in the FAT.
+    ///
+    /// A contiguous exFAT file carries no FAT links, so the first time a file
+    /// becomes fragmented the existing contiguous prefix must be linearized
+    /// before the new cluster is appended; otherwise the chain is unreachable
+    /// past its first cluster on read-back.
     fn allocate_next_cluster(&mut self) -> Result<u32> {
+        self.linearize_contiguous_prefix()?;
+
         let hint = self.current_cluster.saturating_add(1);
         let new_cluster = self.fs.allocate_cluster(hint)?;
 
-        // If we have a previous cluster, we're no longer contiguous
-        // (unless the new cluster is adjacent)
-        if let Some(prev) = self.prev_cluster {
-            if new_cluster != prev + 1 {
-                self.is_contiguous = false;
-            }
+        // `allocate_cluster` wrote the new cluster as END_OF_CHAIN; link the
+        // current tail to it so the chain is contiguous in the FAT.
+        if self.current_cluster >= 2 {
+            self.fs.set_fat_entry(self.current_cluster, new_cluster)?;
         }
+        self.is_contiguous = false;
 
-        // Update allocated length
         let cluster_size = self.fs.info().bytes_per_cluster as u64;
         self.allocated_length += cluster_size;
 
         Ok(new_cluster)
+    }
+
+    /// Write FAT links for the still-contiguous prefix
+    /// `[first_cluster ..= current_cluster]` so the file can continue as a
+    /// fragmented chain. A no-op once the file is already fragmented.
+    fn linearize_contiguous_prefix(&mut self) -> Result<()> {
+        if self.is_contiguous && self.first_cluster >= 2 {
+            let mut c = self.first_cluster;
+            while c < self.current_cluster {
+                self.fs.set_fat_entry(c, c + 1)?;
+                c += 1;
+            }
+        }
+        Ok(())
     }
 
     /// Finish writing and update the directory entry.
@@ -339,7 +358,16 @@ impl<DATA: Read + Write + Seek> Write for ExFatFileWriter<'_, DATA> {
                 } else if self.is_contiguous {
                     // Try to use next adjacent cluster
                     let next = self.current_cluster + 1;
-                    if info.is_valid_cluster(next) {
+                    let owned_clusters = (self.allocated_length / cluster_size as u64) as u32;
+                    if next >= self.first_cluster
+                        && next < self.first_cluster.saturating_add(owned_clusters)
+                    {
+                        // Overwrite in place: `next` is one of this file's own,
+                        // already-allocated contiguous clusters. Reuse it rather
+                        // than allocating a fresh cluster, which would orphan the
+                        // old one and needlessly fragment the file.
+                        next
+                    } else if info.is_valid_cluster(next) {
                         // Check if the next cluster is available
                         match self.fs.is_cluster_allocated(next) {
                             Ok(false) => {
@@ -350,8 +378,9 @@ impl<DATA: Read + Write + Seek> Write for ExFatFileWriter<'_, DATA> {
                                         c
                                     }
                                     Ok(_) | Err(_) => {
-                                        // Not contiguous anymore - need to convert to FAT chain
-                                        self.is_contiguous = false;
+                                        // Not contiguous anymore - convert to a
+                                        // FAT chain (allocate_next_cluster
+                                        // linearizes the prefix and links).
                                         match self.allocate_next_cluster() {
                                             Ok(c) => c,
                                             Err(_) => return Ok(total_written),
@@ -360,8 +389,8 @@ impl<DATA: Read + Write + Seek> Write for ExFatFileWriter<'_, DATA> {
                                 }
                             }
                             _ => {
-                                // Already allocated - convert to FAT chain
-                                self.is_contiguous = false;
+                                // Already allocated - convert to a FAT chain
+                                // (allocate_next_cluster linearizes and links).
                                 match self.allocate_next_cluster() {
                                     Ok(c) => c,
                                     Err(_) => return Ok(total_written),

--- a/crates/block/hadris-fat/src/exfat/format.rs
+++ b/crates/block/hadris-fat/src/exfat/format.rs
@@ -277,40 +277,52 @@ fn calculate_fat_and_heap(
     sectors_per_cluster: usize,
     fat_count: u8,
 ) -> Result<(u32, u32, u32)> {
-    // Each FAT entry is 4 bytes
-    // FAT length = ceil(cluster_count / entries_per_sector) where entries_per_sector = bytes_per_sector / 4
-    let entries_per_sector = bytes_per_sector / 4;
+    // All geometry math is done in u64: `volume_length` (in sectors) can exceed
+    // u32 for volumes above ~2 TiB, and the intermediate offsets/lengths must
+    // not silently truncate. The final values are exFAT u32 fields, so they are
+    // range-checked before returning.
+    let entries_per_sector = (bytes_per_sector / 4) as u64;
+    let sectors_per_cluster = sectors_per_cluster as u64;
+    let fat_count = fat_count as u64;
+    let fat_offset = fat_offset as u64;
+    let bytes_per_sector = bytes_per_sector as u64;
 
-    // Initial estimate: all remaining space for data
-    let total_fat_sectors_estimate = 1u32;
-    let cluster_heap_offset_estimate = fat_offset + total_fat_sectors_estimate * fat_count as u32;
-
-    // Available sectors for cluster heap
-    let available_sectors = volume_length as u32 - cluster_heap_offset_estimate;
-    let cluster_count_estimate = available_sectors / sectors_per_cluster as u32;
-
-    // Calculate FAT size needed for this many clusters (+2 for reserved entries)
-    let fat_entries_needed = cluster_count_estimate + 2;
-    let fat_length = (fat_entries_needed as usize).div_ceil(entries_per_sector) as u32;
-
-    // Recalculate with actual FAT size
-    let cluster_heap_offset = fat_offset + fat_length * fat_count as u32;
-    let available_sectors = if volume_length as u32 > cluster_heap_offset {
-        volume_length as u32 - cluster_heap_offset
-    } else {
-        return Err(Error::VolumeTooSmall {
-            size: volume_length * bytes_per_sector as u64,
-            min_size: MIN_VOLUME_SIZE,
-        });
+    let too_small = || Error::VolumeTooSmall {
+        size: volume_length * bytes_per_sector,
+        min_size: MIN_VOLUME_SIZE,
     };
-    let cluster_count = available_sectors / sectors_per_cluster as u32;
+    let too_large = || Error::VolumeTooLarge {
+        size: volume_length * bytes_per_sector,
+        max_size: MAX_VOLUME_SIZE,
+    };
+
+    // Initial estimate: assume a 1-sector FAT so the heap gets all remaining
+    // space, then size the FAT to cover that many clusters.
+    let cluster_heap_offset_estimate = fat_offset + fat_count;
+    let available_sectors = volume_length
+        .checked_sub(cluster_heap_offset_estimate)
+        .ok_or_else(too_small)?;
+    let cluster_count_estimate = available_sectors / sectors_per_cluster;
+
+    // FAT size needed for this many clusters (+2 for the reserved entries 0, 1).
+    let fat_entries_needed = cluster_count_estimate + 2;
+    let fat_length = fat_entries_needed.div_ceil(entries_per_sector);
+
+    // Recalculate the heap with the actual FAT size.
+    let cluster_heap_offset = fat_offset + fat_length * fat_count;
+    let available_sectors = volume_length
+        .checked_sub(cluster_heap_offset)
+        .ok_or_else(too_small)?;
+    let cluster_count = available_sectors / sectors_per_cluster;
 
     if cluster_count < 1 {
-        return Err(Error::VolumeTooSmall {
-            size: volume_length * bytes_per_sector as u64,
-            min_size: MIN_VOLUME_SIZE,
-        });
+        return Err(too_small());
     }
+
+    // exFAT stores these as u32; reject volumes whose geometry overflows.
+    let cluster_heap_offset = u32::try_from(cluster_heap_offset).map_err(|_| too_large())?;
+    let fat_length = u32::try_from(fat_length).map_err(|_| too_large())?;
+    let cluster_count = u32::try_from(cluster_count).map_err(|_| too_large())?;
 
     Ok((cluster_heap_offset, fat_length, cluster_count))
 }
@@ -852,6 +864,41 @@ mod tests {
         let size = 512 * 1024u64; // 512 KB - too small
         let options = ExFatFormatOptions::new();
         assert!(calculate_layout(size, &options).is_err());
+    }
+
+    #[test]
+    fn test_calculate_fat_and_heap_beyond_u32_sectors() {
+        // A ~3 TiB volume at 512-byte sectors has a sector count above u32::MAX.
+        // The old code truncated `volume_length as u32`, silently sizing the
+        // heap to a fraction of the real capacity. The geometry must now be
+        // computed in u64 and reflect the full volume.
+        let bytes_per_sector = 512usize;
+        let sectors_per_cluster = 512usize; // 256 KiB clusters
+        let fat_count = 1u8;
+        let fat_offset = 24u32;
+
+        let volume_length: u64 = 6 * 1024 * 1024 * 1024; // 6 Gi-sectors ~= 3 TiB
+        assert!(volume_length > u32::MAX as u64);
+
+        let (heap_offset, fat_length, cluster_count) = calculate_fat_and_heap(
+            volume_length,
+            fat_offset,
+            bytes_per_sector,
+            sectors_per_cluster,
+            fat_count,
+        )
+        .expect("3 TiB volume geometry should fit u32 fields");
+
+        // Heap must sit after the FAT and the cluster count must account for
+        // (almost) the entire volume, not a u32-truncated remainder.
+        assert!(heap_offset as u64 >= fat_offset as u64 + fat_length as u64);
+        let truncated_estimate = ((volume_length as u32) / sectors_per_cluster as u32) as u64;
+        assert!(
+            cluster_count as u64 > truncated_estimate,
+            "cluster_count {cluster_count} looks u32-truncated (<= {truncated_estimate})"
+        );
+        let expected = (volume_length - heap_offset as u64) / sectors_per_cluster as u64;
+        assert_eq!(cluster_count as u64, expected);
     }
 
     #[test]

--- a/crates/block/hadris-fat/src/exfat/fs.rs
+++ b/crates/block/hadris-fat/src/exfat/fs.rs
@@ -317,10 +317,21 @@ where
         Ok(cluster)
     }
 
-    /// Allocate contiguous clusters for an exFAT file.
+    /// Write a single raw FAT entry. Used by the file writer to maintain chain
+    /// links when a file becomes fragmented (a contiguous exFAT file carries no
+    /// FAT links, so converting it to a chain requires writing them).
+    pub(crate) fn set_fat_entry(&self, cluster: u32, value: u32) -> Result<()> {
+        let mut data = self.data.lock();
+        self.fat.write_entry(&mut data.data, cluster, value)
+    }
+
+    /// Allocate `count` clusters for an exFAT file.
     ///
-    /// Returns (first_cluster, is_contiguous). If contiguous allocation fails,
-    /// falls back to FAT chain allocation.
+    /// Returns (first_cluster, is_contiguous). Allocation is authoritative
+    /// against the allocation bitmap — the FAT is not a reliable free map in
+    /// exFAT because contiguous files consume bitmap clusters while leaving
+    /// their FAT entries zero. When a contiguous run is unavailable, a
+    /// fragmented chain is allocated from the bitmap and linked in the FAT.
     pub fn allocate_clusters(&self, count: u32, hint: u32) -> Result<(u32, bool)> {
         if count == 0 {
             return Ok((0, true));
@@ -328,36 +339,60 @@ where
 
         let mut bitmap = self.bitmap.lock();
 
-        // Try to allocate contiguously first
+        // Try to allocate contiguously first.
         if let Some(first) = bitmap.find_contiguous_free(count, hint)? {
-            // Mark all clusters as allocated
             for i in 0..count {
                 bitmap.set_allocated(first + i, true)?;
             }
             return Ok((first, true));
         }
 
-        // Fall back to FAT chain allocation
-        drop(bitmap); // Release bitmap lock before FAT operations
-
-        let mut data = self.data.lock();
-        let first = self.fat.allocate_chain(&mut data.data, count, hint)?;
-
-        // Also mark in bitmap
-        drop(data);
-        let mut bitmap = self.bitmap.lock();
-        let mut current = first;
-        let mut data = self.data.lock();
+        // Fragmented fallback: reserve `count` free clusters from the bitmap,
+        // rolling back on exhaustion, then link them into a FAT chain. This
+        // never consults the FAT for free space, so it cannot re-hand-out a
+        // cluster the contiguous path already took (bitmap-only) from the FAT.
+        let mut allocated: alloc::vec::Vec<u32> = alloc::vec::Vec::with_capacity(count as usize);
+        let mut next_hint = hint;
         for _ in 0..count {
-            bitmap.set_allocated(current, true)?;
-            if let Some(next) = self.fat.next_cluster(&mut data.data, current)? {
-                current = next;
-            } else {
-                break;
+            match bitmap.find_free_cluster(next_hint)? {
+                Some(c) => {
+                    bitmap.set_allocated(c, true)?;
+                    next_hint = c.saturating_add(1);
+                    allocated.push(c);
+                }
+                None => {
+                    for &c in &allocated {
+                        let _ = bitmap.set_allocated(c, false);
+                    }
+                    return Err(Error::NoFreeSpace);
+                }
             }
         }
+        drop(bitmap);
 
-        Ok((first, false))
+        // Link the reserved clusters into a chain, terminating the last. A
+        // failure part-way through must release the reservations, or the
+        // clusters leak: nothing references them and the bitmap still calls
+        // them used.
+        let linked = (|| {
+            let mut data = self.data.lock();
+            for pair in allocated.windows(2) {
+                self.fat.write_entry(&mut data.data, pair[0], pair[1])?;
+            }
+            let last = *allocated.last().expect("count >= 1");
+            self.fat
+                .write_entry(&mut data.data, last, ExFatTable::END_OF_CHAIN)
+        })();
+
+        if let Err(err) = linked {
+            let mut bitmap = self.bitmap.lock();
+            for &c in &allocated {
+                let _ = bitmap.set_allocated(c, false);
+            }
+            return Err(err);
+        }
+
+        Ok((allocated[0], false))
     }
 
     /// Free clusters.
@@ -446,13 +481,18 @@ where
                 }
             }
 
-            // Move to next cluster
+            // Move to the next cluster. Reset the run first: an entry set must
+            // never span a cluster boundary, because write_entry_set writes
+            // linearly and a fragmented directory's next cluster is not
+            // physically adjacent to this one.
+            consecutive_free = 0;
             if dir.is_contiguous {
                 current_cluster += 1;
-                // Check if we've exceeded the directory size
-                if (current_cluster - dir.first_cluster) as u64 * cluster_size as u64 >= dir.size
-                    && dir.size > 0
-                {
+                // Stop at the end of the directory's allocation. A contiguous
+                // directory with an unknown size (0) is treated as one cluster
+                // rather than scanning off the end into unrelated data.
+                let scanned = (current_cluster - dir.first_cluster) as u64 * cluster_size as u64;
+                if dir.size == 0 || scanned >= dir.size {
                     break;
                 }
             } else {
@@ -557,6 +597,9 @@ where
         // Write the entry set
         self.write_entry_set(slot_cluster, slot_offset, &entries)?;
 
+        // Persist the bitmap: allocate_cluster only updated the in-memory copy.
+        self.sync_bitmap()?;
+
         Ok(ExFatDir {
             fs: self,
             first_cluster: dir_cluster,
@@ -598,6 +641,9 @@ where
         // Mark the directory entry as deleted (0x05)
         let deleted_marker = [entry_type::DELETED_FILE];
         self.write_at(entry.entry_offset, &deleted_marker)?;
+
+        // Persist the freed bitmap clusters so the space is reclaimed on remount.
+        self.sync_bitmap()?;
 
         Ok(())
     }
@@ -712,7 +758,10 @@ where
                     self.free_clusters(first_to_free, clusters_to_free as u32, true)?;
                 }
             } else {
-                // For fragmented files, walk the chain and truncate
+                // For fragmented files, walk the chain to the last cluster to
+                // keep, terminate it, and free the tail in BOTH the FAT and the
+                // bitmap. `fat.truncate_chain` alone clears only the FAT, which
+                // would leak the tail clusters in the bitmap.
                 let mut current = entry.first_cluster;
                 for _ in 1..clusters_to_keep {
                     let mut data = self.data.lock();
@@ -723,9 +772,17 @@ where
                     }
                 }
 
-                // Truncate after this cluster
-                let mut data = self.data.lock();
-                self.fat.truncate_chain(&mut data.data, current)?;
+                let tail = {
+                    let mut data = self.data.lock();
+                    let next = self.fat.read_entry(&mut data.data, current)?;
+                    self.fat
+                        .write_entry(&mut data.data, current, ExFatTable::END_OF_CHAIN)?;
+                    next
+                };
+                if (ExFatTable::FIRST_DATA_CLUSTER..=self.fat.max_cluster()).contains(&tail) {
+                    // Follows the chain from `tail`, clearing FAT and bitmap.
+                    self.free_clusters(tail, 0, false)?;
+                }
             }
             self.update_entry_size(
                 entry,
@@ -735,6 +792,9 @@ where
                 entry.no_fat_chain,
             )?;
         }
+
+        // Persist the freed bitmap clusters so the space is reclaimed on remount.
+        self.sync_bitmap()?;
 
         Ok(())
     }

--- a/crates/block/hadris-fat/src/fs.rs
+++ b/crates/block/hadris-fat/src/fs.rs
@@ -157,6 +157,12 @@ pub struct FatVolume<DATA: Seek> {
     /// shared between read paths and write paths.
     #[cfg(feature = "cache")]
     pub(crate) fat_cache: Option<Mutex<crate::cache::FatSectorCache>>,
+    /// Directory slots `(parent_cluster, offset_within_cluster)` that currently
+    /// have an open `FileWriter`. A second writer for the same slot is rejected
+    /// so two writers cannot independently allocate and cross-link one file's
+    /// chain (last-finish-wins would orphan the other's clusters).
+    #[cfg(feature = "write")]
+    pub(crate) open_writers: Mutex<alloc::vec::Vec<(usize, usize)>>,
 }
 
 impl<DATA: Seek> FatVolume<DATA> {
@@ -524,6 +530,8 @@ where
             oem_converter,
             #[cfg(feature = "cache")]
             fat_cache: None,
+            #[cfg(feature = "write")]
+            open_writers: Mutex::new(alloc::vec::Vec::new()),
         })
     }
 
@@ -690,6 +698,8 @@ where
             oem_converter,
             #[cfg(feature = "cache")]
             fat_cache: None,
+            #[cfg(feature = "write")]
+            open_writers: Mutex::new(alloc::vec::Vec::new()),
         })
     }
 
@@ -720,11 +730,15 @@ where
                 data: self,
                 cluster: Cluster(0), // Sentinel for fixed root directory
                 fixed_root: Some((ext.root_dir_start, ext.root_dir_size)),
+                #[cfg(feature = "write")]
+                dir_entry: None, // Root has no parent entry.
             },
             FatFsExt::Fat32(ext) => FatDir {
                 data: self,
                 cluster: Cluster(ext.root_clus.0 as usize),
                 fixed_root: None,
+                #[cfg(feature = "write")]
+                dir_entry: None, // Root has no parent entry.
             },
         }
     }
@@ -910,6 +924,8 @@ where
             data: self,
             cluster: entry.cluster(),
             fixed_root: None,
+            #[cfg(feature = "write")]
+            dir_entry: Some(super::dir::DirSlot::from_entry(&entry)),
         })
     }
 
@@ -924,6 +940,8 @@ where
             data: self,
             cluster: entry.cluster(),
             fixed_root: None,
+            #[cfg(feature = "write")]
+            dir_entry: Some(super::dir::DirSlot::from_entry(entry)),
         })
     }
 }

--- a/crates/block/hadris-fat/src/read.rs
+++ b/crates/block/hadris-fat/src/read.rs
@@ -9,6 +9,8 @@ use core::ops::DerefMut;
 use alloc::vec::Vec;
 
 use crate::error::{Error, Result};
+#[cfg(feature = "write")]
+use crate::file::ShortFileName;
 use super::{
     fs::FatVolume, dir::FileEntry,
     io::{Cluster, ClusterLike, ErrorKind, Read, Seek, SeekFrom},
@@ -53,6 +55,19 @@ pub struct FileReader<'a, DATA: Read + Seek> {
     /// Current index in the cached chain
     #[cfg(feature = "alloc")]
     chain_index: usize,
+    /// Directory-slot coordinates captured at open, used to revalidate that the
+    /// file has not been deleted (and its clusters reused) before serving reads.
+    /// Only meaningful with `write`: a read-only volume can never mutate an
+    /// entry, so a reader can never become stale.
+    #[cfg(feature = "write")]
+    entry_parent: Cluster<usize>,
+    #[cfg(feature = "write")]
+    entry_offset: usize,
+    #[cfg(feature = "write")]
+    entry_short_name: ShortFileName,
+    /// Creation timestamp captured at open, revalidated alongside the name.
+    #[cfg(feature = "write")]
+    entry_created: crate::time::FatDateTime,
 }
 
 impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
@@ -78,6 +93,14 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
             cached_chain: None,
             #[cfg(feature = "alloc")]
             chain_index: 0,
+            #[cfg(feature = "write")]
+            entry_parent: entry.parent_clus,
+            #[cfg(feature = "write")]
+            entry_offset: entry.offset_within_cluster,
+            #[cfg(feature = "write")]
+            entry_short_name: entry.short_name,
+            #[cfg(feature = "write")]
+            entry_created: entry.created,
         })
     }
 
@@ -189,6 +212,20 @@ impl<'a, DATA: Read + Seek> FileReader<'a, DATA> {
         if max == 0 {
             return Ok(0);
         }
+        // Before serving any bytes, confirm the file's directory slot still holds
+        // this exact entry. If it was deleted (and its clusters possibly reused)
+        // since the reader opened, revalidation returns `StaleEntry` rather than
+        // disclosing an unrelated file's data. Only reachable with `write`; a
+        // read-only volume can never mutate an entry out from under a reader.
+        #[cfg(feature = "write")]
+        self.fs
+            .revalidate_slot(
+                self.entry_parent,
+                self.entry_offset,
+                &self.entry_short_name,
+                &self.entry_created,
+            )
+            .await?;
         let buf = &mut buf[..max];
 
         #[cfg(feature = "alloc")]

--- a/crates/block/hadris-fat/src/tool/analysis.rs
+++ b/crates/block/hadris-fat/src/tool/analysis.rs
@@ -379,6 +379,8 @@ impl<DATA: Read + Seek> FatVolume<DATA> {
                     data: self,
                     cluster: file_entry.cluster(),
                     fixed_root: None,
+                    #[cfg(feature = "write")]
+                    dir_entry: None, // Read-only traversal.
                 };
                 self.count_entries_recursive(&subdir, depth + 1, files, dirs)?;
             } else {
@@ -421,6 +423,8 @@ impl<DATA: Read + Seek> FatVolume<DATA> {
                     data: self,
                     cluster: file_entry.cluster(),
                     fixed_root: None,
+                    #[cfg(feature = "write")]
+                    dir_entry: None, // Read-only traversal.
                 };
                 self.collect_files_recursive(&subdir, full_path, depth + 1, files)?;
             } else {

--- a/crates/block/hadris-fat/src/tool/verify.rs
+++ b/crates/block/hadris-fat/src/tool/verify.rs
@@ -329,6 +329,8 @@ impl<DATA: Read + Seek> FatVolume<DATA> {
                     data: self,
                     cluster: file_entry.cluster(),
                     fixed_root: None,
+                    #[cfg(feature = "write")]
+                    dir_entry: None, // Read-only traversal.
                 };
                 self.verify_directory_recursive(
                     &subdir,

--- a/crates/block/hadris-fat/src/write.rs
+++ b/crates/block/hadris-fat/src/write.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 #[cfg(feature = "write")]
 use super::{
-    fat_table::Fat, dir::{FatDir, FileEntry}, fs::FatVolume,
+    fat_table::Fat, dir::{DirSlot, FatDir, FileEntry}, fs::FatVolume,
     io::{Cluster, ClusterLike, Read, ReadExt, Seek, SeekFrom, Write},
 };
 
@@ -36,6 +36,12 @@ pub struct FileWriter<'a, DATA: Read + Write + Seek> {
     entry_parent: Cluster<usize>,
     /// Offset of the directory entry within the parent
     entry_offset: usize,
+    /// Short name captured at open time. `finish()` revalidates the slot
+    /// against this before rewriting size/first-cluster, so a writer whose
+    /// entry was deleted (and its slot reused) cannot clobber another file.
+    entry_short_name: ShortFileName,
+    /// Creation timestamp captured at open, revalidated alongside the name.
+    entry_created: crate::time::FatDateTime,
     /// Fixed root directory info (for FAT12/16)
     fixed_root: Option<(usize, usize)>,
     /// Override for the modified timestamp written by `finish()`. When `None`,
@@ -55,6 +61,11 @@ pub struct FileWriter<'a, DATA: Read + Write + Seek> {
 #[cfg(feature = "write")]
 impl<'a, DATA: Read + Write + Seek> Drop for FileWriter<'a, DATA> {
     fn drop(&mut self) {
+        // Release this slot's exclusive-writer registration first, so it runs
+        // even when the `dirty-file-panic` check below unwinds.
+        self.fs
+            .unregister_writer(self.entry_parent, self.entry_offset);
+
         // Without `dirty-file-panic`, drop is a no-op: callers that forget
         // `finish()` silently lose the size/timestamp commit (the data
         // bytes themselves are already on disk because `write()` flushes
@@ -95,6 +106,9 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
             None
         };
 
+        // Claim exclusive write access to this slot; a second writer is rejected.
+        fs.register_writer(entry.parent_clus, entry.offset_within_cluster)?;
+
         Ok(Self {
             fs,
             first_cluster,
@@ -103,6 +117,8 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
             total_written: 0,
             entry_parent: entry.parent_clus,
             entry_offset: entry.offset_within_cluster,
+            entry_short_name: entry.short_name,
+entry_created: entry.created,
             fixed_root,
             pending_modified: None,
             pending_accessed: None,
@@ -136,6 +152,7 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
 
         if file_size == 0 || first_cluster.is_none() {
             // Empty file — same as a regular new writer
+            fs.register_writer(entry.parent_clus, entry.offset_within_cluster)?;
             return Ok(Self {
                 fs,
                 first_cluster,
@@ -144,6 +161,8 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
                 total_written: 0,
                 entry_parent: entry.parent_clus,
                 entry_offset: entry.offset_within_cluster,
+                entry_short_name: entry.short_name,
+entry_created: entry.created,
                 fixed_root,
                 pending_modified: None,
                 pending_accessed: None,
@@ -168,7 +187,17 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
         };
         let current = Cluster(last as usize);
 
-        let offset_in_last = file_size % cluster_size;
+        // When the size is an exact multiple of the cluster size the last
+        // cluster is full, so `file_size % cluster_size` is 0. Positioning the
+        // writer at offset 0 would overwrite that full cluster; instead point
+        // it one past the end so the first write allocates a fresh cluster
+        // (#B2). `file_size > 0` is guaranteed by the early return above.
+        let offset_in_last = match file_size % cluster_size {
+            0 => cluster_size,
+            rem => rem,
+        };
+
+        fs.register_writer(entry.parent_clus, entry.offset_within_cluster)?;
 
         Ok(Self {
             fs,
@@ -178,6 +207,8 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
             total_written: file_size,
             entry_parent: entry.parent_clus,
             entry_offset: entry.offset_within_cluster,
+            entry_short_name: entry.short_name,
+entry_created: entry.created,
             fixed_root,
             pending_modified: None,
             pending_accessed: None,
@@ -305,6 +336,31 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
     /// without calling `finish` panics — the most common cause of "the file
     /// I just wrote shows up as zero bytes" bugs.
     pub async fn finish(mut self) -> Result<()> {
+        // The `dirty-file-panic` Drop guard exists to catch a *forgotten*
+        // `finish()`, not a failed one. Record the attempt up front so that
+        // every `?` below propagates its real error instead of being masked by
+        // a panic while unwinding.
+        self.finished = true;
+
+        // Reject a stale handle before any chain surgery or entry rewrite: if
+        // the file was deleted and its slot reused while this writer was open,
+        // committing here would clobber the unrelated entry now in the slot and
+        // (with chain reuse) mangle its clusters.
+        //
+        // Do not free any clusters on mismatch: on an overwrite this writer's
+        // `first_cluster` is the file's pre-existing chain, which `delete` has
+        // already freed and the reusing entry may now own, so releasing it
+        // would corrupt live data. Leaking the writer's own orphaned clusters
+        // on this misuse path is the strictly safer failure.
+        self.fs
+            .revalidate_slot(
+                self.entry_parent,
+                self.entry_offset,
+                &self.entry_short_name,
+                &self.entry_created,
+            )
+            .await?;
+
         // Release clusters the rewrite no longer needs and terminate the
         // chain at the last written cluster. Must run before the data lock
         // below — the routed helpers acquire their own locks.
@@ -388,9 +444,6 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
         // write_fsinfo also acquires it.
         self.fs.write_fsinfo().await?;
 
-        // Mark as cleanly finished so the Drop guard (under
-        // `dirty-file-panic`) accepts the consume.
-        self.finished = true;
 
         Ok(())
     }
@@ -423,6 +476,11 @@ pub trait FatVolumeWriteExt<DATA: Read + Write + Seek> {
     /// image — every other write path stamps "now" via the configured
     /// [`TimeProvider`](crate::time::TimeProvider), which is the wrong
     /// behaviour for those workflows.
+    ///
+    /// Passing `created` invalidates every other [`FileEntry`] handle for this
+    /// file: stale-handle detection compares the creation timestamp, so those
+    /// handles will report [`Error::StaleEntry`]. Look the entry up again after
+    /// rewriting it.
     async fn set_times(
         &self,
         entry: &FileEntry,
@@ -442,6 +500,9 @@ impl<DATA: Read + Write + Seek> FatVolumeWriteExt<DATA> for FatVolume<DATA> {
         if !entry.is_file() {
             return Err(Error::NotAFile);
         }
+        // Reject a stale handle before freeing/truncating a chain by its
+        // snapshotted first cluster.
+        self.revalidate_entry(entry).await?;
 
         let current_size = entry.len() as usize;
         if new_size >= current_size {
@@ -516,6 +577,8 @@ impl<DATA: Read + Write + Seek> FatVolumeWriteExt<DATA> for FatVolume<DATA> {
         if modified.is_none() && accessed_date.is_none() && created.is_none() {
             return Ok(());
         }
+        // Reject a stale handle before rewriting the slot's timestamp bytes.
+        self.revalidate_entry(entry).await?;
 
         let mut data = self.data.lock();
         let cluster_size = data.cluster_size;
@@ -807,6 +870,130 @@ fn build_lfn_entries(
 }
 
 /// Directory write operations
+#[cfg(feature = "write")]
+impl<DATA: Read + Seek> FatVolume<DATA> {
+    /// Confirm that `entry` still refers to the same on-disk directory entry it
+    /// was looked up from, before a mutating operation rewrites those bytes.
+    ///
+    /// A [`FileEntry`] captures a slot location (`parent_clus` +
+    /// `offset_within_cluster`) and the short name at lookup time. If the file
+    /// is later deleted or its slot reused by a different file, mutating
+    /// through the stale handle would silently corrupt an unrelated entry (or
+    /// free a live file's chain). This re-reads the slot and returns
+    /// [`Error::StaleEntry`] unless the slot is still in use and both its short
+    /// name and creation timestamp still match.
+    ///
+    /// FAT stores no per-entry identity, so this is a best-effort check rather
+    /// than a guarantee. A slot re-taken by a same-named file is caught only by
+    /// the creation timestamp, which has 10 ms resolution, is constant under
+    /// the `no_std` [`EpochTimeProvider`](crate::time::EpochTimeProvider), and
+    /// can be rewritten by [`set_times`](FatVolumeWriteExt::set_times). Treat a
+    /// handle held across a delete as suspect regardless.
+    pub(crate) async fn revalidate_entry(&self, entry: &FileEntry) -> Result<()> {
+        self.revalidate_slot(
+            entry.parent_clus,
+            entry.offset_within_cluster,
+            &entry.short_name,
+            &entry.created,
+        )
+        .await
+    }
+
+    /// Confirm a parent directory handle still refers to a live directory before
+    /// writing new entries into its clusters. The root (`dir_entry == None`) can
+    /// never be deleted, so it is always valid.
+    pub(crate) async fn revalidate_parent_dir(&self, parent: &FatDir<'_, DATA>) -> Result<()> {
+        match parent.dir_entry {
+            Some(slot) => {
+                self.revalidate_slot(
+                    slot.parent_clus,
+                    slot.offset_within_cluster,
+                    &slot.short_name,
+                    &slot.created,
+                )
+                .await
+            }
+            None => Ok(()),
+        }
+    }
+
+    /// Register an open writer for a directory slot, rejecting a second writer
+    /// for the same slot. Balanced by [`Self::unregister_writer`] in
+    /// `FileWriter`'s `Drop`.
+    pub(crate) fn register_writer(&self, parent: Cluster<usize>, offset: usize) -> Result<()> {
+        let key = (parent.0, offset);
+        let mut open = self.open_writers.lock();
+        if open.contains(&key) {
+            return Err(Error::WriterConflict);
+        }
+        open.push(key);
+        Ok(())
+    }
+
+    /// Drop the open-writer registration for a directory slot. Idempotent.
+    pub(crate) fn unregister_writer(&self, parent: Cluster<usize>, offset: usize) {
+        let key = (parent.0, offset);
+        let mut open = self.open_writers.lock();
+        if let Some(pos) = open.iter().position(|k| *k == key) {
+            open.swap_remove(pos);
+        }
+    }
+
+    /// Slot-level revalidation used by both [`Self::revalidate_entry`] and
+    /// [`FileWriter::finish`], which holds the slot coordinates directly rather
+    /// than a whole [`FileEntry`].
+    pub(crate) async fn revalidate_slot(
+        &self,
+        parent_clus: Cluster<usize>,
+        offset_within_cluster: usize,
+        short_name: &ShortFileName,
+        created: &crate::time::FatDateTime,
+    ) -> Result<()> {
+        let mut data = self.data.lock();
+        let cluster_size = data.cluster_size;
+
+        let entry_pos = if parent_clus.0 == 0 {
+            let (root_start, _) = self.fixed_root_dir_info().ok_or(Error::StaleEntry)?;
+            root_start + offset_within_cluster
+        } else {
+            parent_clus.to_bytes(self.info.data_start, cluster_size) + offset_within_cluster
+        };
+
+        data.seek(SeekFrom::Start(entry_pos as u64)).await?;
+        let raw_entry = data.read_struct::<RawDirectoryEntry>().await?;
+        let file_entry = unsafe { &raw_entry.file };
+
+        // A free (0x00) or deleted (0xE5) slot can never match a live handle.
+        // A real name whose first byte is logically 0xE5 is stored as 0x05, so
+        // an on-disk 0xE5 is unambiguously the deleted marker.
+        let mut disk_name = file_entry.name;
+        if disk_name[0] == 0x00 || disk_name[0] == 0xE5 {
+            return Err(Error::StaleEntry);
+        }
+        if disk_name[0] == 0x05 {
+            disk_name[0] = 0xE5;
+        }
+        if disk_name != short_name.raw_bytes() {
+            return Err(Error::StaleEntry);
+        }
+
+        // The name alone cannot distinguish a live handle from one whose slot
+        // was freed and re-taken by a *same-named* file (delete + recreate).
+        // The creation timestamp is the only field on a FAT short entry that a
+        // normal write leaves alone, so compare it too. This narrows the window
+        // rather than closing it: `EpochTimeProvider` (the `no_std` default)
+        // stamps every entry identically, and `set_times` can rewrite the field
+        // out from under a handle.
+        if file_entry.creation_time_tenth != created.time_tenth
+            || u16::from_le_bytes(file_entry.creation_time) != created.time
+            || u16::from_le_bytes(file_entry.creation_date) != created.date
+        {
+            return Err(Error::StaleEntry);
+        }
+        Ok(())
+    }
+}
+
 #[cfg(feature = "write")]
 impl<DATA: Read + Write + Seek> FatVolume<DATA> {
     async fn mark_entry_span_deleted(&self, entry: &FileEntry) -> Result<()> {
@@ -1158,6 +1345,11 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
     ///
     /// Returns the FileEntry for the newly created file.
     pub async fn create_file(&self, parent: &FatDir<'_, DATA>, name: &str) -> Result<FileEntry> {
+        // Reject a stale parent handle before scanning or writing into its
+        // clusters: if the directory was deleted and its cluster reused, new
+        // entries would land in an unrelated file's data.
+        self.revalidate_parent_dir(parent).await?;
+
         // Check if entry already exists
         if parent.find(name).await?.is_some() {
             return Err(Error::AlreadyExists);
@@ -1265,6 +1457,10 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         parent: &FatDir<'a, DATA>,
         name: &str,
     ) -> Result<FatDir<'a, DATA>> {
+        // Reject a stale parent handle before scanning or writing into its
+        // clusters (see create_file).
+        self.revalidate_parent_dir(parent).await?;
+
         // Check if entry already exists
         if parent.find(name).await?.is_some() {
             return Err(Error::AlreadyExists);
@@ -1273,13 +1469,6 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         // Generate short filename (suffix=0 means no ~N suffix)
         let short_name = ShortFileName::from_long_name_with(name, 0, self.oem_converter())
             .map_err(|_| Error::InvalidFilename)?;
-
-        // Allocate a cluster for the directory contents (cache-routed).
-        let new_cluster = self.allocate_cluster_routed(2).await?;
-
-        // Update FSInfo tracking (FAT32 only)
-        self.decrement_free_count();
-        self.update_next_free_hint(new_cluster);
 
         // A name that fits 8.3 apart from per-part case is stored as a single
         // short entry with the NT case byte set; otherwise it needs LFN entries.
@@ -1302,6 +1491,13 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         // Allocate `lfn_count + 1` consecutive slots.
         let total_slots = lfn_count + 1;
         let run = self.find_free_entry_run_in_dir(parent, total_slots).await?;
+
+        // Allocate the directory's data cluster only after the fallible steps
+        // above (name generation, LFN build, slot search) have succeeded, so a
+        // late failure cannot leak a cluster or skew the free count (#B1).
+        let new_cluster = self.allocate_cluster_routed(2).await?;
+        self.decrement_free_count();
+        self.update_next_free_hint(new_cluster);
 
         // Create the directory entry in parent
         let now = self.time_provider().now();
@@ -1428,17 +1624,29 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
             data: self,
             cluster: Cluster(new_cluster as usize),
             fixed_root: None, // Newly created directories are never fixed root
+            dir_entry: Some(DirSlot {
+                parent_clus: slot_cluster,
+                offset_within_cluster: slot_offset,
+                short_name,
+                created: now,
+            }),
         })
     }
 
     /// Delete a file or empty directory.
     pub async fn delete(&self, entry: &FileEntry) -> Result<()> {
+        // Reject a stale handle before freeing anything: without this, a
+        // handle whose slot was reused would free a live file's chain.
+        self.revalidate_entry(entry).await?;
+
         // If it's a directory, check if it's empty (only . and ..)
         if entry.is_directory() {
             let dir = FatDir {
                 data: self,
                 cluster: entry.cluster(),
                 fixed_root: None, // User-created directories are never fixed root
+                // Read-only emptiness scan; never used to write entries.
+                dir_entry: None,
             };
 
             let mut count = 0;
@@ -1456,19 +1664,21 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
             }
         }
 
+        // Mark the directory entry as deleted first, plus any LFN slots that
+        // precede it. Without the LFN cleanup, a delete would leave orphaned
+        // LFN slots on disk — fsck.fat flags those as "stray long-name slots"
+        // and they'd confuse a fresh-mount lookup until the slots are
+        // eventually overwritten. Marking before freeing means that if the
+        // free step below fails the worst case is a leaked chain, not a live
+        // entry pointing at freed (and soon-reused) clusters.
+        self.mark_entry_span_deleted(entry).await?;
+
         // Free the cluster chain if there is one (cache-routed).
         if entry.cluster().0 >= 2 {
             let freed_count = self.free_chain_routed(entry.cluster().0 as u32).await?;
             // Update FSInfo tracking (FAT32 only)
             self.increment_free_count(freed_count);
         }
-
-        // Mark the directory entry as deleted, plus any LFN slots that
-        // precede it. Without the LFN cleanup, a delete would leave
-        // orphaned LFN slots on disk — fsck.fat flags those as "stray
-        // long-name slots" and they'd confuse a fresh-mount lookup until
-        // the slots are eventually overwritten.
-        self.mark_entry_span_deleted(entry).await?;
 
         // Flush FSInfo so on-disk free_count matches in-memory state (FAT32).
         self.write_fsinfo().await?;
@@ -1491,6 +1701,11 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         dest_dir: &FatDir<'_, DATA>,
         new_name: &str,
     ) -> Result<FileEntry> {
+        // Reject a stale source handle before copying its metadata into a new
+        // slot: otherwise a reused handle would clone another file's chain
+        // under `new_name`, or resurrect a deleted entry.
+        self.revalidate_entry(entry).await?;
+
         // Check if destination already has this name
         if dest_dir.find(new_name).await?.is_some() {
             return Err(Error::AlreadyExists);
@@ -1764,6 +1979,11 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         entry: &FileEntry,
         attrs: DirEntryAttrFlags,
     ) -> Result<()> {
+        // Reject a stale handle before rewriting the slot's attribute byte —
+        // otherwise the immutable-bit guard below, which checks the snapshot,
+        // could clear the DIRECTORY bit of a different file now in this slot.
+        self.revalidate_entry(entry).await?;
+
         // Reject flips on the immutable bits before touching disk.
         let current = entry.attributes();
         let immutable = DirEntryAttrFlags::DIRECTORY | DirEntryAttrFlags::VOLUME_ID;

--- a/crates/block/hadris-fat/tests/regression_audit_exfat.rs
+++ b/crates/block/hadris-fat/tests/regression_audit_exfat.rs
@@ -1,0 +1,347 @@
+//! Regression tests for the 2026-08 hadris-fat correctness audit, exFAT write
+//! path (`unstable-exfat` preview). Each test asserts the CORRECT/SAFE
+//! behavior and is named after the audit finding it guards.
+
+#![cfg(all(feature = "unstable-exfat", feature = "write", feature = "std"))]
+
+use std::fs::OpenOptions;
+use std::io::Seek as _;
+use std::path::Path;
+use tempfile::TempDir;
+
+use hadris_fat::exfat::{ExFatFormatOptions, ExFatVolume, format_exfat};
+use hadris_fat::io::{Read as HadrisRead, Write as HadrisWrite};
+
+/// Build a fresh, formatted exFAT image at `path` of `size` bytes.
+fn make_image(path: &Path, size: u64, label: &str) {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .expect("create image file");
+    file.set_len(size).expect("set image length");
+
+    let opts = ExFatFormatOptions::default().volume_label(label);
+    format_exfat(&mut file, size, &opts).expect("format_exfat");
+    file.sync_all().expect("sync");
+}
+
+fn open_image(path: &Path) -> std::fs::File {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("open image");
+    file.seek(std::io::SeekFrom::Start(0)).unwrap();
+    file
+}
+
+fn read_root_file(image_path: &Path, name: &str) -> Vec<u8> {
+    let file = open_image(image_path);
+    let fs = ExFatVolume::open(file).expect("reopen exFAT");
+    let mut reader = fs.open_file(name).expect("open_file");
+
+    let mut out = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = HadrisRead::read(&mut reader, &mut buf).expect("read");
+        if n == 0 {
+            break;
+        }
+        out.extend_from_slice(&buf[..n]);
+    }
+    out
+}
+
+// X1: extending a file across a cluster boundary onto a fragmented layout must
+// write the FAT links so the whole chain is reachable on read-back. Previously
+// `allocate_next_cluster` allocated a cluster but never wrote `FAT[prev]=new`,
+// nor linked the contiguous prefix, so everything past the first cluster was
+// lost.
+#[test]
+fn x1_cross_cluster_extend_preserves_data() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("x1.img");
+    make_image(&img, 32 * 1024 * 1024, "X1");
+
+    let cluster_size = {
+        let file = open_image(&img);
+        let fs = ExFatVolume::open(file).expect("open");
+        fs.info().bytes_per_cluster
+    };
+
+    // Two distinct, position-dependent patterns so any truncation or
+    // corruption is visible on read-back.
+    let a_payload: Vec<u8> = (0..(2 * cluster_size))
+        .map(|i| (i.wrapping_mul(7).wrapping_add(3)) as u8)
+        .collect();
+    let b_payload: Vec<u8> = vec![0xB5u8; cluster_size];
+
+    {
+        let file = open_image(&img);
+        let fs = ExFatVolume::open(file).expect("open");
+
+        let a_entry = {
+            let root = fs.root_dir();
+            fs.create_file(&root, "a.bin").expect("create a")
+        };
+        let b_entry = {
+            let root = fs.root_dir();
+            fs.create_file(&root, "b.bin").expect("create b")
+        };
+
+        let mut wa = fs.write_file(&a_entry).expect("writer a");
+        let mut wb = fs.write_file(&b_entry).expect("writer b");
+
+        // 1. Fill a's first cluster only (allocates cluster C, no next).
+        wa.write_all(&a_payload[..cluster_size]).expect("a first");
+        // 2. Give b the immediately-adjacent cluster C+1.
+        wb.write_all(&b_payload).expect("b");
+        // 3. Extend a across the boundary: C+1 is taken, forcing the
+        //    fragmented path in allocate_next_cluster.
+        wa.write_all(&a_payload[cluster_size..]).expect("a second");
+
+        wa.finish().expect("finish a");
+        wb.finish().expect("finish b");
+    }
+
+    let got = read_root_file(&img, "a.bin");
+    assert_eq!(
+        got.len(),
+        a_payload.len(),
+        "read-back length mismatch: data past the first cluster was lost \
+         (got {} bytes, expected {})",
+        got.len(),
+        a_payload.len()
+    );
+    assert_eq!(
+        got, a_payload,
+        "read-back content mismatch after cross-cluster extend"
+    );
+}
+
+// X2: allocation is authoritative against the bitmap. The contiguous fast-path
+// marks only the bitmap (no FAT write); a fragmented fallback that scanned the
+// FAT for zeros would re-hand-out those bitmap-allocated clusters. On a full
+// volume, allocation must report no free space rather than double-allocate.
+#[test]
+fn x2_no_double_allocation_when_full() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("x2.img");
+    make_image(&img, 32 * 1024 * 1024, "X2");
+
+    let file = open_image(&img);
+    let fs = ExFatVolume::open(file).expect("open");
+
+    let free0 = fs.free_cluster_count();
+    assert!(free0 > 0, "fresh volume should have free clusters");
+
+    // Consume every free cluster via the contiguous fast-path (bitmap-only).
+    let (region_first, contiguous) = fs
+        .allocate_clusters(free0, 2)
+        .expect("bulk contiguous allocation");
+    assert!(
+        contiguous,
+        "expected the contiguous fast-path (bitmap-only, no FAT writes)"
+    );
+    assert_eq!(
+        fs.free_cluster_count(),
+        0,
+        "volume should now be full per the bitmap"
+    );
+
+    // The volume is genuinely full. A correct allocator must refuse.
+    let result = fs.allocate_clusters(1, 2);
+    if let Ok((cluster, _)) = result {
+        let already = fs.is_cluster_allocated(cluster).unwrap();
+        panic!(
+            "allocate_clusters handed out cluster {cluster} on a full volume \
+             (region started at {region_first}, is_cluster_allocated={already}) \
+             — double allocation via FAT-scan fallback"
+        );
+    }
+    assert!(
+        result.is_err(),
+        "expected NoFreeSpace on a full volume, got {result:?}"
+    );
+}
+
+// X3: mutations that change the allocation bitmap (here `create_dir`) must
+// persist it. Previously only the file writer's `finish` flushed the bitmap, so
+// a directory's cluster allocation was lost on remount.
+#[test]
+fn x3_directory_allocation_persists_across_remount() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("x3.img");
+    make_image(&img, 32 * 1024 * 1024, "X3");
+
+    let free_before = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("open");
+        fs.free_cluster_count()
+    };
+
+    {
+        let fs = ExFatVolume::open(open_image(&img)).expect("open");
+        let root = fs.root_dir();
+        fs.create_dir(&root, "sub").expect("create_dir");
+        // No explicit flush: create_dir must persist the bitmap itself.
+    }
+
+    let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+    assert_eq!(
+        fs.free_cluster_count(),
+        free_before - 1,
+        "create_dir's cluster allocation was not persisted to the bitmap"
+    );
+}
+
+// X5: truncating a fragmented file must free the dropped tail clusters in the
+// allocation bitmap, not only in the FAT. Previously the fragmented branch
+// called `fat.truncate_chain` (FAT-only), leaking the clusters in the bitmap.
+#[test]
+fn x5_fragmented_truncate_frees_bitmap() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("x5.img");
+    make_image(&img, 32 * 1024 * 1024, "X5");
+
+    let cs = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("open");
+        fs.info().bytes_per_cluster
+    };
+
+    // Build a fragmented, multi-cluster file "a" by interleaving writes with a
+    // second file "b" so a's clusters cannot stay adjacent.
+    {
+        let fs = ExFatVolume::open(open_image(&img)).expect("open");
+        let a = {
+            let r = fs.root_dir();
+            fs.create_file(&r, "a.bin").unwrap()
+        };
+        let b = {
+            let r = fs.root_dir();
+            fs.create_file(&r, "b.bin").unwrap()
+        };
+        let mut wa = fs.write_file(&a).unwrap();
+        let mut wb = fs.write_file(&b).unwrap();
+        let pat_a = vec![0xA7u8; 3 * cs];
+        let pat_b = vec![0xB3u8; 2 * cs];
+        wa.write_all(&pat_a[..cs]).unwrap();
+        wb.write_all(&pat_b[..cs]).unwrap();
+        wa.write_all(&pat_a[cs..2 * cs]).unwrap();
+        wb.write_all(&pat_b[cs..]).unwrap();
+        wa.write_all(&pat_a[2 * cs..]).unwrap();
+        wa.finish().unwrap();
+        wb.finish().unwrap();
+    }
+
+    let free_with_full_a = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+        let a = fs.root_dir().find("a.bin").unwrap().expect("a exists");
+        assert!(
+            !a.no_fat_chain,
+            "precondition: 'a' must be fragmented (chained), not contiguous"
+        );
+        fs.free_cluster_count()
+    };
+
+    // Truncate "a" down to one cluster: two fragmented tail clusters must be
+    // freed in the bitmap.
+    {
+        let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+        let a = fs.root_dir().find("a.bin").unwrap().expect("a exists");
+        fs.truncate(&a, cs as u64).expect("truncate");
+    }
+
+    let free_after_truncate = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+        fs.free_cluster_count()
+    };
+
+    assert!(
+        free_after_truncate > free_with_full_a,
+        "fragmented truncate did not reclaim tail clusters in the bitmap \
+         (free stayed at {free_with_full_a})"
+    );
+    assert_eq!(
+        free_after_truncate,
+        free_with_full_a + 2,
+        "expected exactly 2 tail clusters reclaimed"
+    );
+}
+
+// X6: overwriting a contiguous, multi-cluster file in place must reuse the
+// file's own already-allocated clusters. Previously, crossing a cluster
+// boundary during an overwrite saw the file's next cluster as "already
+// allocated" and allocated a brand-new cluster instead, orphaning the old one
+// (a bitmap leak) and needlessly fragmenting the file (the issue #90 pattern).
+#[test]
+fn x6_contiguous_overwrite_reuses_clusters() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("x6.img");
+    make_image(&img, 32 * 1024 * 1024, "X6");
+
+    let cs = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("open");
+        fs.info().bytes_per_cluster
+    };
+
+    // Create a contiguous 3-cluster file with no interleaving so it stays
+    // contiguous (no_fat_chain).
+    let original: Vec<u8> = (0..(3 * cs)).map(|i| (i % 251) as u8).collect();
+    {
+        let fs = ExFatVolume::open(open_image(&img)).expect("open");
+        let a = {
+            let r = fs.root_dir();
+            fs.create_file(&r, "a.bin").unwrap()
+        };
+        let mut w = fs.write_file(&a).unwrap();
+        w.write_all(&original).unwrap();
+        w.finish().unwrap();
+    }
+
+    let free_before = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+        let a = fs.root_dir().find("a.bin").unwrap().expect("a exists");
+        assert!(
+            a.no_fat_chain,
+            "precondition: 'a' must be contiguous (no_fat_chain) before overwrite"
+        );
+        fs.free_cluster_count()
+    };
+
+    // Overwrite the whole file in place with a distinct, same-size pattern.
+    let replacement: Vec<u8> = (0..(3 * cs)).map(|i| (i % 251) as u8 ^ 0xFF).collect();
+    {
+        let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+        let a = fs.root_dir().find("a.bin").unwrap().expect("a exists");
+        let mut w = fs.write_file(&a).unwrap();
+        w.write_all(&replacement).unwrap();
+        w.finish().unwrap();
+    }
+
+    let free_after = {
+        let fs = ExFatVolume::open(open_image(&img)).expect("reopen");
+        let a = fs.root_dir().find("a.bin").unwrap().expect("a exists");
+        assert!(
+            a.no_fat_chain,
+            "overwrite fragmented a contiguous file instead of reusing its clusters"
+        );
+        fs.free_cluster_count()
+    };
+
+    assert_eq!(
+        free_after,
+        free_before,
+        "in-place overwrite allocated new clusters (leaked {} cluster(s))",
+        free_before as i64 - free_after as i64
+    );
+
+    let got = read_root_file(&img, "a.bin");
+    assert_eq!(got.len(), replacement.len(), "read-back length mismatch");
+    assert_eq!(
+        got, replacement,
+        "read-back content mismatch after overwrite"
+    );
+}

--- a/crates/block/hadris-fat/tests/regression_audit_fat.rs
+++ b/crates/block/hadris-fat/tests/regression_audit_fat.rs
@@ -1,0 +1,803 @@
+//! Regression tests for the 2026-08 hadris-fat correctness audit.
+//!
+//! Each test asserts the CORRECT/SAFE behavior and is named after the audit
+//! finding it guards. Single-threaded only (`FatVolume` is `!Sync`).
+
+#![cfg(all(feature = "write", feature = "std"))]
+
+use hadris_fat::raw::DirEntryAttrFlags;
+use hadris_fat::time::FatDateTime;
+use hadris_fat::write::FileWriter;
+use hadris_fat::{Error, FatVolume, FatVolumeReadExt, FatVolumeWriteExt};
+
+mod fat32_image {
+    use std::io::Cursor;
+    const SECTOR_SIZE: usize = 512;
+    const SECTORS_PER_CLUSTER: u8 = 1;
+    const CLUSTER_SIZE: usize = SECTOR_SIZE * SECTORS_PER_CLUSTER as usize;
+    const RESERVED_SECTORS: u16 = 32;
+    const FAT_COUNT: u8 = 2;
+    const SECTORS_PER_FAT: u32 = 128;
+    const ROOT_CLUSTER: u32 = 2;
+    const FSINFO_LEAD_SIG: u32 = 0x41615252;
+    const FSINFO_STRUC_SIG: u32 = 0x61417272;
+    const FSINFO_TRAIL_SIG: u32 = 0xAA550000;
+    pub const TOTAL_DATA_CLUSTERS: u32 = 256;
+
+    pub fn create_fat32_image() -> Cursor<Vec<u8>> {
+        let data_start_sector = RESERVED_SECTORS as u32 + FAT_COUNT as u32 * SECTORS_PER_FAT;
+        let total_sectors = data_start_sector + TOTAL_DATA_CLUSTERS;
+        let total_size = total_sectors as usize * SECTOR_SIZE;
+        let mut image = vec![0u8; total_size];
+        write_boot_sector(&mut image);
+        write_fsinfo_sector(&mut image, TOTAL_DATA_CLUSTERS - 1);
+        let fat_start = RESERVED_SECTORS as usize * SECTOR_SIZE;
+        write_fat_table(&mut image, fat_start);
+        let fat2_start = fat_start + SECTORS_PER_FAT as usize * SECTOR_SIZE;
+        write_fat_table(&mut image, fat2_start);
+        Cursor::new(image)
+    }
+
+    fn write_boot_sector(image: &mut [u8]) {
+        image[0] = 0xEB;
+        image[1] = 0x58;
+        image[2] = 0x90;
+        image[3..11].copy_from_slice(b"HADRISFT");
+        image[11..13].copy_from_slice(&(SECTOR_SIZE as u16).to_le_bytes());
+        image[13] = SECTORS_PER_CLUSTER;
+        image[14..16].copy_from_slice(&RESERVED_SECTORS.to_le_bytes());
+        image[16] = FAT_COUNT;
+        image[17..19].copy_from_slice(&0u16.to_le_bytes());
+        image[19..21].copy_from_slice(&0u16.to_le_bytes());
+        image[21] = 0xF8;
+        image[22..24].copy_from_slice(&0u16.to_le_bytes());
+        image[24..26].copy_from_slice(&63u16.to_le_bytes());
+        image[26..28].copy_from_slice(&255u16.to_le_bytes());
+        image[28..32].copy_from_slice(&0u32.to_le_bytes());
+        let total_sectors = RESERVED_SECTORS as u32 + FAT_COUNT as u32 * SECTORS_PER_FAT + 256;
+        image[32..36].copy_from_slice(&total_sectors.to_le_bytes());
+        image[36..40].copy_from_slice(&SECTORS_PER_FAT.to_le_bytes());
+        image[40..42].copy_from_slice(&0u16.to_le_bytes());
+        image[42..44].copy_from_slice(&0u16.to_le_bytes());
+        image[44..48].copy_from_slice(&ROOT_CLUSTER.to_le_bytes());
+        image[48..50].copy_from_slice(&1u16.to_le_bytes());
+        image[50..52].copy_from_slice(&6u16.to_le_bytes());
+        image[64] = 0x80;
+        image[66] = 0x29;
+        image[67..71].copy_from_slice(&0x12345678u32.to_le_bytes());
+        image[71..82].copy_from_slice(b"TEST       ");
+        image[82..90].copy_from_slice(b"FAT32   ");
+        image[510] = 0x55;
+        image[511] = 0xAA;
+    }
+
+    fn write_fsinfo_sector(image: &mut [u8], free_clusters: u32) {
+        let offset = SECTOR_SIZE;
+        image[offset..offset + 4].copy_from_slice(&FSINFO_LEAD_SIG.to_le_bytes());
+        image[offset + 484..offset + 488].copy_from_slice(&FSINFO_STRUC_SIG.to_le_bytes());
+        image[offset + 488..offset + 492].copy_from_slice(&free_clusters.to_le_bytes());
+        image[offset + 492..offset + 496].copy_from_slice(&3u32.to_le_bytes());
+        image[offset + 508..offset + 512].copy_from_slice(&FSINFO_TRAIL_SIG.to_le_bytes());
+    }
+
+    fn write_fat_table(image: &mut [u8], fat_start: usize) {
+        image[fat_start..fat_start + 4].copy_from_slice(&0x0FFFFFF8u32.to_le_bytes());
+        image[fat_start + 4..fat_start + 8].copy_from_slice(&0x0FFFFFFFu32.to_le_bytes());
+        image[fat_start + 8..fat_start + 12].copy_from_slice(&0x0FFFFFF8u32.to_le_bytes());
+    }
+
+    pub const fn cluster_size() -> usize {
+        CLUSTER_SIZE
+    }
+    pub const fn fat_start_bytes() -> usize {
+        RESERVED_SECTORS as usize * SECTOR_SIZE
+    }
+
+    /// Count non-free FAT32 entries (index >= 2) in the primary FAT.
+    /// A "free" entry is 0x0000000 (after masking off the top 4 bits).
+    #[allow(dead_code)] // used by TOCTOU tests added in a later commit
+    pub fn allocated_fat_entries(image: &[u8]) -> usize {
+        let fat_start = fat_start_bytes();
+        let mut allocated = 0;
+        for i in 2..(2 + TOTAL_DATA_CLUSTERS as usize) {
+            let off = fat_start + i * 4;
+            let raw =
+                u32::from_le_bytes([image[off], image[off + 1], image[off + 2], image[off + 3]])
+                    & 0x0FFF_FFFF;
+            if raw != 0 {
+                allocated += 1;
+            }
+        }
+        allocated
+    }
+
+    /// Read the 28-bit FAT32 entry for `cluster` from the primary FAT.
+    #[allow(dead_code)] // used by TOCTOU tests added in a later commit
+    pub fn fat_entry(image: &[u8], cluster: usize) -> u32 {
+        let off = fat_start_bytes() + cluster * 4;
+        u32::from_le_bytes([image[off], image[off + 1], image[off + 2], image[off + 3]])
+            & 0x0FFF_FFFF
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FAT16 image builder (copied from tests/test_write.rs::fat16_image)
+// ---------------------------------------------------------------------------
+mod fat16_image {
+    use std::io::Cursor;
+    const SECTOR_SIZE: usize = 512;
+    const SECTORS_PER_CLUSTER: u8 = 1;
+    const RESERVED_SECTORS: u16 = 1;
+    const FAT_COUNT: u8 = 2;
+    const SECTORS_PER_FAT: u16 = 32;
+    pub const ROOT_ENTRY_COUNT: u16 = 512;
+
+    pub fn create_fat16_image() -> Cursor<Vec<u8>> {
+        let root_dir_sectors = (ROOT_ENTRY_COUNT as usize * 32).div_ceil(SECTOR_SIZE);
+        let data_start_sector = RESERVED_SECTORS as usize
+            + FAT_COUNT as usize * SECTORS_PER_FAT as usize
+            + root_dir_sectors;
+        let total_data_clusters: usize = 8192;
+        let total_sectors = data_start_sector + total_data_clusters;
+        let total_size = total_sectors * SECTOR_SIZE;
+        let mut image = vec![0u8; total_size];
+        write_boot_sector(&mut image, total_sectors as u32);
+        let fat_start = RESERVED_SECTORS as usize * SECTOR_SIZE;
+        write_fat_table(&mut image, fat_start);
+        let fat2_start = fat_start + SECTORS_PER_FAT as usize * SECTOR_SIZE;
+        write_fat_table(&mut image, fat2_start);
+        Cursor::new(image)
+    }
+
+    fn write_boot_sector(image: &mut [u8], total_sectors: u32) {
+        image[0] = 0xEB;
+        image[1] = 0x3C;
+        image[2] = 0x90;
+        image[3..11].copy_from_slice(b"HADRISFT");
+        image[11..13].copy_from_slice(&(SECTOR_SIZE as u16).to_le_bytes());
+        image[13] = SECTORS_PER_CLUSTER;
+        image[14..16].copy_from_slice(&RESERVED_SECTORS.to_le_bytes());
+        image[16] = FAT_COUNT;
+        image[17..19].copy_from_slice(&ROOT_ENTRY_COUNT.to_le_bytes());
+        if total_sectors <= 65535 {
+            image[19..21].copy_from_slice(&(total_sectors as u16).to_le_bytes());
+        } else {
+            image[19..21].copy_from_slice(&0u16.to_le_bytes());
+        }
+        image[21] = 0xF8;
+        image[22..24].copy_from_slice(&SECTORS_PER_FAT.to_le_bytes());
+        image[24..26].copy_from_slice(&63u16.to_le_bytes());
+        image[26..28].copy_from_slice(&255u16.to_le_bytes());
+        image[28..32].copy_from_slice(&0u32.to_le_bytes());
+        if total_sectors > 65535 {
+            image[32..36].copy_from_slice(&total_sectors.to_le_bytes());
+        } else {
+            image[32..36].copy_from_slice(&0u32.to_le_bytes());
+        }
+        image[36] = 0x80;
+        image[38] = 0x29;
+        image[39..43].copy_from_slice(&0x12345678u32.to_le_bytes());
+        image[43..54].copy_from_slice(b"TEST       ");
+        image[54..62].copy_from_slice(b"FAT16   ");
+        image[510] = 0x55;
+        image[511] = 0xAA;
+    }
+
+    fn write_fat_table(image: &mut [u8], fat_start: usize) {
+        image[fat_start..fat_start + 2].copy_from_slice(&0xFFF8u16.to_le_bytes());
+        image[fat_start + 2..fat_start + 4].copy_from_slice(&0xFFFFu16.to_le_bytes());
+    }
+
+    pub const fn fat_start_bytes() -> usize {
+        RESERVED_SECTORS as usize * SECTOR_SIZE
+    }
+
+    /// Count non-free FAT16 entries (index >= 2) in the primary FAT. A free
+    /// entry is 0x0000. The two reserved entries (0, 1) are skipped.
+    pub fn allocated_fat_entries(image: &[u8]) -> usize {
+        let fat_start = fat_start_bytes();
+        let entries = SECTORS_PER_FAT as usize * SECTOR_SIZE / 2;
+        let mut allocated = 0;
+        for i in 2..entries {
+            let off = fat_start + i * 2;
+            let raw = u16::from_le_bytes([image[off], image[off + 1]]);
+            if raw != 0 {
+                allocated += 1;
+            }
+        }
+        allocated
+    }
+}
+// ---------------------------------------------------------------------------
+// B1: create_dir leaks its cluster on the DirectoryFull error path.
+//
+// Target: crates/block/hadris-fat/src/write.rs
+//   create_dir allocates its data cluster and decrements the free count
+//   (write.rs:1249-1253) BEFORE the fallible find_free_entry_run_in_dir call
+//   (write.rs:1275). On a full fixed-root directory that call returns
+//   DirectoryFull, leaving the just-allocated cluster marked EOC in the FAT
+//   but referenced by nothing.
+//
+// Compare create_file, which allocates NO data cluster for the entry (empty
+// file, cluster 0) and does its LFN work before touching the FAT — no
+// asymmetric leak is possible there.
+// ---------------------------------------------------------------------------
+#[test]
+fn b1_create_dir_leaks_cluster_on_directory_full() {
+    let image = fat16_image::create_fat16_image();
+    let fs = FatVolume::open(image).expect("open FAT16");
+
+    // Fill the fixed root directory to capacity with single-entry 8.3 files.
+    // Each empty file occupies exactly one 32-byte slot and allocates NO data
+    // cluster, so the FAT stays empty (all data clusters free) before the
+    // create_dir attempt.
+    let root = fs.root_dir();
+    for i in 0..fat16_image::ROOT_ENTRY_COUNT {
+        let name = format!("{i:03}.TXT");
+        fs.create_file(&root, &name)
+            .expect("create_file should succeed while root has space");
+    }
+
+    // Now attempt to create a directory in the full root. This must fail with
+    // DirectoryFull.
+    let root = fs.root_dir();
+    let result = fs.create_dir(&root, "SUB");
+    match result {
+        Err(Error::DirectoryFull) => {}
+        Err(other) => panic!("expected DirectoryFull, got Err({other:?})"),
+        Ok(_) => panic!("expected DirectoryFull, but create_dir succeeded"),
+    }
+
+    // CORRECT behavior: the failed create_dir must not have leaked a cluster.
+    // Empty files consume no data clusters, so a correct implementation leaves
+    // the FAT with zero allocated data clusters.
+    let bytes = fs.into_inner().into_inner();
+    let allocated_after = fat16_image::allocated_fat_entries(&bytes);
+    assert_eq!(
+        allocated_after, 0,
+        "create_dir failing with DirectoryFull must not leak a cluster in the FAT \
+         (found {allocated_after} allocated EOC entries referenced by nothing)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B2: FileWriter::new_append overwrites the last cluster when the file size
+// is an exact multiple of cluster_size.
+//
+// Target: crates/block/hadris-fat/src/write.rs:171
+//   offset_in_last = file_size % cluster_size == 0 while current_cluster is
+//   the last (full) cluster. write()'s guard `offset_in_cluster >=
+//   cluster_size` is false at 0, so the first appended byte lands at offset 0
+//   of the already-full last cluster, clobbering existing data.
+// ---------------------------------------------------------------------------
+#[test]
+fn b2_new_append_overwrites_last_full_cluster() {
+    let image = fat32_image::create_fat32_image();
+    let fs = FatVolume::open(image).expect("open FAT32");
+    let cluster_sz = fat32_image::cluster_size();
+
+    // Create a file and write exactly one cluster of a known pattern.
+    let root = fs.root_dir();
+    let entry = fs.create_file(&root, "APPEND.BIN").expect("create_file");
+    {
+        let mut w = fs.write_file(&entry).expect("write_file");
+        let pattern = vec![0x11u8; cluster_sz];
+        w.write(&pattern).expect("write");
+        w.finish().expect("finish");
+    }
+
+    // Re-find to pick up the committed size / first cluster.
+    let root = fs.root_dir();
+    let entry = root
+        .find("APPEND.BIN")
+        .expect("find")
+        .expect("entry exists");
+    assert_eq!(
+        entry.len(),
+        cluster_sz as u64,
+        "precondition: one full cluster"
+    );
+
+    // Append 6 bytes via new_append.
+    {
+        let mut w = FileWriter::new_append(&fs, &entry).expect("new_append");
+        w.write(b"APPEND").expect("append write");
+        w.finish().expect("finish append");
+    }
+
+    // Read the file back.
+    let root = fs.root_dir();
+    let entry = root
+        .find("APPEND.BIN")
+        .expect("find")
+        .expect("entry exists");
+    let content = fs
+        .read_file(&entry)
+        .expect("read_file")
+        .read_to_vec()
+        .expect("read_to_vec");
+
+    println!(
+        "B2: read_back_len={} first8={:02x?} last8={:02x?}",
+        content.len(),
+        &content[..8.min(content.len())],
+        &content[content.len().saturating_sub(8)..]
+    );
+
+    // CORRECT behavior: the original cluster is preserved and "APPEND" is
+    // appended AFTER it.
+    assert_eq!(
+        content.len(),
+        cluster_sz + 6,
+        "appended file should be cluster_size + 6 bytes"
+    );
+    assert!(
+        content[..cluster_sz].iter().all(|&b| b == 0x11),
+        "the original cluster's bytes must be preserved (0x11), but they were \
+         overwritten: first byte = {:#x}",
+        content[0]
+    );
+    assert_eq!(
+        &content[cluster_sz..],
+        b"APPEND",
+        "the appended bytes must follow the original cluster"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stale-handle (TOCTOU) guards. A `FileEntry` snapshots parent cluster, slot
+// offset, and short name. If the file is deleted and its slot reused before a
+// mutating API acts on the snapshot, the API would operate on the unrelated
+// entry now in the slot. Each mutating API (delete/rename/set_attributes/
+// set_times/truncate) and `FileWriter::finish` now revalidates the on-disk
+// short name (and not-deleted marker) before acting and returns
+// `Error::StaleEntry` on mismatch, leaving the reusing entry untouched.
+// ---------------------------------------------------------------------------
+
+// A1: delete() through a stale handle must not free the live chain now owned by
+// the renamed file.
+#[test]
+fn a1_stale_delete_rejected_and_preserves_renamed_file() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let cluster_sz = fat32_image::cluster_size();
+    let content: Vec<u8> = (0..cluster_sz * 3).map(|i| (i % 251) as u8).collect();
+
+    let root = fs.root_dir();
+    let a = fs.create_file(&root, "A.TXT").expect("create A.TXT");
+    {
+        let mut w = fs.write_file(&a).expect("writer");
+        w.write(&content).expect("write");
+        w.finish().expect("finish");
+    }
+
+    // Snapshot a stale handle to A.TXT, then rename A.TXT -> B.TXT so B owns the
+    // same live cluster chain.
+    let root = fs.root_dir();
+    let stale = root.find("A.TXT").expect("find").expect("A.TXT exists");
+    let chain_start = stale.cluster();
+    let dst = fs.root_dir();
+    let b = fs.rename(&stale, &dst, "B.TXT").expect("rename");
+    assert_eq!(b.cluster(), chain_start, "rename keeps the chain");
+
+    match fs.delete(&stale) {
+        Err(Error::StaleEntry) => {}
+        other => panic!("stale delete must return StaleEntry, got {other:?}"),
+    }
+
+    let root = fs.root_dir();
+    let b_now = root
+        .find("B.TXT")
+        .expect("find")
+        .expect("B.TXT must still exist");
+    let read_back = fs
+        .read_file(&b_now)
+        .expect("reader")
+        .read_to_vec()
+        .expect("read");
+    assert_eq!(read_back, content, "B.TXT contents must be intact");
+}
+
+// A2: set_attributes() through a stale handle must not clear the DIRECTORY bit
+// of the directory now occupying the reused slot.
+#[test]
+fn a2_stale_set_attributes_rejected_and_preserves_dir() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let root = fs.root_dir();
+    fs.create_file(&root, "F.TXT").expect("create F.TXT");
+    let root = fs.root_dir();
+    let stale = root.find("F.TXT").expect("find").expect("F.TXT exists");
+    assert!(stale.is_file());
+
+    fs.delete(&stale).expect("delete F.TXT");
+    fs.create_dir(&root, "SUB").expect("create_dir SUB");
+
+    let attrs = DirEntryAttrFlags::ARCHIVE | DirEntryAttrFlags::HIDDEN;
+    match fs.set_attributes(&stale, attrs) {
+        Err(Error::StaleEntry) => {}
+        other => panic!("stale set_attributes must return StaleEntry, got {other:?}"),
+    }
+
+    let root = fs.root_dir();
+    let sub = root.find("SUB").expect("find").expect("SUB must exist");
+    assert!(
+        sub.is_directory(),
+        "SUB must remain a directory (attrs {:?})",
+        sub.attributes()
+    );
+}
+
+// A3: FileWriter::finish() at stale coordinates must not clobber the entry now
+// occupying the reused slot. The reusing entry here is a directory (created via
+// create_dir, which opens no writer) so the slot's exclusive-writer guard does
+// not pre-empt the scenario — this isolates the finish-time revalidation.
+#[test]
+fn a3_stale_finish_rejected_and_preserves_reused_slot() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let cluster_sz = fat32_image::cluster_size();
+    let root = fs.root_dir();
+    let old = fs.create_file(&root, "OLD.TXT").expect("create OLD.TXT");
+
+    // Open a writer against OLD.TXT and write (but do not finish yet).
+    let mut writer = fs.write_file(&old).expect("writer");
+    let old_data: Vec<u8> = (0..cluster_sz * 2).map(|i| (i % 253) as u8).collect();
+    writer.write(&old_data).expect("write old");
+
+    // Delete OLD.TXT, then create a directory that reuses the freed slot.
+    fs.delete(&old).expect("delete OLD.TXT");
+    fs.create_dir(&root, "REUSED").expect("create_dir REUSED");
+
+    let root = fs.root_dir();
+    let reused_before = root.find("REUSED").expect("find").expect("REUSED exists");
+    let reused_cluster = reused_before.cluster();
+
+    match writer.finish() {
+        Err(Error::StaleEntry) => {}
+        other => panic!("stale finish must return StaleEntry, got {other:?}"),
+    }
+
+    // The directory that reused the slot must be untouched.
+    let root = fs.root_dir();
+    let reused_after = root
+        .find("REUSED")
+        .expect("find")
+        .expect("REUSED must still exist");
+    assert!(
+        reused_after.is_directory(),
+        "REUSED must remain a directory after the stale finish"
+    );
+    assert_eq!(
+        reused_after.cluster(),
+        reused_cluster,
+        "REUSED first cluster must be intact"
+    );
+}
+
+// A4: rename() through a stale handle must not move the entry now occupying the
+// reused slot, nor create the destination name.
+#[test]
+fn a4_stale_rename_rejected_and_preserves_reused_slot() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let root = fs.root_dir();
+    fs.create_file(&root, "A.TXT").expect("create A.TXT");
+    let root = fs.root_dir();
+    let stale = root.find("A.TXT").expect("find").expect("A.TXT exists");
+
+    fs.delete(&stale).expect("delete A.TXT");
+    fs.create_dir(&root, "SUB").expect("create_dir SUB");
+
+    let dst = fs.root_dir();
+    match fs.rename(&stale, &dst, "Z.TXT") {
+        Err(Error::StaleEntry) => {}
+        other => panic!("stale rename must return StaleEntry, got {other:?}"),
+    }
+
+    let root = fs.root_dir();
+    assert!(
+        root.find("Z.TXT").expect("find").is_none(),
+        "stale rename must not create Z.TXT"
+    );
+    let sub = root.find("SUB").expect("find").expect("SUB must exist");
+    assert!(sub.is_directory(), "SUB must remain a directory");
+}
+
+// A6: a FileReader held across a delete + reuse must not disclose the data of
+// the file that reused the cluster. The reader revalidates its slot before
+// serving bytes and returns StaleEntry instead of leaking PUBLIC's content.
+#[test]
+fn a6_stale_reader_rejected_not_disclosing_reused_cluster() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let cluster_sz = fat32_image::cluster_size();
+    let secret_pattern = vec![0xABu8; cluster_sz];
+    let public_pattern = vec![0xCDu8; cluster_sz];
+
+    let root = fs.root_dir();
+    let secret = fs.create_file(&root, "SECRET.TXT").expect("create SECRET");
+    {
+        let mut w = fs.write_file(&secret).expect("writer");
+        w.write(&secret_pattern).expect("write secret");
+        w.finish().expect("finish");
+    }
+
+    let root = fs.root_dir();
+    let secret = root
+        .find("SECRET.TXT")
+        .expect("find")
+        .expect("SECRET exists");
+    let secret_cluster = secret.cluster();
+
+    // Open a reader but do not read yet.
+    let mut reader = fs.read_file(&secret).expect("reader");
+
+    // Delete SECRET, then create PUBLIC which reuses the freed cluster.
+    fs.delete(&secret).expect("delete SECRET");
+    let public = fs.create_file(&root, "PUBLIC.TXT").expect("create PUBLIC");
+    {
+        let mut w = fs.write_file(&public).expect("writer");
+        w.write(&public_pattern).expect("write public");
+        w.finish().expect("finish");
+    }
+    let root = fs.root_dir();
+    let public = root
+        .find("PUBLIC.TXT")
+        .expect("find")
+        .expect("PUBLIC exists");
+    assert_eq!(
+        public.cluster(),
+        secret_cluster,
+        "precondition: PUBLIC reuses SECRET's cluster"
+    );
+
+    // The stale reader must refuse to serve PUBLIC's bytes.
+    match reader.read_to_vec() {
+        Err(Error::StaleEntry) => {}
+        Ok(bytes) => panic!(
+            "stale reader disclosed {} bytes (first = {:#x}) instead of erroring",
+            bytes.len(),
+            bytes.first().copied().unwrap_or(0)
+        ),
+        Err(other) => panic!("expected StaleEntry from stale reader, got {other:?}"),
+    }
+}
+
+// A7: creating an entry through a stale FatDir (its directory was deleted and
+// the slot reused) must be rejected, not write directory entries into the
+// unrelated file that now occupies the directory's old slot/clusters.
+#[test]
+fn a7_stale_dir_create_rejected_and_preserves_reuser() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let root = fs.root_dir();
+
+    // Create SUB and keep its directory handle.
+    let sub_dir = fs.create_dir(&root, "SUB").expect("create_dir SUB");
+
+    // Delete SUB, freeing its entry slot and its data cluster.
+    let root = fs.root_dir();
+    let sub_entry = root.find("SUB").expect("find").expect("SUB exists");
+    fs.delete(&sub_entry).expect("delete SUB");
+
+    // Create a file in root that reuses SUB's freed slot/cluster.
+    let victim = fs.create_file(&root, "VICTIM.TXT").expect("create VICTIM");
+    {
+        let mut w = fs.write_file(&victim).expect("writer");
+        w.write(b"victim-data").expect("write");
+        w.finish().expect("finish");
+    }
+
+    // Both create paths through the stale directory handle must be rejected.
+    match fs.create_file(&sub_dir, "X.TXT") {
+        Err(Error::StaleEntry) => {}
+        other => panic!("stale-dir create_file must return StaleEntry, got {other:?}"),
+    }
+    match fs.create_dir(&sub_dir, "Y") {
+        Err(Error::StaleEntry) => {}
+        Err(other) => panic!("stale-dir create_dir must return StaleEntry, got {other:?}"),
+        Ok(_) => panic!("stale-dir create_dir unexpectedly succeeded"),
+    }
+
+    // VICTIM.TXT must be intact and root must not have gained X.TXT / Y.
+    let root = fs.root_dir();
+    assert!(
+        root.find("X.TXT").expect("find").is_none(),
+        "stale-dir create must not create X.TXT"
+    );
+    assert!(
+        root.find("Y").expect("find").is_none(),
+        "stale-dir create must not create Y"
+    );
+    let v = root
+        .find("VICTIM.TXT")
+        .expect("find")
+        .expect("VICTIM exists");
+    let data = fs
+        .read_file(&v)
+        .expect("reader")
+        .read_to_vec()
+        .expect("read");
+    assert_eq!(data, b"victim-data", "VICTIM.TXT content must be intact");
+}
+
+// A5: a second FileWriter for a directory entry that already has one open must
+// be rejected, so two writers cannot independently allocate and cross-link the
+// file's chain (leaking the loser's clusters when the last finish wins).
+#[test]
+fn a5_second_writer_on_same_entry_rejected() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let cluster_sz = fat32_image::cluster_size();
+    let root = fs.root_dir();
+    let entry = fs.create_file(&root, "SHARED.BIN").expect("create");
+    let free_before = fs.free_cluster_count().expect("fat32 tracks free count");
+
+    let mut a = fs.write_file(&entry).expect("writer a");
+    match fs.write_file(&entry) {
+        Err(Error::WriterConflict) => {}
+        Err(other) => panic!("second writer must return WriterConflict, got {other:?}"),
+        Ok(_) => panic!("second writer on the same entry was unexpectedly allowed"),
+    }
+
+    // The first writer works normally.
+    let data = vec![0xAAu8; cluster_sz * 2];
+    a.write(&data).expect("write a");
+    a.finish().expect("finish a");
+
+    // Content is intact and exactly the two written clusters were consumed —
+    // no orphaned/leaked chain from a phantom second writer.
+    let entry = fs
+        .root_dir()
+        .find("SHARED.BIN")
+        .expect("find")
+        .expect("exists");
+    let read_back = fs
+        .read_file(&entry)
+        .expect("reader")
+        .read_to_vec()
+        .expect("read");
+    assert_eq!(read_back, data, "single-writer content must be intact");
+    let free_after = fs.free_cluster_count().expect("fat32 tracks free count");
+    assert_eq!(
+        free_before - free_after,
+        2,
+        "exactly two clusters consumed; none leaked"
+    );
+
+    // Finishing the first writer released the slot, so a new writer opens.
+    // This one overwrites from offset 0, so it runs after the assertions above.
+    let b = fs.write_file(&entry).expect("writer after finish");
+    b.finish().expect("finish b");
+}
+
+/// A8: a handle whose slot was freed and re-taken by a *same-named* file must
+/// not act on the new file. The short name alone cannot tell the two apart, so
+/// the creation timestamp is compared as well.
+#[test]
+fn a8_stale_handle_rejected_when_slot_reused_by_same_name() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let root = fs.root_dir();
+
+    let victim = fs
+        .create_file(&root, "REUSED.BIN")
+        .expect("create original");
+    {
+        let mut w = fs.write_file(&victim).expect("writer");
+        w.write(&[0x11u8; 64]).expect("write");
+        w.finish().expect("finish");
+    }
+    let stale = fs
+        .root_dir()
+        .find("REUSED.BIN")
+        .expect("find")
+        .expect("exists");
+
+    fs.delete(&stale).expect("delete original");
+
+    // Recreate under the exact same name. Stamp a creation timestamp that
+    // differs from the original's so the test does not depend on clock
+    // granularity between the two creates.
+    let fresh = fs.create_file(&root, "REUSED.BIN").expect("recreate");
+    let payload = [0x22u8; 96];
+    {
+        let mut w = fs.write_file(&fresh).expect("writer");
+        w.write(&payload).expect("write");
+        w.finish().expect("finish");
+    }
+    let fresh = fs
+        .root_dir()
+        .find("REUSED.BIN")
+        .expect("find")
+        .expect("exists");
+    let distinct = FatDateTime::new(2001, 2, 3, 4, 5, 6);
+    fs.set_times(&fresh, None, None, Some(distinct))
+        .expect("stamp creation time");
+
+    match fs.delete(&stale) {
+        Err(Error::StaleEntry) => {}
+        other => panic!("stale same-name handle must be rejected, got {other:?}"),
+    }
+
+    let survivor = fs
+        .root_dir()
+        .find("REUSED.BIN")
+        .expect("find")
+        .expect("recreated file must survive");
+    let content = fs
+        .read_file(&survivor)
+        .expect("reader")
+        .read_to_vec()
+        .expect("read");
+    assert_eq!(content, payload, "recreated file must be untouched");
+}
+
+/// B3: `finish()` must surface a real I/O failure. Under `dirty-file-panic` the
+/// Drop guard previously fired on the way out of a failing `finish()`, masking
+/// the error with a panic about a writer that had in fact been finished.
+#[test]
+fn b3_finish_reports_io_error_instead_of_dirty_panic() {
+    let fs = FatVolume::open(fail_after::device(fat32_image::create_fat32_image())).expect("open");
+    let root = fs.root_dir();
+    let entry = fs.create_file(&root, "IOFAIL.BIN").expect("create");
+
+    let mut w = fs.write_file(&entry).expect("writer");
+    w.write(&[0x33u8; 64]).expect("write");
+
+    fail_after::arm();
+    let result = w.finish();
+    fail_after::disarm();
+
+    match result {
+        Err(Error::Io(_)) => {}
+        other => panic!("finish() must report the I/O error, got {other:?}"),
+    }
+}
+
+mod fail_after {
+    use std::cell::Cell;
+    use std::io::{Cursor, Read, Result, Seek, SeekFrom, Write};
+
+    thread_local! {
+        static ARMED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    pub fn arm() {
+        ARMED.with(|a| a.set(true));
+    }
+
+    pub fn disarm() {
+        ARMED.with(|a| a.set(false));
+    }
+
+    /// Wraps an image so that every write fails once armed. Reads and seeks
+    /// keep working, so the failure lands inside `finish()` rather than during
+    /// mount or lookup.
+    pub struct FailingWrites(Cursor<Vec<u8>>);
+
+    pub fn device(inner: Cursor<Vec<u8>>) -> FailingWrites {
+        FailingWrites(inner)
+    }
+
+    impl Write for FailingWrites {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            if ARMED.with(|a| a.get()) {
+                return Err(std::io::Error::other("injected write failure"));
+            }
+            self.0.write(buf)
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            if ARMED.with(|a| a.get()) {
+                return Err(std::io::Error::other("injected flush failure"));
+            }
+            self.0.flush()
+        }
+    }
+
+    impl Read for FailingWrites {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            self.0.read(buf)
+        }
+    }
+
+    impl Seek for FailingWrites {
+        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+            self.0.seek(pos)
+        }
+    }
+}


### PR DESCRIPTION
Ten write-path correctness bugs found in an audit of `hadris-fat`, plus a
format-geometry bug. Two commits: FAT and `unstable-exfat`.

## FAT

- `create_dir` no longer leaks its data cluster when a later step fails
  (`DirectoryFull` on a full fixed root, over-long name). The cluster is
  allocated after the fallible name/slot steps, matching `create_file`.
- `FileWriter::new_append` no longer overwrites the last cluster of a file
  whose size is an exact multiple of the cluster size.
- Stale `FileEntry`/`FatDir` handles can no longer corrupt an unrelated file.
  `delete`, `rename`, `truncate`, `set_attributes`, `set_times`,
  `FileWriter::finish`, `FileReader`, `create_file`, and `create_dir` now
  revalidate the directory slot's on-disk short name and return
  `Error::StaleEntry` on mismatch. `delete` marks the entry deleted before
  freeing its chain.
- Opening a second `FileWriter` for the same directory entry now returns
  `Error::WriterConflict` instead of letting both writers cross-link one
  cluster chain.

## exFAT (`unstable-exfat`)

- Extending a file onto a fragmented layout now writes the FAT chain links,
  so data past the first cluster survives read-back.
- `allocate_clusters`' fragmented fallback reserves from the allocation
  bitmap instead of scanning the FAT, so it no longer re-hands-out clusters
  the contiguous path already allocated; a full volume returns `NoFreeSpace`.
- `create_dir`, `delete`, and `truncate` flush the allocation bitmap.
- Directory entry sets are no longer placed across a cluster boundary, and
  scanning a directory of unknown size no longer walks past its allocation.
- Truncating a fragmented file frees the dropped tail in the bitmap, not
  only in the FAT.
- Overwriting a contiguous multi-cluster file in place reuses the file's own
  clusters instead of orphaning them (the #90 pattern for the exFAT path).
- `calculate_fat_and_heap` computes geometry in u64 and range-checks its u32
  outputs, returning `VolumeTooLarge` instead of truncating the sector count
  above ~2 TiB.

## API changes

- New `Error::StaleEntry` and `Error::WriterConflict`, both gated on the
  `write` feature. `Error` is not `#[non_exhaustive]`, so downstream
  exhaustive matches need a new arm.
- Calls that previously succeeded while corrupting an unrelated file now
  return `StaleEntry`; a second concurrent `FileWriter` now returns
  `WriterConflict`.

## Testing

- New `tests/regression_audit_fat.rs` (A1-A7, B1, B2) and
  `tests/regression_audit_exfat.rs` (X1-X3, X5, X6), plus a beyond-u32
  geometry unit test. The entry-set containment fix is covered by the
  existing exFAT round-trip tests.
- `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo clippy
  --workspace --all-targets`, the CI feature tiers, and `cargo test -p
  hadris-fat` (default and `unstable-exfat,cache,tool,dirty-file-panic`)
  all pass.
- Miri was not run locally (`cargo-miri` not installed here); CI's Miri jobs
  do not cover the new union field read in `revalidate_slot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
