### PR TITLE
add rust-analyzer component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.88.0"
-components = ["rustfmt", "clippy"]
+components = ["rust-analyzer", "rustfmt", "clippy"]


### PR DESCRIPTION
As per title, otherwise vs code whines with:

<img width="575" height="196" alt="image" src="https://github.com/user-attachments/assets/06aed7ca-8026-4f09-84ed-be9481141937" />

Not sure if its specific to my platform, its win11 25h2