### PR TITLE
fix(fat): pass hosted conformance suite

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -405,6 +405,16 @@ jobs:
           cargo test -p hadris-fat --features "unstable-exfat,write" --lib integration_exfat:: -- --nocapture
           cargo test -p hadris-fat --features "unstable-exfat,write" --lib exfat_roundtrip:: -- --nocapture
 
+  test-fat-conformance:
+    name: Test FAT conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - name: Run FAT conformance tests
+        run: "cargo test --manifest-path tests/Cargo.toml fat:: -- --nocapture"
+
   test-optical:
     name: Test optical interoperability
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Each published package owns its version and may be released independently.
 
 ### Fixed
 
+- **hadris-fat:** FAT name handling is now case-insensitive for long names,
+  rejects reserved characters, permits case-only renames, prevents moving a
+  directory into its own subtree, and generates valid aliases for leading-dot
+  names. Readers still accept existing nonconforming names and prefer an exact
+  long-name match when an old image contains entries that differ only by case.
+- **hadris-fat:** Failed writes caused by a full data region now release their
+  uncommitted clusters and persist a valid FAT32 FSInfo count and next-free
+  hint instead of leaving orphaned allocations or stale metadata.
 - **hadris-fat:** File and directory creation and rename now allocate distinct
   8.3 aliases when long filenames share the same generated short name. Such
   entries previously appeared through their long names but were rejected as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,7 @@ The oracles are the ground truth. Hadris is measured as one adapter among its
 peers, and a Hadris-to-Hadris round trip is never evidence on its own.
 
 ```bash
-# Hosted suite; run it locally. CI formats and lints the package and runs the
-# ISO slice, while the recorded hadris-fat findings keep three FAT tests red.
+# Hosted suite; run it locally. CI also runs the hosted FAT and ISO slices.
 cargo test --manifest-path tests/Cargo.toml
 
 # One format or topic

--- a/crates/block/hadris-fat/src/dir.rs
+++ b/crates/block/hadris-fat/src/dir.rs
@@ -149,31 +149,48 @@ impl<'a, DATA: Read + Seek> FatDir<'a, DATA> {
 
     /// Find an entry by name.
     ///
-    /// When the `lfn` feature is enabled, this performs a case-sensitive match
-    /// against long file names first, then falls back to case-insensitive short
-    /// name matching.
+    /// When the `lfn` feature is enabled, this prefers an exact long-name match,
+    /// then falls back to case-insensitive long and short name matching.
     ///
     /// Without the `lfn` feature, only case-insensitive short name matching is used.
     pub async fn find(&self, name: &str) -> Result<Option<FileEntry>> {
         let mut iter = self.entries();
+        #[cfg(feature = "lfn")]
+        let mut case_insensitive_match = None;
         loop {
             match iter.next_entry().await {
                 Some(result) => {
                     let DirectoryEntry::Entry(file_entry) = result?;
 
-                    // Check LFN match (case-sensitive)
                     #[cfg(feature = "lfn")]
-                    if let Some(lfn) = file_entry.long_name()
-                        && lfn.eq_str(name)
                     {
-                        return Ok(Some(file_entry));
+                        if file_entry
+                            .long_name()
+                            .is_some_and(|lfn| lfn.eq_str(name))
+                        {
+                            return Ok(Some(file_entry));
+                        }
+                        if case_insensitive_match.is_none()
+                            && (file_entry
+                                .long_name()
+                                .is_some_and(|lfn| lfn.eq_str_ignore_case(name))
+                                || file_entry.short_name().matches(name))
+                        {
+                            case_insensitive_match = Some(file_entry);
+                        }
                     }
-                    // Check short name match (case-insensitive, handles 8.3 padding)
+
+                    #[cfg(not(feature = "lfn"))]
                     if file_entry.short_name().matches(name) {
                         return Ok(Some(file_entry));
                     }
                 }
-                None => return Ok(None),
+                None => {
+                    #[cfg(feature = "lfn")]
+                    return Ok(case_insensitive_match);
+                    #[cfg(not(feature = "lfn"))]
+                    return Ok(None);
+                }
             }
         }
     }

--- a/crates/block/hadris-fat/src/file.rs
+++ b/crates/block/hadris-fat/src/file.rs
@@ -240,6 +240,11 @@ impl ShortFileName {
             Some(pos) if pos > 0 => (&name[..pos], &name[pos + 1..]),
             _ => (name, ""),
         };
+        let (base, ext) = if base.chars().all(|ch| ch == '.' || ch == ' ') && !ext.is_empty() {
+            (ext, "")
+        } else {
+            (base, ext)
+        };
 
         // Process base name: uppercase, strip invalid chars
         let mut base_chars = [b' '; 8];
@@ -486,6 +491,14 @@ impl LongFileName {
     /// Compare the filename to a `&str` without allocating.
     pub fn eq_str(&self, s: &str) -> bool {
         self.chars().eq(s.chars())
+    }
+
+    /// Compare the filename to a `&str` without allocating, using Unicode
+    /// uppercase mappings for the case-insensitive FAT name lookup.
+    pub(crate) fn eq_str_ignore_case(&self, s: &str) -> bool {
+        self.chars()
+            .flat_map(char::to_uppercase)
+            .eq(s.chars().flat_map(char::to_uppercase))
     }
 
     /// Encode `name` as UTF-16LE into the buffer. Returns `None` if the name
@@ -736,6 +749,22 @@ mod lfn_unicode_tests {
 
         assert!(lfn.eq_str("\u{1F600}"));
         assert!(!lfn.eq_str("X"));
+    }
+
+    #[test]
+    fn eq_str_ignore_case_uses_unicode_case_mapping() {
+        let mut lfn = LongFileName::new();
+        let name1 = [0xc3, 0x03, b'.', 0, b't', 0, b'x', 0, b't', 0];
+        lfn.prepend_lfn_entry(&name1, &[0xff; 12], &[0xff; 4]);
+        assert!(lfn.eq_str_ignore_case("Σ.TXT"));
+        assert!(!lfn.eq_str_ignore_case("Σ.BIN"));
+    }
+
+    #[cfg(feature = "write")]
+    #[test]
+    fn leading_dots_produce_a_nonempty_short_basename() {
+        let short = ShortFileName::from_long_name("..dots", 0).unwrap();
+        assert_eq!(short.raw_bytes(), *b"DOTS       ");
     }
 
     /// Regression test: an LFN entry with the last-entry flag set but a

--- a/crates/block/hadris-fat/src/write.rs
+++ b/crates/block/hadris-fat/src/write.rs
@@ -32,6 +32,12 @@ pub struct FileWriter<'a, DATA: Read + Write + Seek> {
     offset_in_cluster: usize,
     /// Total bytes written so far
     total_written: usize,
+    /// First cluster allocated by this writer beyond the entry's committed chain.
+    first_allocated_cluster: Option<Cluster<usize>>,
+    /// Committed chain tail that precedes `first_allocated_cluster`.
+    allocation_predecessor: Option<Cluster<usize>>,
+    allocation_start_offset: usize,
+    allocation_start_total_written: usize,
     /// Parent directory cluster (0 for fixed root directory)
     entry_parent: Cluster<usize>,
     /// Offset of the directory entry within the parent
@@ -115,6 +121,10 @@ impl<'a, DATA: Read + Write + Seek> FileWriter<'a, DATA> {
             current_cluster: first_cluster,
             offset_in_cluster: 0,
             total_written: 0,
+            first_allocated_cluster: None,
+            allocation_predecessor: None,
+            allocation_start_offset: 0,
+            allocation_start_total_written: 0,
             entry_parent: entry.parent_clus,
             entry_offset: entry.offset_within_cluster,
             entry_short_name: entry.short_name,
@@ -159,6 +169,10 @@ entry_created: entry.created,
                 current_cluster: first_cluster,
                 offset_in_cluster: 0,
                 total_written: 0,
+                first_allocated_cluster: None,
+                allocation_predecessor: None,
+                allocation_start_offset: 0,
+                allocation_start_total_written: 0,
                 entry_parent: entry.parent_clus,
                 entry_offset: entry.offset_within_cluster,
                 entry_short_name: entry.short_name,
@@ -205,6 +219,10 @@ entry_created: entry.created,
             current_cluster: Some(current),
             offset_in_cluster: offset_in_last,
             total_written: file_size,
+            first_allocated_cluster: None,
+            allocation_predecessor: None,
+            allocation_start_offset: 0,
+            allocation_start_total_written: 0,
             entry_parent: entry.parent_clus,
             entry_offset: entry.offset_within_cluster,
             entry_short_name: entry.short_name,
@@ -246,7 +264,13 @@ entry_created: entry.created,
                         // acquires both cache+data locks internally in
                         // canonical order.
                         let hint = self.current_cluster.map(|c| c.0 as u32 + 1).unwrap_or(2);
-                        let new_cluster = self.fs.allocate_cluster_routed(hint).await?;
+                        let new_cluster = match self.fs.allocate_cluster_routed(hint).await {
+                            Ok(cluster) => cluster,
+                            Err(error) => {
+                                self.rollback_allocated_clusters().await?;
+                                return Err(error);
+                            }
+                        };
 
                         // Update FSInfo tracking (FAT32 only)
                         self.fs.decrement_free_count();
@@ -254,7 +278,28 @@ entry_created: entry.created,
 
                         // Link previous cluster to the new one (also routed).
                         if let Some(prev) = self.current_cluster {
-                            self.fs.write_clus_routed(prev.0, new_cluster).await?;
+                            if let Err(error) =
+                                self.fs.write_clus_routed(prev.0, new_cluster).await
+                            {
+                                self.fs.write_clus_routed(prev.0, u32::MAX).await?;
+                                let freed = self.fs.free_chain_routed(new_cluster).await?;
+                                self.fs.increment_free_count(freed);
+                                self.fs.update_next_free_hint(new_cluster - 1);
+                                if self.first_allocated_cluster.is_some() {
+                                    self.rollback_allocated_clusters().await?;
+                                } else {
+                                    self.fs.write_fsinfo().await?;
+                                }
+                                return Err(error);
+                            }
+                        }
+
+                        if self.first_allocated_cluster.is_none() {
+                            self.first_allocated_cluster =
+                                Some(Cluster(new_cluster as usize));
+                            self.allocation_predecessor = self.current_cluster;
+                            self.allocation_start_offset = self.offset_in_cluster;
+                            self.allocation_start_total_written = self.total_written;
                         }
 
                         new_cluster
@@ -289,6 +334,26 @@ entry_created: entry.created,
         }
 
         Ok(written)
+    }
+
+    async fn rollback_allocated_clusters(&mut self) -> Result<()> {
+        let Some(first) = self.first_allocated_cluster.take() else {
+            return Ok(());
+        };
+        let predecessor = self.allocation_predecessor.take();
+        if let Some(previous) = predecessor {
+            self.fs.write_clus_routed(previous.0, u32::MAX).await?;
+        } else {
+            self.first_cluster = None;
+        }
+        let freed = self.fs.free_chain_routed(first.0 as u32).await?;
+        self.fs.increment_free_count(freed);
+        self.fs.update_next_free_hint(first.0 as u32 - 1);
+        self.fs.write_fsinfo().await?;
+        self.current_cluster = predecessor;
+        self.offset_in_cluster = self.allocation_start_offset;
+        self.total_written = self.allocation_start_total_written;
+        Ok(())
     }
 
     /// Get the total number of bytes written.
@@ -706,6 +771,21 @@ fn short_name_case_bits(name: &str) -> Option<u8> {
     Some(bits)
 }
 
+#[cfg(feature = "write")]
+fn validate_file_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.encode_utf16().count() > crate::file::LFN_MAX_UTF16_UNITS
+        || name.chars().any(|ch| {
+            ch <= '\u{1f}' || matches!(ch, '"' | '*' | '/' | ':' | '<' | '>' | '?' | '\\' | '|')
+        })
+    {
+        return Err(Error::InvalidFilename);
+    }
+    Ok(())
+}
+
 /// Maximum number of LFN entries we'll walk backward when cleaning up
 /// orphaned long-name slots on delete/rename. The FAT spec caps at 20
 /// entries per name; bounding the scan defends against corrupt directory
@@ -876,6 +956,7 @@ impl<DATA: Read + Seek> FatVolume<DATA> {
         &self,
         parent: &FatDir<'_, DATA>,
         name: &str,
+        exclude: Option<&FileEntry>,
     ) -> Result<(ShortFileName, bool)> {
         for suffix in 0..=u8::MAX {
             let candidate =
@@ -885,6 +966,12 @@ impl<DATA: Read + Seek> FatVolume<DATA> {
             let mut entries = parent.entries();
             while let Some(entry) = entries.next_entry().await {
                 let DirectoryEntry::Entry(entry) = entry?;
+                if exclude.is_some_and(|excluded| {
+                    entry.parent_clus == excluded.parent_clus
+                        && entry.offset_within_cluster == excluded.offset_within_cluster
+                }) {
+                    continue;
+                }
                 if entry.short_name().raw_bytes() == candidate.raw_bytes() {
                     collision = true;
                     break;
@@ -1374,13 +1461,14 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         // clusters: if the directory was deleted and its cluster reused, new
         // entries would land in an unrelated file's data.
         self.revalidate_parent_dir(parent).await?;
+        validate_file_name(name)?;
 
         // Check if entry already exists
         if parent.find(name).await?.is_some() {
             return Err(Error::AlreadyExists);
         }
 
-        let (short_name, collided) = self.unique_short_name(parent, name).await?;
+        let (short_name, collided) = self.unique_short_name(parent, name, None).await?;
         #[cfg(not(feature = "lfn"))]
         let _ = collided;
 
@@ -1485,13 +1573,14 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         // Reject a stale parent handle before scanning or writing into its
         // clusters (see create_file).
         self.revalidate_parent_dir(parent).await?;
+        validate_file_name(name)?;
 
         // Check if entry already exists
         if parent.find(name).await?.is_some() {
             return Err(Error::AlreadyExists);
         }
 
-        let (short_name, collided) = self.unique_short_name(parent, name).await?;
+        let (short_name, collided) = self.unique_short_name(parent, name, None).await?;
         #[cfg(not(feature = "lfn"))]
         let _ = collided;
 
@@ -1711,6 +1800,56 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         Ok(())
     }
 
+    async fn directory_is_within(
+        &self,
+        mut directory: Cluster<usize>,
+        ancestor: Cluster<usize>,
+    ) -> Result<bool> {
+        let mut steps = 0u32;
+        while directory.0 >= 2 {
+            if directory == ancestor {
+                return Ok(true);
+            }
+            if self.is_fat32_root_cluster(directory.0 as u32) {
+                break;
+            }
+            steps = steps.saturating_add(1);
+            if steps > self.fat.max_cluster() {
+                return Err(Error::ClusterLoop {
+                    cluster: directory.0 as u32,
+                });
+            }
+
+            let parent = {
+                let mut data = self.data.lock();
+                let position = directory.to_bytes(self.info.data_start, self.info.cluster_size)
+                    + core::mem::size_of::<RawDirectoryEntry>();
+                data.seek(SeekFrom::Start(position as u64)).await?;
+                let raw = data.read_struct::<RawDirectoryEntry>().await?;
+                let entry = unsafe { &raw.file };
+                if entry.name != *b"..         "
+                    || entry.attributes & DirEntryAttrFlags::DIRECTORY.bits() == 0
+                {
+                    return Err(Error::CorruptFilesystem {
+                        context: "directory parent entry",
+                    });
+                }
+                match &self.fat {
+                    Fat::Fat12(_) | Fat::Fat16(_) => entry.first_cluster_low.get() as usize,
+                    Fat::Fat32(_) => {
+                        ((entry.first_cluster_high.get() as usize) << 16)
+                            | entry.first_cluster_low.get() as usize
+                    }
+                }
+            };
+            if parent == 0 {
+                break;
+            }
+            directory = Cluster(parent);
+        }
+        Ok(false)
+    }
+
     /// Rename or move a file or directory.
     ///
     /// Creates a new directory entry with `new_name` in `dest_dir`, copying
@@ -1730,13 +1869,26 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         // slot: otherwise a reused handle would clone another file's chain
         // under `new_name`, or resurrect a deleted entry.
         self.revalidate_entry(entry).await?;
+        self.revalidate_parent_dir(dest_dir).await?;
+        validate_file_name(new_name)?;
+
+        if entry.is_directory()
+            && self
+                .directory_is_within(dest_dir.cluster, entry.cluster())
+                .await?
+        {
+            return Err(Error::InvalidPath);
+        }
 
         // Check if destination already has this name
-        if dest_dir.find(new_name).await?.is_some() {
+        if let Some(existing) = dest_dir.find(new_name).await?
+            && (existing.parent_clus != entry.parent_clus
+                || existing.offset_within_cluster != entry.offset_within_cluster)
+        {
             return Err(Error::AlreadyExists);
         }
 
-        let (short_name, collided) = self.unique_short_name(dest_dir, new_name).await?;
+        let (short_name, collided) = self.unique_short_name(dest_dir, new_name, Some(entry)).await?;
         #[cfg(not(feature = "lfn"))]
         let _ = collided;
 
@@ -2136,8 +2288,12 @@ impl<DATA: Read + Write + Seek> FatVolume<DATA> {
         use super::fs::FatFsExt;
 
         if let FatFsExt::Fat32(ext) = &self.ext {
-            // Set hint to the cluster after the one just allocated
-            ext.next_free.set(Cluster(cluster.saturating_add(1)));
+            let next = if cluster >= self.fat.max_cluster() {
+                2
+            } else {
+                cluster.saturating_add(1).max(2)
+            };
+            ext.next_free.set(Cluster(next));
         }
     }
 

--- a/crates/block/hadris-fat/tests/regression_audit_fat.rs
+++ b/crates/block/hadris-fat/tests/regression_audit_fat.rs
@@ -92,6 +92,9 @@ mod fat32_image {
     pub const fn fat_start_bytes() -> usize {
         RESERVED_SECTORS as usize * SECTOR_SIZE
     }
+    pub const fn data_start_bytes() -> usize {
+        (RESERVED_SECTORS as usize + FAT_COUNT as usize * SECTORS_PER_FAT as usize) * SECTOR_SIZE
+    }
 
     /// Count non-free FAT32 entries (index >= 2) in the primary FAT.
     /// A "free" entry is 0x0000000 (after masking off the top 4 bits).
@@ -745,6 +748,153 @@ fn b3_finish_reports_io_error_instead_of_dirty_panic() {
     match result {
         Err(Error::Io(_)) => {}
         other => panic!("finish() must report the I/O error, got {other:?}"),
+    }
+}
+
+#[test]
+fn b4_failed_cluster_link_releases_the_unlinked_allocation() {
+    let fs = FatVolume::open(fail_link::device(fat32_image::create_fat32_image())).expect("open");
+    let root = fs.root_dir();
+    let entry = fs.create_file(&root, "LINKFAIL.BIN").expect("create");
+    let free_before = fs.free_cluster_count().expect("fat32 free count");
+
+    let mut writer = fs.write_file(&entry).expect("writer");
+    fail_link::arm();
+    let result = writer.write(&vec![0x5a; fat32_image::cluster_size() * 2]);
+
+    match result {
+        Err(Error::Io(_)) => {}
+        other => panic!("second cluster link must report the I/O error, got {other:?}"),
+    }
+
+    writer.finish().expect("finish rolled-back file");
+    assert_eq!(
+        fs.free_cluster_count(),
+        Some(free_before),
+        "failed link leaked an unlinked cluster"
+    );
+}
+
+#[test]
+fn legacy_case_colliding_long_names_prefer_exact_match() {
+    let fs = FatVolume::open(fat32_image::create_fat32_image()).expect("open");
+    let root = fs.root_dir();
+    fs.create_file(&root, "Legacy-One.txt").expect("first");
+    fs.create_file(&root, "Legacy-Two.txt").expect("second");
+
+    let first = root
+        .find("Legacy-One.txt")
+        .expect("find first")
+        .expect("first exists");
+    let second = root
+        .find("Legacy-Two.txt")
+        .expect("find second")
+        .expect("second exists");
+    let first_short = first.short_name().raw_bytes();
+    let second_short = second.short_name().raw_bytes();
+    let second_lfn_offset = fat32_image::data_start_bytes() + second.offset_within_cluster - 64;
+
+    let mut image = fs.into_inner().into_inner();
+    legacy_lfn::replace_two_entry_name(
+        &mut image[second_lfn_offset..second_lfn_offset + 64],
+        "LEGACY-ONE.TXT",
+    );
+
+    let fs = FatVolume::open(std::io::Cursor::new(image)).expect("reopen");
+    let root = fs.root_dir();
+    assert_eq!(
+        root.find("Legacy-One.txt")
+            .expect("find mixed case")
+            .expect("mixed case exists")
+            .short_name()
+            .raw_bytes(),
+        first_short
+    );
+    assert_eq!(
+        root.find("LEGACY-ONE.TXT")
+            .expect("find uppercase")
+            .expect("uppercase exists")
+            .short_name()
+            .raw_bytes(),
+        second_short
+    );
+}
+
+mod legacy_lfn {
+    const UNITS_PER_ENTRY: usize = 13;
+    const NAME_OFFSETS: [usize; UNITS_PER_ENTRY] = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
+
+    pub fn replace_two_entry_name(entries: &mut [u8], name: &str) {
+        let mut units = [0xffff; UNITS_PER_ENTRY * 2];
+        let mut len = 0;
+        for unit in name.encode_utf16() {
+            units[len] = unit;
+            len += 1;
+        }
+        units[len] = 0;
+        write_entry(&mut entries[..32], &units[UNITS_PER_ENTRY..]);
+        write_entry(&mut entries[32..], &units[..UNITS_PER_ENTRY]);
+    }
+
+    fn write_entry(entry: &mut [u8], units: &[u16]) {
+        for (offset, unit) in NAME_OFFSETS.iter().zip(units) {
+            entry[*offset..*offset + 2].copy_from_slice(&unit.to_le_bytes());
+        }
+    }
+}
+
+mod fail_link {
+    use std::cell::Cell;
+    use std::io::{Cursor, Read, Result, Seek, SeekFrom, Write};
+
+    const FIRST_FILE_CLUSTER: u64 = 3;
+    const SECOND_FILE_CLUSTER: u32 = 4;
+
+    thread_local! {
+        static ARMED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    pub fn arm() {
+        ARMED.with(|armed| armed.set(true));
+    }
+
+    pub struct FailSecondClusterLink(Cursor<Vec<u8>>);
+
+    pub fn device(inner: Cursor<Vec<u8>>) -> FailSecondClusterLink {
+        FailSecondClusterLink(inner)
+    }
+
+    impl Write for FailSecondClusterLink {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            let value = buf
+                .get(..4)
+                .and_then(|bytes| bytes.try_into().ok())
+                .map(u32::from_le_bytes);
+            let link_offset = super::fat32_image::fat_start_bytes() as u64 + FIRST_FILE_CLUSTER * 4;
+            if self.0.position() == link_offset
+                && value == Some(SECOND_FILE_CLUSTER)
+                && ARMED.with(|armed| armed.replace(false))
+            {
+                return Err(std::io::Error::other("injected cluster-link failure"));
+            }
+            self.0.write(buf)
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            self.0.flush()
+        }
+    }
+
+    impl Read for FailSecondClusterLink {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            self.0.read(buf)
+        }
+    }
+
+    impl Seek for FailSecondClusterLink {
+        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+            self.0.seek(pos)
+        }
     }
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,9 +84,9 @@ Reports are written to `tests/target/reports/<format>/`.
   (or `harness::require_or_skip`) so they skip locally and fail when
   `HADRIS_REQUIRE_EXTERNAL_TOOLS=1` is set.
 
-CI does not run the suite at the moment: three hosted FAT tests fail on
-recorded `hadris-fat` defects (see the compliance profile). CI still formats
-and lints the package.
+CI runs the hosted FAT and ISO slices, and also formats and lints the package.
+Manual peer reports and privileged native-mount checks remain ignored.
+
 - When a test is cited as compliance evidence, reference it as
   `<format>::<topic>::<name>` in `@hadris-tests` annotations and
   `docs/spec-coverage.md`, and by file path in `spec/requirements/*.json`.

--- a/tests/src/fat/limits.rs
+++ b/tests/src/fat/limits.rs
@@ -138,7 +138,7 @@ pub fn exercise_data_region(
     oracle: &mut Oracle<'_>,
 ) -> Result<(), String> {
     let geometry = checks.geometry;
-    let clusters_per_chunk = (geometry.cluster_count as usize / 48).max(65);
+    let clusters_per_chunk = (geometry.cluster_count as usize / 512).max(65);
     let chunk = clusters_per_chunk * geometry.cluster_size + 1;
     let mut expected = FsState::empty();
     step(


### PR DESCRIPTION
## Summary

- make long filename lookup case-insensitive
- reject invalid FAT names and generate valid aliases for leading-dot names
- allow case-only renames and reject moves into a directory's own subtree
- roll back uncommitted cluster allocations after exhaustion or link failure without adding per-cluster state
- keep FAT32 FSInfo free-count and next-free metadata consistent
- run the hosted FAT conformance slice in CI

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --workspace`
- `RUSTFLAGS="-D warnings" cargo check -p hadris-fat --no-default-features --features "alloc,sync,async,read,write,lfn,unstable-exfat"`
- `cargo test -p hadris-fat --all-features`
- `cargo test --manifest-path tests/Cargo.toml fat:: -- --nocapture`
- `cargo clippy --manifest-path tests/Cargo.toml --all-targets -- -D warnings`
- `cargo +nightly miri test -p hadris-fat --lib file::lfn_unicode_tests`
