### PR TITLE
test(iso): add multi-extent conformance coverage

### DIFF
--- a/spec/requirements/hadris-iso.json
+++ b/spec/requirements/hadris-iso.json
@@ -60,8 +60,12 @@
       "direction": "read",
       "status": "partial",
       "symbols": [{"path": "crates/optical/hadris-iso/src/read/directory.rs", "name": "IsoDir::read_entries"}],
-      "tests": [{"path": "crates/optical/hadris-iso/tests/no_alloc_reader.rs", "name": "navigation_and_streaming_allocate_nothing", "kind": "integration"}],
-      "gap": "Positive chaining and key identity fields are checked, but every attribute mandated by clause 9.2 is not yet compared."
+      "tests": [
+        {"path": "crates/optical/hadris-iso/tests/no_alloc_reader.rs", "name": "navigation_and_streaming_allocate_nothing", "kind": "integration"},
+        {"path": "tests/suite/iso/multi_extent.rs", "name": "three_section_file_matches_oracle_and_hadris_reader", "kind": "integration"},
+        {"path": "tests/suite/iso/multi_extent.rs", "name": "oracle_rejects_invalid_multi_extent_chains", "kind": "integration"}
+      ],
+      "gap": "The allocating reader rejects protection-bit changes between sections even though clause 9.2 does not require that bit to match."
     },
     {
       "id": "ECMA-119-1987:6.7.1.1#primary-required",

--- a/tests/src/iso/spec.rs
+++ b/tests/src/iso/spec.rs
@@ -13,6 +13,8 @@ use super::model::IsoState;
 use crate::harness::join_path;
 use crate::harness::tree::EntryData;
 
+const CONSISTENT_FILE_FLAGS: u8 = 0x6f;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PathRecord {
     name: Vec<u8>,
@@ -232,13 +234,17 @@ fn read_directory(
         ));
     }
 
-    for child in ordinary {
-        if child.flags & 0x84 != 0 {
-            return Err(format!("entry in {path} is associated or multi-extent"));
+    let mut children = ordinary.into_iter();
+    while let Some(child) = children.next() {
+        if child.flags & 0x04 != 0 {
+            return Err(format!("entry in {path} is associated"));
         }
         let name = decode_primary_identifier(&child.identifier, child.flags & 0x02 != 0)?;
         let child_path = join_path(path, &name);
         if child.flags & 0x02 != 0 {
+            if child.flags & 0x80 != 0 {
+                return Err(format!("directory {child_path} is multi-extent"));
+            }
             if child.data_len == 0 {
                 return Err(format!("directory {child_path} has zero length"));
             }
@@ -267,18 +273,42 @@ fn read_directory(
                 entries,
             )?;
         } else {
-            let data_lba = child.extent + u32::from(child.extended_attr_blocks);
-            let contents = if child.data_len == 0 {
-                Vec::new()
-            } else {
-                image_slice(
-                    image,
-                    data_lba as usize * SECTOR_SIZE,
-                    child.data_len as usize,
-                    volume_len,
-                )?
-                .to_vec()
-            };
+            let identifier = child.identifier.clone();
+            let stable_flags = child.flags & CONSISTENT_FILE_FLAGS;
+            let mut sections = vec![child];
+            while sections
+                .last()
+                .is_some_and(|section| section.flags & 0x80 != 0)
+            {
+                let continuation = children
+                    .next()
+                    .ok_or_else(|| format!("truncated multi-extent file {child_path}"))?;
+                if continuation.identifier != identifier
+                    || continuation.flags & CONSISTENT_FILE_FLAGS != stable_flags
+                {
+                    return Err(format!(
+                        "invalid multi-extent continuation for {child_path}"
+                    ));
+                }
+                sections.push(continuation);
+            }
+            let total_len = sections.iter().try_fold(0usize, |total, section| {
+                total
+                    .checked_add(section.data_len as usize)
+                    .ok_or_else(|| format!("file length overflows usize for {child_path}"))
+            })?;
+            let mut contents = Vec::with_capacity(total_len);
+            for section in sections {
+                let data_lba = section.extent + u32::from(section.extended_attr_blocks);
+                if section.data_len != 0 {
+                    contents.extend_from_slice(image_slice(
+                        image,
+                        data_lba as usize * SECTOR_SIZE,
+                        section.data_len as usize,
+                        volume_len,
+                    )?);
+                }
+            }
             if entries
                 .insert(child_path.clone(), EntryData::File(contents))
                 .is_some()

--- a/tests/suite/iso/mod.rs
+++ b/tests/suite/iso/mod.rs
@@ -1,6 +1,7 @@
 mod boot;
 mod directory;
 mod hybrid;
+mod multi_extent;
 mod native;
 mod peers;
 mod rock_ridge;

--- a/tests/suite/iso/multi_extent.rs
+++ b/tests/suite/iso/multi_extent.rs
@@ -1,0 +1,125 @@
+//! Multi-extent file conformance and reader coverage.
+
+use std::collections::BTreeMap;
+
+use hadris_tests::harness::tree::EntryData;
+use hadris_tests::iso::model::IsoState;
+use hadris_tests::iso::{SECTOR_SIZE, VOLUME_ID, hadris, spec};
+
+const FILE_SIZE: usize = 4 * SECTOR_SIZE;
+const MULTI_EXTENT: u8 = 0x80;
+
+struct Fixture {
+    bytes: Vec<u8>,
+    expected: IsoState,
+    records: [usize; 3],
+}
+
+fn write_both_u32(bytes: &mut [u8], offset: usize, value: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    bytes[offset + 4..offset + 8].copy_from_slice(&value.to_be_bytes());
+}
+
+fn fixture() -> Fixture {
+    let contents = (0..FILE_SIZE).map(|index| (index % 251) as u8).collect();
+    let expected = IsoState {
+        volume_id: VOLUME_ID.to_string(),
+        entries: BTreeMap::from([("/LARGE.BIN".to_string(), EntryData::File(contents))]),
+    };
+    let mut bytes = hadris::write(&expected).unwrap();
+    let root_record = 16 * SECTOR_SIZE + 156;
+    let root_extent =
+        u32::from_le_bytes(bytes[root_record + 2..root_record + 6].try_into().unwrap()) as usize;
+    let mut file_record = root_extent * SECTOR_SIZE;
+    file_record += bytes[file_record] as usize;
+    file_record += bytes[file_record] as usize;
+    let record_len = bytes[file_record] as usize;
+    let first_extent =
+        u32::from_le_bytes(bytes[file_record + 2..file_record + 6].try_into().unwrap());
+    let template = bytes[file_record..file_record + record_len].to_vec();
+    let records = [
+        file_record,
+        file_record + record_len,
+        file_record + record_len * 2,
+    ];
+    let sections = [
+        (first_extent, SECTOR_SIZE as u32, true),
+        (first_extent + 1, (2 * SECTOR_SIZE) as u32, true),
+        (first_extent + 3, SECTOR_SIZE as u32, false),
+    ];
+    for (record, (extent, length, has_more)) in records.iter().zip(sections) {
+        bytes[*record..*record + record_len].copy_from_slice(&template);
+        write_both_u32(&mut bytes, *record + 2, extent);
+        write_both_u32(&mut bytes, *record + 10, length);
+        if has_more {
+            bytes[*record + 25] |= MULTI_EXTENT;
+        } else {
+            bytes[*record + 25] &= !MULTI_EXTENT;
+        }
+    }
+    Fixture {
+        bytes,
+        expected,
+        records,
+    }
+}
+
+#[test]
+fn three_section_file_matches_oracle_and_hadris_reader() {
+    let fixture = fixture();
+    hadris::verify_image(
+        "three-section multi-extent fixture",
+        fixture.bytes,
+        &fixture.expected,
+    )
+    .unwrap();
+}
+
+#[test]
+fn unaligned_non_final_section_matches_oracle_and_hadris_reader() {
+    let mut fixture = fixture();
+    write_both_u32(
+        &mut fixture.bytes,
+        fixture.records[0] + 10,
+        (SECTOR_SIZE - 1) as u32,
+    );
+    let EntryData::File(contents) = fixture.expected.entries.get_mut("/LARGE.BIN").unwrap() else {
+        unreachable!();
+    };
+    contents.remove(SECTOR_SIZE - 1);
+    hadris::verify_image(
+        "unaligned non-final multi-extent section",
+        fixture.bytes,
+        &fixture.expected,
+    )
+    .unwrap();
+}
+
+#[test]
+fn oracle_accepts_per_section_protection_flag() {
+    let mut fixture = fixture();
+    fixture.bytes[fixture.records[1] + 25] |= 0x10;
+    assert_eq!(spec::snapshot(&fixture.bytes).unwrap(), fixture.expected);
+}
+
+#[test]
+fn oracle_rejects_invalid_multi_extent_chains() {
+    type Corrupt = fn(&mut Fixture);
+
+    let cases: [(&str, Corrupt); 2] = [
+        ("truncated chain", |fixture| {
+            fixture.bytes[fixture.records[2]] = 0;
+        }),
+        ("changed identifier", |fixture| {
+            fixture.bytes[fixture.records[1] + 33] = b'X';
+        }),
+    ];
+    for (name, corrupt) in cases {
+        let mut fixture = fixture();
+        corrupt(&mut fixture);
+        assert!(
+            spec::snapshot(&fixture.bytes).is_err(),
+            "oracle accepted {name}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- teach the ECMA-119 oracle to assemble adjacent multi-extent file records
- compare the continuation fields required by clause 9.2 while allowing per-section protection flags
- add three-section and unaligned-section fixtures checked by the oracle and Hadris reader
- cover truncated chains and mismatched continuation identifiers
- record the new evidence and the remaining reader limitation in the ISO compliance catalog

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --workspace`
- `cargo test --manifest-path tests/Cargo.toml iso:: -- --nocapture`
- `cargo clippy --manifest-path tests/Cargo.toml --all-targets -- -D warnings`
- `python3 scripts/check-spec-annotations.py`
- `python3 scripts/check-compliance-catalog.py`
