### PR TITLE
chore: prepare v2.3.0 release

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# shellcheck shell=bash
+
+use flake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: Version without the v prefix
         required: true
-        default: 2.2.0
+        default: 2.3.0
         type: string
       mode:
         description: Validate packages or publish the release
@@ -48,7 +48,7 @@ jobs:
             exit 1
           fi
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Version must be a stable semantic version such as 2.2.0" >&2
+            echo "Version must be a stable semantic version such as 2.3.0" >&2
             exit 1
           fi
           if [[ $(grep -Fc "## [$VERSION] - " CHANGELOG.md) -ne 1 ]]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -406,13 +406,19 @@ jobs:
           cargo test -p hadris-fat --features "unstable-exfat,write" --lib exfat_roundtrip:: -- --nocapture
 
   test-fat-conformance:
-    name: Test FAT conformance
+    name: Test FAT conformance and interoperability
     runs-on: ubuntu-latest
+    env:
+      HADRIS_REQUIRE_EXTERNAL_TOOLS: "1"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - name: Run FAT conformance tests
+      - name: Install FAT image tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dosfstools mtools
+      - name: Run FAT conformance and interoperability tests
         run: "cargo test --manifest-path tests/Cargo.toml fat:: -- --nocapture"
 
   test-optical:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -418,6 +418,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y dosfstools mtools
+      - name: Run test harness unit tests
+        run: "cargo test --manifest-path tests/Cargo.toml --lib"
       - name: Run FAT conformance and interoperability tests
         run: "cargo test --manifest-path tests/Cargo.toml fat:: -- --nocapture"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,28 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
-## [2.3.0] - 2026-09-01
+## [2.3.0] - 2026-09-02
 
 ### Added
 
-- **hadris-iso:** The refactored ISO writer now emits multi-extent files larger
-  than 4 GiB, and the allocating reader can consume them incrementally through
-  `read_file_chunked`. Józef Podlecki contributed the original implementation
-  in [#96](https://github.com/hxyulin/hadris/pull/96).
+- **hadris-iso:** The ISO writer now emits multi-extent files larger than 4 GiB.
+  The allocating reader can consume them incrementally with
+  `read_file_chunked`.
+  ([@Jozefpodlecki](https://github.com/Jozefpodlecki),
+  [#96](https://github.com/hxyulin/hadris/pull/96))
+- **hadris-part:** Added `MbrPartition::new_iso_partition` for whole-image
+  ISO 9660 partitions in isohybrid-style MBRs.
+  ([@Jozefpodlecki](https://github.com/Jozefpodlecki),
+  [#96](https://github.com/hxyulin/hadris/pull/96))
 
 ### Changed
 
 - **Tests:** FAT and ISO now use the same hosted, external-tool, and manual
   test tiers. CI requires mtools and dosfstools for FAT interoperability and
   xorriso for ISO interoperability, while local runs skip unavailable tools.
+- **Development:** The pinned Rust toolchain now installs `rust-analyzer` for
+  editor support. ([@Jozefpodlecki](https://github.com/Jozefpodlecki),
+  [#100](https://github.com/hxyulin/hadris/pull/100))
 
 ### Fixed
 
@@ -37,66 +45,6 @@ Each published package owns its version and may be released independently.
   8.3 aliases when long filenames share the same generated short name. Such
   entries previously appeared through their long names but were rejected as
   duplicate directory entries by `fsck.fat`.
-- **hadris-udf:** dstring decoding no longer includes one trailing garbage byte
-  (usually a NUL). The dstring length byte counts the compression-ID byte, so
-  `PrimaryVolumeDescriptor::volume_id()`, `LogicalVolumeDescriptor::volume_id()`,
-  and `FileSetDescriptor::file_set_id()` previously returned values like
-  `"LABEL\0"` and equality comparisons against the written label failed. The
-  decoder also guards hostile length bytes without panicking.
-- **hadris-udf:** 16-bit (UTF-16) dstrings and filenames are now decoded with
-  proper surrogate-pair handling. Characters outside the Basic Multilingual
-  Plane (such as emoji) were previously dropped from names, so files written
-  with such names could not be listed or found by name; unpaired surrogates
-  decode to U+FFFD.
-- **hadris-cd:** Creating an image without a name-preserving namespace (Joliet
-  disabled and Rock Ridge off) no longer fails with `ISO writer did not produce
-  the planned file` for names the ISO 9660 charset sanitizes (such as
-  hyphenated filenames), and no longer produces images whose ISO and UDF
-  namespaces diverge for sanitized directory names. The writer now applies the
-  ISO name mapping to the shared tree up front, with per-directory
-  deduplication, so both namespaces present the same sanitized logical tree.
-- **hadris-cd:** Rock Ridge metadata requested via `rock_ridge` creation
-  options (or the CLI's `-R`) is now actually written. The base ISO namespace
-  did not advertise RRIP support, so hadris-iso silently skipped emitting the
-  system-use fields.
-- **hadris-cd:** The CLI's `verify` command now compares Rock Ridge alternate
-  names when present, so `-R` images verify cleanly.
-- **hadris-iso:** `PrimaryVolumeDescriptor::new` and
-  `SupplementaryVolumeDescriptor::new_evd` no longer panic on volume names
-  longer than 32 characters; the constructors are truly lossy (truncate and
-  substitute), and the writer's validation still rejects over-long
-  `volume_name` values with a clean `InvalidInput` error, so
-  `hadris-iso create -V <long name>` exits with an error instead of a panic.
-- **hadris-io:** Converting `ErrorKind::UnexpectedEof` and
-  `ErrorKind::WouldBlock` to `std::io::ErrorKind` now preserves the kind
-  instead of collapsing both to `Other` via the embedded-io mapping, so
-  EOF detection through the std interop works.
-- **hadris-io:** `Cursor::seek` uses checked position arithmetic: seeks that
-  overflow return `InvalidInput` instead of panicking in debug builds or
-  wrapping in release builds, and `SeekFrom::Start` offsets above `i64::MAX`
-  are accepted as in `std::io::Cursor`.
-- **hadris-storage:** Building with neither the `sync` nor `async` feature no
-  longer emits dead-code warnings.
-- **tools:** All five CLI tools reset `SIGPIPE` to the default disposition on
-  Unix, so piping output into commands like `head` terminates quietly instead
-  of panicking with a broken-pipe message.
-- **hadris-udf-cli:** `create --revision` now validates against the supported
-  UDF revisions (1.02, 1.50, 2.00, 2.01, 2.50, 2.60) instead of accepting any
-  numeric value.
-
-### Documentation
-
-- **hadris-io:** Corrected the claim that the I/O traits re-export from
-  `std::io` under the `std` feature (they are always hadris's own traits with
-  blanket impls for std types), documented the `alloc` feature as currently a
-  no-op, and removed a dead, never-compiled `traits.rs` from the package.
-- **hadris-cd:** The README quick start now opens the output file readable as
-  well as writable, which `OpticalImageWriter::finish` requires; the runtime
-  error for a write-only target now says so explicitly.
-- **hadris-fixed:** Documented that `From<&[u8]>` for `FixedBytes` panics on
-  over-long slices and that `try_from_slice` is the fallible alternative.
-- **hadris-common:** Corrected the `sync` feature's default in the crate-level
-  feature table.
 
 ## [2.2.0] - 2026-08-24
 
@@ -105,6 +53,8 @@ Each published package owns its version and may be released independently.
 - **hadris-fat:** `FileReader` now supports start-, current-, and end-relative
   seeking in both the synchronous and asynchronous APIs, including buffered
   and cached-chain readers.
+  ([@stlankes](https://github.com/stlankes),
+  [#89](https://github.com/hxyulin/hadris/pull/89))
 - **hadris-fat:** New `Error::StaleEntry` (with the `write` feature) reported by
   the mutating APIs and `FileReader` when a `FileEntry` handle no longer refers
   to the same on-disk directory entry (see below).
@@ -233,6 +183,59 @@ Each published package owns its version and may be released independently.
   than ~2 TiB previously truncated the sector count to `u32`, silently sizing
   the filesystem to a fraction of the device; oversized geometry now returns
   `VolumeTooLarge` instead of corrupting the layout.
+- **hadris-udf:** dstring decoding no longer includes one trailing garbage byte
+  (usually a NUL). The dstring length byte counts the compression-ID byte, so
+  `PrimaryVolumeDescriptor::volume_id()`, `LogicalVolumeDescriptor::volume_id()`,
+  and `FileSetDescriptor::file_set_id()` previously returned values like
+  `"LABEL\0"` and equality comparisons against the written label failed. The
+  decoder also guards hostile length bytes without panicking.
+- **hadris-udf:** 16-bit (UTF-16) dstrings and filenames are now decoded with
+  proper surrogate-pair handling. Characters outside the Basic Multilingual
+  Plane were previously dropped from names, so files written with such names
+  could not be listed or found by name. Unpaired surrogates decode to U+FFFD.
+- **hadris-cd:** Creating an image without a name-preserving namespace (Joliet
+  disabled and Rock Ridge off) no longer fails with `ISO writer did not produce
+  the planned file` for names the ISO 9660 charset sanitizes, and no longer
+  produces images whose ISO and UDF namespaces diverge for sanitized directory
+  names. The writer now maps ISO names onto the shared tree before writing and
+  deduplicates them within each directory.
+- **hadris-cd:** Rock Ridge metadata requested with `rock_ridge` creation
+  options or the CLI's `-R` flag is now written. The base ISO namespace did not
+  advertise RRIP support, so hadris-iso silently skipped the system-use fields.
+- **hadris-cd:** The CLI's `verify` command now compares Rock Ridge alternate
+  names when present, so `-R` images verify cleanly.
+- **hadris-iso:** `PrimaryVolumeDescriptor::new` and
+  `SupplementaryVolumeDescriptor::new_evd` no longer panic on volume names
+  longer than 32 characters. The constructors truncate or substitute invalid
+  input, while the writer rejects an over-long `volume_name` with
+  `InvalidInput`.
+- **hadris-io:** Converting `ErrorKind::UnexpectedEof` and
+  `ErrorKind::WouldBlock` to `std::io::ErrorKind` now preserves the kind instead
+  of mapping both to `Other` through the embedded-io conversion.
+- **hadris-io:** `Cursor::seek` uses checked position arithmetic. Overflowing
+  seeks return `InvalidInput`, and `SeekFrom::Start` accepts offsets above
+  `i64::MAX`, matching `std::io::Cursor`.
+- **hadris-storage:** Building with neither the `sync` nor `async` feature no
+  longer emits dead-code warnings.
+- **tools:** All five CLI tools reset `SIGPIPE` to the default disposition on
+  Unix, so piping output into commands such as `head` exits without a
+  broken-pipe panic.
+- **hadris-udf-cli:** `create --revision` now accepts only the supported UDF
+  revisions: 1.02, 1.50, 2.00, 2.01, 2.50, and 2.60.
+
+### Documentation
+
+- **hadris-io:** Corrected the claim that the I/O traits re-export from
+  `std::io` under the `std` feature. They are Hadris traits with blanket impls
+  for standard-library types. The docs now mark `alloc` as a no-op, and the
+  package no longer contains the unused `traits.rs`.
+- **hadris-cd:** The README quick start now opens the output file for reading
+  and writing, as required by `OpticalImageWriter::finish`. The runtime error
+  for a write-only target now states that requirement.
+- **hadris-fixed:** Documented that `From<&[u8]>` for `FixedBytes` panics on
+  over-long slices and that `try_from_slice` is the fallible alternative.
+- **hadris-common:** Corrected the `sync` feature's default in the crate-level
+  feature table.
 
 ## [2.1.0] - 2026-08-18
 
@@ -240,9 +243,18 @@ Each published package owns its version and may be released independently.
 
 - **hadris-fat:** Directory entries and parse results now implement `Clone`,
   allowing parsed metadata to be retained independently of directory iterators.
+  ([@stlankes](https://github.com/stlankes),
+  [#84](https://github.com/hxyulin/hadris/pull/84))
 - **Release automation:** Added a manually triggered GitHub Actions workflow
   that validates and publishes the workspace crates in dependency order, tags
   the release, and creates GitHub release notes from this changelog entry.
+
+### Changed
+
+- **hadris-fat:** `TimeProvider` and `OemCpConverter` now require `Sync`, which
+  allows a `FatVolume` that uses them to be moved into a mutex and shared across
+  threads. ([@stlankes](https://github.com/stlankes),
+  [#83](https://github.com/hxyulin/hadris/pull/83))
 
 ### Fixed
 
@@ -366,6 +378,7 @@ under Semantic Versioning.
 - **hadris-ntfs:** Added an experimental, read-only NTFS leaf crate with
   validated boot geometry, MFT and directory traversal, resident/non-resident
   file reading, sparse runs, Unicode names, and sync/async `no_std` support.
+  ([@aruiz](https://github.com/aruiz))
 - **Facade crates:** Added package READMEs for `hadris-archive`,
   `hadris-block`, and `hadris-optical`.
 - **Specification compliance:** Added a compliance catalog framework with
@@ -614,6 +627,8 @@ under Semantic Versioning.
   failed operation instead of a bare I/O error.
 - **hadris-part:** MBR LBA and GPT on-disk fields use `endian-num` typed
   endian fields instead of manual byte handling.
+  ([@aruiz](https://github.com/aruiz),
+  [#21](https://github.com/hxyulin/hadris/pull/21))
 - **Workspace:** endianness types moved to `zerocopy`; `alloc` error types
   supported in no-std builds.
 
@@ -626,6 +641,8 @@ under Semantic Versioning.
   (cluster-loop / out-of-bounds / bad-cluster markers now return errors).
 - **hadris-fat:** FAT32 `FSInfo` was not flushed on some write paths.
 - **hadris-udf:** Fixed errors when parsing Windows 11 ISO images.
+  ([@Jozefpodlecki](https://github.com/Jozefpodlecki),
+  [#29](https://github.com/hxyulin/hadris/pull/29))
 - **hadris-iso:** Auto-convert lowercase in PVD string fields instead of
   panicking.
 - **Docs:** Fixed broken rustdoc intra-doc links (`OemCpConverter`, `FAT[1]`);
@@ -653,8 +670,22 @@ under Semantic Versioning.
 
 ## [1.1.0] - 2026-03-12
 
-Baseline for this changelog. See the git history for changes at and before this
-tag.
+### Added
+
+- **hadris-fat:** Added configurable FAT table readahead and reduced fragmented
+  file reads to one I/O operation when `FileReader` uses a cached chain.
+  ([@aruiz](https://github.com/aruiz),
+  [#13](https://github.com/hxyulin/hadris/pull/13),
+  [#15](https://github.com/hxyulin/hadris/pull/15))
+
+### Fixed
+
+- **hadris-fat:** Corrected FAT32 entry endianness and fixed cached builds to use
+  the volume's cluster bounds. ([@aruiz](https://github.com/aruiz),
+  [#11](https://github.com/hxyulin/hadris/pull/11),
+  [#12](https://github.com/hxyulin/hadris/pull/12))
+- **Build:** Disabled `thiserror` default features so the workspace builds as
+  `no_std`. ([@aruiz](https://github.com/aruiz))
 
 [Unreleased]: https://github.com/hxyulin/hadris/compare/v2.3.0...HEAD
 [2.3.0]: https://github.com/hxyulin/hadris/compare/v2.2.0...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,20 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-09-01
+
 ### Added
 
-- **hadris-iso:** The ISO writer now emits multi-extent files larger than 4 GiB,
-  and the allocating reader can consume those files incrementally through
-  `read_file_chunked`.
+- **hadris-iso:** The refactored ISO writer now emits multi-extent files larger
+  than 4 GiB, and the allocating reader can consume them incrementally through
+  `read_file_chunked`. Józef Podlecki contributed the original implementation
+  in [#96](https://github.com/hxyulin/hadris/pull/96).
+
+### Changed
+
+- **Tests:** FAT and ISO now use the same hosted, external-tool, and manual
+  test tiers. CI requires mtools and dosfstools for FAT interoperability and
+  xorriso for ISO interoperability, while local runs skip unavailable tools.
 
 ### Fixed
 
@@ -647,7 +656,8 @@ under Semantic Versioning.
 Baseline for this changelog. See the git history for changes at and before this
 tag.
 
-[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/hxyulin/hadris/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/hxyulin/hadris/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/hxyulin/hadris/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/hxyulin/hadris/compare/v2.0.0-rc.4...v2.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,12 +46,16 @@ The oracles are the ground truth. Hadris is measured as one adapter among its
 peers, and a Hadris-to-Hadris round trip is never evidence on its own.
 
 ```bash
-# Hosted suite; run it locally. CI also runs the hosted FAT and ISO slices.
+# Hosted suite. Missing command-line peer tools are skipped locally.
 cargo test --manifest-path tests/Cargo.toml
 
 # One format or topic
 cargo test --manifest-path tests/Cargo.toml fat::
 cargo test --manifest-path tests/Cargo.toml iso::boot::
+
+# Strict tool-backed suite through the repository flake
+nix develop -c env HADRIS_REQUIRE_EXTERNAL_TOOLS=1 \
+  cargo test --manifest-path tests/Cargo.toml
 
 # Match the CI lint and format gates for the suite
 cargo fmt --manifest-path tests/Cargo.toml --all -- --check
@@ -68,18 +72,18 @@ cargo clippy --manifest-path tests/Cargo.toml --all-targets -- -D warnings
 
 #### FAT conformance
 
-The full FAT12/16/32 suite is manual. Its ground truth is a deterministic
-filesystem model plus a test-only raw-image oracle derived from the FAT on-disk
-rules. The oracle independently checks geometry, mirrored FATs, reserved
-entries, FAT32 metadata, cluster chains, cross-links, directory records, LFN
-sequences and checksums, unique short aliases, names, attributes, and contents.
+The FAT12/16/32 specification suite runs by default. Its ground truth is a
+deterministic filesystem model plus a test-only raw-image oracle derived from
+the FAT on-disk rules. The oracle independently checks geometry, mirrored FATs,
+reserved entries, FAT32 metadata, cluster chains, cross-links, directory
+records, LFN sequences and checksums, unique short aliases, names, attributes,
+and contents.
 
 The same harness measures mtools, dosfstools, and the independent Rust `fatfs`
 crate against that ground truth. External-tool mismatches and crashes are
 reported rather than treated as authoritative failures. The peer reports use
 short, isolated scenarios so one failed operation does not mask the remainder
-of a generated trace. The Nix shell supplies the command-line tools and uses
-the repository's Rust toolchain.
+of a generated trace. The repository flake supplies mtools and dosfstools.
 
 Besides the operation traces, every implementation is scored on rejection
 scenarios (case-insensitive duplicates, moves into a directory's own subtree,
@@ -93,7 +97,7 @@ measurement.
 
 ```bash
 cargo test --manifest-path tests/Cargo.toml \
-  fat::spec::fat_spec_conformance -- --ignored --exact --nocapture
+  fat::spec::fat_spec_conformance -- --exact --nocapture
 
 cargo test --manifest-path tests/Cargo.toml \
   fat::peers::fatfs_accuracy_report -- --ignored --exact --nocapture
@@ -143,8 +147,9 @@ cargo test --manifest-path tests/Cargo.toml \
   iso::spec::hadris_iso_matches_ecma_119_oracle -- --exact
 ```
 
-The Nix shell supplies xorriso/libisofs and the original cdrtools `mkisofs`.
-The peer report checks images in both directions where the tool supports them:
+The repository flake supplies xorriso/libisofs and the original cdrtools
+`mkisofs`. The peer report checks images in both directions where the tool
+supports them:
 
 ```bash
 nix develop -c cargo test --manifest-path tests/Cargo.toml \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "hadris"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hadris-archive",
  "hadris-block",
@@ -465,14 +465,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-archive"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hadris-cpio",
 ]
 
 [[package]]
 name = "hadris-block"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "hadris-fat",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hadris-io",
  "hadris-iso",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "hadris-cd",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hadris-common",
  "hadris-io",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -607,14 +607,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "hadris-io"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "hadris-iso",
@@ -657,14 +657,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-ntfs"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-optical"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hadris-cd",
  "hadris-io",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-part"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "crc",
@@ -700,11 +700,11 @@ dependencies = [
 
 [[package]]
 name = "hadris-path"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "hadris-storage"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "embedded-io",
  "hadris-io",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "hadris-udf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,19 +44,19 @@ anyhow = "1.0"
 libc = "0.2"
 
 # Internal crates
-hadris-macros = { version = "2.2.0", path = "crates/core/hadris-macros" }
-hadris-io = { version = "2.2.0", path = "crates/core/hadris-io", default-features = false }
-hadris-fixed = { version = "2.2.0", path = "crates/core/hadris-fixed", default-features = false }
-hadris-path = { version = "2.2.0", path = "crates/core/hadris-path", default-features = false }
-hadris-common = { version = "2.2.0", path = "crates/core/hadris-common", default-features = false }
-hadris-storage = { version = "2.2.0", path = "crates/core/hadris-storage", default-features = false }
-hadris-block = { version = "2.2.0", path = "crates/block/hadris-block", default-features = false }
-hadris-fat = { version = "2.2.0", path = "crates/block/hadris-fat", default-features = false }
-hadris-part = { version = "2.2.0", path = "crates/block/hadris-part", default-features = false }
-hadris-optical = { version = "2.2.0", path = "crates/optical/hadris-optical", default-features = false }
-hadris-iso = { version = "2.2.0", path = "crates/optical/hadris-iso", default-features = false }
-hadris-udf = { version = "2.2.0", path = "crates/optical/hadris-udf", default-features = false }
-hadris-cd = { version = "2.2.0", path = "crates/optical/hadris-cd", default-features = false }
-hadris-archive = { version = "2.2.0", path = "crates/archive/hadris-archive", default-features = false }
-hadris-cpio = { version = "2.2.0", path = "crates/archive/hadris-cpio", default-features = false }
-hadris-ntfs = { version = "2.2.0", path = "crates/block/hadris-ntfs", default-features = false }
+hadris-macros = { version = "2.3.0", path = "crates/core/hadris-macros" }
+hadris-io = { version = "2.3.0", path = "crates/core/hadris-io", default-features = false }
+hadris-fixed = { version = "2.3.0", path = "crates/core/hadris-fixed", default-features = false }
+hadris-path = { version = "2.3.0", path = "crates/core/hadris-path", default-features = false }
+hadris-common = { version = "2.3.0", path = "crates/core/hadris-common", default-features = false }
+hadris-storage = { version = "2.3.0", path = "crates/core/hadris-storage", default-features = false }
+hadris-block = { version = "2.3.0", path = "crates/block/hadris-block", default-features = false }
+hadris-fat = { version = "2.3.0", path = "crates/block/hadris-fat", default-features = false }
+hadris-part = { version = "2.3.0", path = "crates/block/hadris-part", default-features = false }
+hadris-optical = { version = "2.3.0", path = "crates/optical/hadris-optical", default-features = false }
+hadris-iso = { version = "2.3.0", path = "crates/optical/hadris-iso", default-features = false }
+hadris-udf = { version = "2.3.0", path = "crates/optical/hadris-udf", default-features = false }
+hadris-cd = { version = "2.3.0", path = "crates/optical/hadris-cd", default-features = false }
+hadris-archive = { version = "2.3.0", path = "crates/archive/hadris-archive", default-features = false }
+hadris-cpio = { version = "2.3.0", path = "crates/archive/hadris-cpio", default-features = false }
+hadris-ntfs = { version = "2.3.0", path = "crates/block/hadris-ntfs", default-features = false }

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ cargo build -p hadris-fat --no-default-features --features "read,sync"
 ```
 
 See [CLAUDE.md](CLAUDE.md) for detailed build instructions and architecture notes, and [CONTRIBUTING.md](CONTRIBUTING.md) for PR workflow.
-See the [`2.3.0` changelog](CHANGELOG.md#230---2026-09-01) for the current
+See the [`2.3.0` changelog](CHANGELOG.md#230---2026-09-02) for the current
 release summary and the [`2.0.0` release notes](docs/hadris-2.0.0-release-notes.md)
 for the V2 upgrade guide.
 The Docusaurus source for the task-oriented documentation site lives in

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ layers coherent without hiding format-specific capabilities.
 
 Hadris follows [Semantic Versioning](https://semver.org/). The
 release-candidate series completed the V2 feature and public-API freeze, and
-`2.2.0` is the current stable release of that API. Within the `2.x` series,
+`2.3.0` is the current stable release of that API. Within the `2.x` series,
 breaking changes to the public API require a new major version; minor releases
 add backward-compatible functionality, and patch releases are limited to
 correctness fixes, interoperability qualification, and documentation.
@@ -134,14 +134,12 @@ organizational only: published package names such as `hadris-fat` are unchanged.
 Hadris-generated images are checked against an independent raw-image oracle
 and common FAT implementations. These results cover the same filesystem
 operations on every listed FAT variant. The oracle row counts the 18 peer
-scenarios and the three geometry-sized limit exercises; its three open
-failures per width are recorded library bugs (a refused case-only rename, an
-invalid 8.3 alias for a name starting with two periods, and clusters leaked
-when the volume fills).
+scenarios and the three geometry-sized limit exercises, all of which pass in
+the 2.3.0 hosted suite.
 
 | Consumer | FAT12 | FAT16 | FAT32 |
 |----------|-------|-------|-------|
-| Hadris specification oracle | 18/21 | 18/21 | 18/21 |
+| Hadris specification oracle | Pass (21/21) | Pass (21/21) | Pass (21/21) |
 | mtools 4.0.49 reader | Pass (14/16) | Pass (14/16) | Pass (14/16) |
 | dosfstools `fsck.fat` 4.2 | Pass (16/16) | Pass (16/16) | Pass (16/16) |
 | Rust `fatfs` master (`2aefc2a`) reader | Pass (16/16) | Pass (16/16) | Pass (16/16) |
@@ -177,10 +175,10 @@ Choose the narrowest entry point that fits the application:
 ```toml
 [dependencies]
 # One filesystem:
-hadris-fat = "2.2.0"
+hadris-fat = "2.3.0"
 
 # Or the unified storage ecosystem:
-hadris = { version = "2.2.0", features = ["block", "optical"] }
+hadris = { version = "2.3.0", features = ["block", "optical"] }
 ```
 
 The umbrella crate re-exports the same underlying format crates through
@@ -188,15 +186,15 @@ The umbrella crate re-exports the same underlying format crates through
 grow into partition detection or additional disk-image formats without
 replacing their filesystem implementation.
 
-Each package now owns its version; all current packages target **2.2.0**:
+Each package now owns its version; all current packages target **2.3.0**:
 
 ```toml
 [dependencies]
-hadris-iso = "2.2.0"
-hadris-fat = "2.2.0"
-hadris-part = { version = "2.2.0", features = ["read"] }
-hadris-fixed = "2.2.0"
-hadris-path = "2.2.0"
+hadris-iso = "2.3.0"
+hadris-fat = "2.3.0"
+hadris-part = { version = "2.3.0", features = ["read"] }
+hadris-fixed = "2.3.0"
+hadris-path = "2.3.0"
 ```
 
 For allocation-free `no_std` ISO reading:
@@ -204,8 +202,8 @@ For allocation-free `no_std` ISO reading:
 ```toml
 [dependencies]
 # No heap allocator: ISO 9660/Joliet lookup and streamed file reads.
-hadris-iso = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
-hadris-fat = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
 ```
 
 Add the `alloc` feature to `hadris-iso` when owned collections, convenience
@@ -225,7 +223,7 @@ cargo build -p hadris-fat --no-default-features --features "read,sync"
 ```
 
 See [CLAUDE.md](CLAUDE.md) for detailed build instructions and architecture notes, and [CONTRIBUTING.md](CONTRIBUTING.md) for PR workflow.
-See the [`2.2.0` changelog](CHANGELOG.md#220---2026-08-24) for the current
+See the [`2.3.0` changelog](CHANGELOG.md#230---2026-09-01) for the current
 release summary and the [`2.0.0` release notes](docs/hadris-2.0.0-release-notes.md)
 for the V2 upgrade guide.
 The Docusaurus source for the task-oriented documentation site lives in

--- a/crates/archive/hadris-archive/Cargo.toml
+++ b/crates/archive/hadris-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-archive"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-archive/README.md
+++ b/crates/archive/hadris-archive/README.md
@@ -13,7 +13,7 @@ The current facade exposes:
 
 ```toml
 [dependencies]
-hadris-archive = "2.2.0"
+hadris-archive = "2.3.0"
 ```
 
 ```rust
@@ -40,7 +40,7 @@ needs:
 
 ```toml
 [dependencies]
-hadris-archive = { version = "2.2.0", default-features = false, features = ["cpio", "read", "sync"] }
+hadris-archive = { version = "2.3.0", default-features = false, features = ["cpio", "read", "sync"] }
 ```
 
 For format-specific examples and limitations, see the

--- a/crates/archive/hadris-cpio/Cargo.toml
+++ b/crates/archive/hadris-cpio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-cpio/README.md
+++ b/crates/archive/hadris-cpio/README.md
@@ -76,21 +76,21 @@ configurations should enable `sync`, `async`, or both explicitly.
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
+hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Kernels with Heap (no-std + alloc)
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.2.0", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-cpio = "2.2.0"  # Uses default features
+hadris-cpio = "2.3.0"  # Uses default features
 ```
 
 ## Archive Format

--- a/crates/archive/hadris-cpio/src/lib.rs
+++ b/crates/archive/hadris-cpio/src/lib.rs
@@ -62,21 +62,21 @@
 //!
 //! ```toml
 //! [dependencies]
-//! hadris-cpio = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
+//! hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
 //! ```
 //!
 //! ### For Kernels with Heap (no-std + alloc)
 //!
 //! ```toml
 //! [dependencies]
-//! hadris-cpio = { version = "2.2.0", default-features = false, features = ["read", "alloc", "sync"] }
+//! hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "alloc", "sync"] }
 //! ```
 //!
 //! ### For Desktop Applications (full features)
 //!
 //! ```toml
 //! [dependencies]
-//! hadris-cpio = "2.2.0"
+//! hadris-cpio = "2.3.0"
 //! ```
 //!
 //! ## Archive Format

--- a/crates/block/hadris-block/Cargo.toml
+++ b/crates/block/hadris-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-block"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-block/README.md
+++ b/crates/block/hadris-block/README.md
@@ -11,7 +11,7 @@ needed.
 
 ```toml
 [dependencies]
-hadris-block = "2.2.0"
+hadris-block = "2.3.0"
 ```
 
 ```rust

--- a/crates/block/hadris-fat/Cargo.toml
+++ b/crates/block/hadris-fat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-fat"
 autotests = false
-version = "2.2.0"
+version = "2.3.0"
 description = "Rust FAT12/FAT16/FAT32 filesystem library for disk images, embedded devices, and no-std"
 readme = "README.md"
 keywords = ["fat", "fat32", "vfat", "filesystem", "no-std"]

--- a/crates/block/hadris-fat/README.md
+++ b/crates/block/hadris-fat/README.md
@@ -191,21 +191,21 @@ Automatic FAT type selection follows Microsoft recommendations:
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Embedded Systems with Heap
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.2.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
+hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-fat = "2.2.0"  # Uses default features
+hadris-fat = "2.3.0"  # Uses default features
 ```
 
 ## FAT Variant Support
@@ -242,7 +242,7 @@ application needs:
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.2.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync", "cache"] }
+hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync", "cache"] }
 ```
 
 Install it while opening the volume:

--- a/crates/block/hadris-ntfs/Cargo.toml
+++ b/crates/block/hadris-ntfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-ntfs"
 autotests = false
-version = "2.2.0"
+version = "2.3.0"
 description = "A library for reading NTFS filesystems"
 readme = "README.md"
 keywords = ["ntfs", "filesystem", "no-std"]

--- a/crates/block/hadris-part/Cargo.toml
+++ b/crates/block/hadris-part/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-part"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-part/README.md
+++ b/crates/block/hadris-part/README.md
@@ -114,16 +114,16 @@ for (idx, entry) in gpt.partitions() {
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
+hadris-part = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Desktop Applications
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.2.0", features = ["write"] }  # read is already default
+hadris-part = { version = "2.3.0", features = ["write"] }  # read is already default
 # Optional GPT CRC verification:
-# hadris-part = { version = "2.2.0", features = ["write", "crc"] }
+# hadris-part = { version = "2.3.0", features = ["write", "crc"] }
 ```
 
 ## Partition Types

--- a/crates/block/hadris-part/src/mbr.rs
+++ b/crates/block/hadris-part/src/mbr.rs
@@ -263,16 +263,16 @@ impl MbrPartition {
     /// Type 0x17 is ISO9660/Hidden NTFS which is commonly used for hybrid ISOs.
     ///
     /// # Arguments
-    /// * `end_block` - Last sector (in 512-byte blocks)
+    /// * `sector_count` - Image length in 512-byte sectors
     /// * `bootable` - Whether the partition is bootable (0x80) or not (0x00)
-    pub fn new_iso_partition(end_block: u32, bootable: bool) -> Self {
+    pub fn new_iso_partition(sector_count: u32, bootable: bool) -> Self {
         Self {
             boot_indicator: if bootable { 0x80 } else { 0x00 },
             start_chs: Chs::new(0),
             part_type: MbrPartitionType::Iso9660.to_u8(),
-            end_chs: Chs::new(end_block.saturating_sub(1)),
+            end_chs: Chs::new(sector_count.saturating_sub(1)),
             start_lba: Le::<u32>::from_ne(0),
-            sector_count: Le::<u32>::from_ne(end_block),
+            sector_count: Le::<u32>::from_ne(sector_count),
         }
     }
 

--- a/crates/core/hadris-common/Cargo.toml
+++ b/crates/core/hadris-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-common"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-common/README.md
+++ b/crates/core/hadris-common/README.md
@@ -58,14 +58,14 @@ assert_eq!(hadris_common::BOOT_SECTOR_BIN[511], 0xAA);
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.2.0", default-features = false, features = ["alloc", "bytemuck"] }
+hadris-common = { version = "2.3.0", default-features = false, features = ["alloc", "bytemuck"] }
 ```
 
 ### Minimal (No Heap)
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.2.0", default-features = false, features = ["bytemuck"] }
+hadris-common = { version = "2.3.0", default-features = false, features = ["bytemuck"] }
 ```
 
 ## Documentation

--- a/crates/core/hadris-common/boot_sector/Cargo.lock
+++ b/crates/core/hadris-common/boot_sector/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "boot_sector"
-version = "2.2.0"
+version = "2.3.0"

--- a/crates/core/hadris-common/boot_sector/Cargo.toml
+++ b/crates/core/hadris-common/boot_sector/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "boot_sector"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/hadris-fixed/Cargo.toml
+++ b/crates/core/hadris-fixed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fixed"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/Cargo.toml
+++ b/crates/core/hadris-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-io"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/README.md
+++ b/crates/core/hadris-io/README.md
@@ -35,14 +35,14 @@ while custom configurations may select `sync`, `async`, or both.
 
 ```toml
 [dependencies]
-hadris-io = "2.2.0"
+hadris-io = "2.3.0"
 ```
 
 ### No-std
 
 ```toml
 [dependencies]
-hadris-io = { version = "2.2.0", default-features = false, features = ["sync"] }
+hadris-io = { version = "2.3.0", default-features = false, features = ["sync"] }
 ```
 
 ## Quick Start

--- a/crates/core/hadris-macros/Cargo.toml
+++ b/crates/core/hadris-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-macros"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-path/Cargo.toml
+++ b/crates/core/hadris-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-path"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-storage/Cargo.toml
+++ b/crates/core/hadris-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-storage"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris/Cargo.toml
+++ b/crates/core/hadris/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-cd/Cargo.toml
+++ b/crates/optical/hadris-cd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-iso"
 autotests = false
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -124,7 +124,7 @@ only under `sync`.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.2.0", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
 ```
 
 The `read` feature exposes `IsoReader`, which opens and navigates ISO 9660 and
@@ -154,14 +154,14 @@ the allocation-free reader exposes raw system-use bytes for custom handling.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.2.0", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-iso = { version = "2.3.0", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-iso = "2.2.0"  # Uses default features
+hadris-iso = "2.3.0"  # Uses default features
 ```
 
 ## Extension Support

--- a/crates/optical/hadris-iso/src/lib.rs
+++ b/crates/optical/hadris-iso/src/lib.rs
@@ -267,11 +267,11 @@
 //!   writer does not synthesize a filesystem inside them.
 //! - **High-level `IsoImage`:** Requires the `alloc` feature. `read` alone
 //!   exposes low-level modules suitable for no-alloc bootloaders.
-//! - **Not supported (writer rejects or does not emit):** files larger than
-//!   4 GiB / multi-extent write; Extended Attribute Record contents; the Volume
-//!   Partition Descriptor body; interleaved files; associated-file write; the
-//!   optional secondary path tables; RRIP `SF` (sparse) and `RR` (legacy
-//!   presence) entries; zisofs compression; and the Apple Partition Map.
+//! - **Not supported (writer rejects or does not emit):** Extended Attribute
+//!   Record contents; the Volume Partition Descriptor body; interleaved files;
+//!   associated-file write; the optional secondary path tables; RRIP `SF`
+//!   (sparse) and `RR` (legacy presence) entries; zisofs compression; and the
+//!   Apple Partition Map.
 //! - **Non-2048 logical block size:** `IsoImage` requires a 2048-byte logical
 //!   block and rejects other sizes; the allocation-free `IsoReader` honors the
 //!   declared block size.

--- a/crates/optical/hadris-iso/src/write/mod.rs
+++ b/crates/optical/hadris-iso/src/write/mod.rs
@@ -1043,14 +1043,14 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 
     /// Writes an MBR partition table for BIOS USB boot (isohybrid-style).
     async fn write_mbr_boot(&mut self, end_sector: LogicalSector) -> io::Result<()> {
-        let end_block = (end_sector.0 * (self.data.sector_size / 512)) as u32;
+        let sector_count = (end_sector.0 * (self.data.sector_size / 512)) as u32;
 
         let hybrid_opts = self.ops.features.hybrid_boot.as_ref();
         let bootable = hybrid_opts.map(|h| h.bootable).unwrap_or(true);
 
         let mut mbr = MasterBootRecord::default();
         mbr.with_partition_table(|pt| {
-            pt[0] = MbrPartition::new_iso_partition(end_block, bootable);
+            pt[0] = MbrPartition::new_iso_partition(sector_count, bootable);
         });
 
         // Inject bootstrap code if provided

--- a/crates/optical/hadris-optical/Cargo.toml
+++ b/crates/optical/hadris-optical/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-optical"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-optical/README.md
+++ b/crates/optical/hadris-optical/README.md
@@ -10,7 +10,7 @@ validly contain both filesystems.
 
 ```toml
 [dependencies]
-hadris-optical = "2.2.0"
+hadris-optical = "2.3.0"
 ```
 
 ```rust,no_run

--- a/crates/optical/hadris-udf/Cargo.toml
+++ b/crates/optical/hadris-udf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-udf"
 autotests = false
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-udf/README.md
+++ b/crates/optical/hadris-udf/README.md
@@ -17,7 +17,7 @@ UDF (ECMA-167) is the filesystem used for DVD-ROM, DVD-Video, DVD-RAM, Blu-ray d
 
 ```toml
 [dependencies]
-hadris-udf = "2.2.0"
+hadris-udf = "2.3.0"
 ```
 
 ```rust,no_run
@@ -43,7 +43,7 @@ Enable the writer explicitly:
 
 ```toml
 [dependencies]
-hadris-udf = { version = "2.2.0", features = ["write"] }
+hadris-udf = { version = "2.3.0", features = ["write"] }
 ```
 
 ```rust,no_run

--- a/crates/tools/hadris-cd-cli/Cargo.toml
+++ b/crates/tools/hadris-cd-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd-cli"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-cpio-cli/Cargo.toml
+++ b/crates/tools/hadris-cpio-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio-cli"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-fat-cli/Cargo.toml
+++ b/crates/tools/hadris-fat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fat-cli"
-version = "2.2.0"
+version = "2.3.0"
 description = "CLI utility for FAT filesystem analysis and management"
 readme = "README.md"
 keywords = ["fat", "fat32", "filesystem", "cli", "disk"]

--- a/crates/tools/hadris-iso-cli/Cargo.toml
+++ b/crates/tools/hadris-iso-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-iso-cli"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-udf-cli/Cargo.toml
+++ b/crates/tools/hadris-udf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-udf-cli"
-version = "2.2.0"
+version = "2.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs/compliance/hadris-fat.md
+++ b/docs/compliance/hadris-fat.md
@@ -58,20 +58,24 @@ host mount privileges.
 
 The 2.3.0 suite now gates the following cases, which failed in 2.2.0:
 
-- A rename that only changes the case of an 8.3 name (`lower.txt` to
-  `LOWER.TXT`) is refused as an existing entry.
-- Long-name lookups are case-sensitive, so `MIXED CASE NAME.BIN` is created
-  next to `Mixed Case Name.bin`, a directory can be created next to another
-  differing only in case, and a rename onto such a name succeeds.
-- Moving a directory into its own subtree (`/A` to `/A/B/A` or `/A/A`) is
-  accepted and detaches the subtree into an unreachable cycle.
-- The reserved characters `: * ? " < > |` and control characters are accepted
-  in long names.
-- `..dots` receives the alias `        DOT`, which starts with a space and
-  which `fsck.fat` reports as a bad short name.
-- When the data region fills, the aborted write leaks the clusters it had
-  already allocated on FAT12 and FAT16, and leaves the FAT32 FSInfo free
-  count stale.
+- A rename that only changed the case of an 8.3 name (`lower.txt` to
+  `LOWER.TXT`) was refused as an existing entry. Case-only renames now
+  succeed.
+- Long-name lookups were case-sensitive, so `MIXED CASE NAME.BIN` was created
+  next to `Mixed Case Name.bin`, a directory could be created next to another
+  differing only in case, and a rename onto such a name succeeded. Lookups
+  are now case-insensitive.
+- Moving a directory into its own subtree (`/A` to `/A/B/A` or `/A/A`) was
+  accepted and detached the subtree into an unreachable cycle. It is now
+  rejected.
+- The reserved characters `: * ? " < > |` and control characters were
+  accepted in long names. They are now rejected.
+- `..dots` received the alias `        DOT`, which started with a space and
+  which `fsck.fat` reported as a bad short name. Leading-dot names now get a
+  valid alias.
+- When the data region filled, the aborted write leaked the clusters it had
+  already allocated on FAT12 and FAT16, and left the FAT32 FSInfo free count
+  stale. Failed writes now release their clusters and persist a valid FSInfo.
 
 ### Peer writers
 

--- a/docs/compliance/hadris-fat.md
+++ b/docs/compliance/hadris-fat.md
@@ -15,8 +15,8 @@ active-FAT selection when mirroring is disabled and do not recover through the
 backup boot record. exFAT mounts validate only the main boot region, and
 fragmented up-case tables are rejected rather than followed through the FAT.
 
-The manual FAT12/16/32 conformance suite uses a specification-oriented raw
-image oracle rather than another filesystem tool as its ground truth. mtools,
+The FAT12/16/32 conformance suite uses a specification-oriented raw image
+oracle rather than another filesystem tool as its ground truth. mtools,
 dosfstools, macOS FAT tools, native Linux/macOS kernel mounts, and the Rust
 `fatfs` crate are measured independently and may disagree or crash without
 changing the expected FAT semantics.
@@ -40,26 +40,23 @@ character set, and unique short aliases.
 
 | Consumer | FAT12 | FAT16 | FAT32 | Interpretation |
 |----------|-------|-------|-------|----------------|
-| Hadris specification oracle | 18/21 | 18/21 | 18/21 | The 16 generated traces, 16 peer scenarios, and two limit exercises match the model. The failures are the open library bugs listed below. |
+| Hadris specification oracle | 21/21 | 21/21 | 21/21 | All 18 peer scenarios and three geometry-sized limit exercises match the model. |
 | mtools 4.0.49 reader | 14/16 | 14/16 | 14/16 | The two failures are names outside the Basic Multilingual Plane, which mtools transliterates instead of reading as surrogate pairs. |
 | dosfstools `fsck.fat` 4.2 | 16/16 | 16/16 | 16/16 | Every oracle-valid Hadris image passed a read-only structural check. |
 | Rust `fatfs` master (`2aefc2a`) reader | 16/16 | 16/16 | 16/16 | The independent Rust reader reconstructed every oracle-valid tree, surrogate pairs included. |
 | macOS `fsck_msdos` | 2/2 | 2/2 | 2/2 | The curated trace and one deterministic trace passed read-only checks on macOS 26.6.2. |
 
 The per-width oracle count covers the 18 peer scenarios and three limit
-exercises; peers are only measured on the 16 scenarios where Hadris produced
-an oracle-valid reference image. These are bounded interoperability results,
+exercises. The peer rows retain their last recorded 16-scenario qualification
+and use a different denominator. These are bounded interoperability results,
 not claims that the tools accept every possible image Hadris can produce.
-Native writable-mount tests for the Linux `vfat` and macOS FAT drivers are
-also available in the harness, but are reported separately because they
-require host mount privileges.
+Native writable-mount tests for the Linux `vfat` and macOS FAT drivers are also
+available in the harness, but are reported separately because they require
+host mount privileges.
 
-### Open Hadris findings
+### Resolved in 2.3.0
 
-The extended suite records the following library defects; the hosted tests
-`fat::spec::fat_edge_cases_match_spec`,
-`fat::limits::hadris_rejects_invalid_operations`, and
-`fat::limits::hadris_data_region_exhaustion` fail until they are fixed.
+The 2.3.0 suite now gates the following cases, which failed in 2.2.0:
 
 - A rename that only changes the case of an 8.3 name (`lower.txt` to
   `LOWER.TXT`) is refused as an existing entry.
@@ -80,7 +77,7 @@ The extended suite records the following library defects; the hosted tests
 
 | Producer and operations | Completed | Oracle-valid | Additional result |
 |-------------------------|-----------|--------------|-------------------|
-| Hadris | 51/54 traces, 48/87 rejections, 6/9 limits | 48/51 completed traces, 6/9 limits | The failures are the open findings above. |
+| Hadris | 54/54 traces, 87/87 rejections, 9/9 limits | 54/54 completed traces, 9/9 limits | The hosted 2.3.0 suite gates every result. |
 | `mkfs.fat` + mtools 4.0.49 | 44/54 traces, 63/87 rejections, 8/9 limits | 42/44 completed traces, 8/9 limits | Hadris read and `fsck.fat` accepted all completed images. |
 | Rust `fatfs` master (`2aefc2a`) | 39/54 traces, 60/87 rejections, 2/9 limits | 30/39 completed traces, 2/9 limits | Hadris read every oracle-valid image. |
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             pkgs.cdrtools
             pkgs.dosfstools
             pkgs.mtools
+            pkgs.python3
             pkgs.xorriso
           ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
             pkgs.util-linux

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             pkgs.dosfstools
             pkgs.mtools
             pkgs.python3
+            pkgs.qemu
             pkgs.xorriso
           ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
             pkgs.util-linux

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_version="${1:-2.2.0}"
+expected_version="${1:-2.3.0}"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "release check failed: working tree is not clean" >&2

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -251,14 +251,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "hadris-io"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -286,14 +286,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-part"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "crc",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-path"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "hadris-tests"

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,8 @@ tests/
   suite/              the single test binary
     main.rs
     fat/{spec,limits,peers,native}.rs
-    iso/{spec,peers,native,volume_descriptors,directory,rock_ridge,boot,hybrid}.rs
+    iso/{spec,peers,native,volume_descriptors,directory,multi_extent,
+         rock_ridge,boot,hybrid}.rs
 ```
 
 Tests are addressed as `<format>::<topic>::<name>`:
@@ -59,10 +60,17 @@ cargo test --manifest-path tests/Cargo.toml              # hosted suite
 cargo test --manifest-path tests/Cargo.toml fat::        # one format
 cargo test --manifest-path tests/Cargo.toml iso::boot::  # one topic
 cargo test --manifest-path tests/Cargo.toml -- --ignored # manual peer reports
+
+# Require every command-line peer tool through the repository flake
+nix develop -c env HADRIS_REQUIRE_EXTERNAL_TOOLS=1 \
+  cargo test --manifest-path tests/Cargo.toml
 ```
 
-Manual reports and privileged native-mount checks are `#[ignore]`d; the
-commands and environment variables are documented in the repository
+FAT and ISO use the same three test tiers. Hosted oracle tests always run.
+External-tool interoperability tests skip when their tools are absent, while
+CI sets `HADRIS_REQUIRE_EXTERNAL_TOOLS=1` to make them mandatory. Accuracy
+reports, QEMU checks, and privileged native-mount checks are `#[ignore]`d.
+The commands and environment variables are documented in the repository
 [`CONTRIBUTING.md`](../CONTRIBUTING.md#conformance-and-interoperability-suite).
 Reports are written to `tests/target/reports/<format>/`.
 
@@ -84,8 +92,9 @@ Reports are written to `tests/target/reports/<format>/`.
   (or `harness::require_or_skip`) so they skip locally and fail when
   `HADRIS_REQUIRE_EXTERNAL_TOOLS=1` is set.
 
-CI runs the hosted FAT and ISO slices, and also formats and lints the package.
-Manual peer reports and privileged native-mount checks remain ignored.
+CI runs both format slices with their command-line peer tools installed, and
+also formats and lints the package. Manual accuracy reports, QEMU checks, and
+privileged native-mount checks remain ignored.
 
 - When a test is cited as compliance evidence, reference it as
   `<format>::<topic>::<name>` in `@hadris-tests` annotations and

--- a/tests/src/fat/mtools.rs
+++ b/tests/src/fat/mtools.rs
@@ -2,15 +2,15 @@ use std::collections::{BTreeMap, VecDeque};
 use std::ffi::OsString;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Output;
 
 use super::adapter::FatAdapter;
 use super::model::{EntryState, FsState, Operation};
 use super::{ARCHIVE, FatCase, HIDDEN, LABEL, MUTABLE_ATTRS, READ_ONLY, SYSTEM};
 use crate::harness::command::run_command_with_env;
 use crate::harness::normalize_path;
-use crate::harness::run_command;
 use crate::harness::tree::EntryData;
+use crate::harness::{require_or_skip, run_command};
 
 pub const NAME: &str = "mtools";
 
@@ -312,15 +312,13 @@ pub fn fsck(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-pub fn require_tools() -> Result<(), String> {
+pub fn require_tools() -> bool {
     for program in PROGRAMS {
-        Command::new(program)
-            .arg("--help")
-            .env("LC_ALL", "C.UTF-8")
-            .output()
-            .map_err(|error| format!("required external tool {program} is unavailable: {error}"))?;
+        if !require_or_skip(program, "--help") {
+            return false;
+        }
     }
-    Ok(())
+    true
 }
 
 fn mtools_path(path: &str) -> String {

--- a/tests/src/fat/mtools.rs
+++ b/tests/src/fat/mtools.rs
@@ -73,7 +73,7 @@ impl MtoolsFatAdapter {
                 "-i".into(),
                 self.image.as_os_str().into(),
                 "-D".into(),
-                "o".into(),
+                if preserve_attrs { "o" } else { "s" }.into(),
                 source.as_os_str().into(),
                 mtools_path(path).into(),
             ],
@@ -205,6 +205,8 @@ impl FatAdapter for MtoolsFatAdapter {
                     vec![
                         "-i".into(),
                         self.image.as_os_str().into(),
+                        "-D".into(),
+                        "s".into(),
                         mtools_path(path).into(),
                     ],
                 )?;
@@ -228,6 +230,8 @@ impl FatAdapter for MtoolsFatAdapter {
                     vec![
                         "-i".into(),
                         self.image.as_os_str().into(),
+                        "-D".into(),
+                        "s".into(),
                         mtools_path(from).into(),
                         mtools_path(to).into(),
                     ],

--- a/tests/src/harness/scorecard.rs
+++ b/tests/src/harness/scorecard.rs
@@ -105,6 +105,25 @@ impl Scorecard {
         self.passed(label) == self.attempted(label)
     }
 
+    pub fn require_all(&self, metrics: &[(&str, usize)]) -> Result<(), String> {
+        let incomplete = metrics
+            .iter()
+            .filter(|(label, expected)| {
+                self.attempted(label) != *expected || self.passed(label) != *expected
+            })
+            .map(|(label, expected)| format!("{label} (expected {expected})"))
+            .collect::<Vec<_>>();
+        if incomplete.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "required metrics did not pass: {}\n{}",
+                incomplete.join(", "),
+                self.report()
+            ))
+        }
+    }
+
     pub fn report(&self) -> String {
         let (passed, attempted) = self
             .metrics
@@ -134,5 +153,26 @@ impl Scorecard {
         ));
         lines.extend(self.details.iter().cloned());
         lines.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Scorecard;
+
+    #[test]
+    fn required_metrics_must_be_attempted() {
+        let scorecard = Scorecard::new("peer");
+        assert!(scorecard.require_all(&[("read", 1)]).is_err());
+    }
+
+    #[test]
+    fn required_metrics_must_all_pass() {
+        let mut scorecard = Scorecard::new("peer");
+        scorecard.attempt("read");
+        assert!(scorecard.require_all(&[("read", 1)]).is_err());
+        scorecard.pass("read");
+        assert!(scorecard.require_all(&[("read", 1)]).is_ok());
+        assert!(scorecard.require_all(&[("read", 2)]).is_err());
     }
 }

--- a/tests/suite/fat/peers.rs
+++ b/tests/suite/fat/peers.rs
@@ -391,9 +391,33 @@ fn fatfs_dot_entries_match_spec() {
 }
 
 #[test]
-#[ignore = "requires mtools and dosfstools; run through nix develop"]
+fn external_tools_interoperate_with_hadris() {
+    if !mtools::require_tools() {
+        return;
+    }
+    let operations = hadris_tests::fat::scenarios::curated_operations();
+    let mut scorecard = mtools_scorecard();
+    for case in FAT_CASES {
+        measure_mtools(case, "curated", &operations, &mut scorecard).unwrap_or_else(|error| {
+            panic!(
+                "{} curated: {error}\ntrace:\n{}",
+                case.name,
+                format_trace(&operations)
+            )
+        });
+    }
+    scorecard
+        .require_all(&[
+            (MTOOLS_READS, FAT_CASES.len()),
+            (FSCK_HADRIS, FAT_CASES.len()),
+        ])
+        .unwrap();
+}
+
+#[test]
+#[ignore = "manual mtools and dosfstools accuracy suite"]
 fn mtools_accuracy_report() {
-    mtools::require_tools().unwrap();
+    assert!(mtools::require_tools());
     let mut scorecard = mtools_scorecard();
     for (scenario, operations) in interoperability_scenarios() {
         for case in FAT_CASES {

--- a/tests/suite/fat/peers.rs
+++ b/tests/suite/fat/peers.rs
@@ -415,6 +415,69 @@ fn external_tools_interoperate_with_hadris() {
 }
 
 #[test]
+fn mtools_collisions_are_noninteractive() {
+    if !mtools::require_tools() {
+        return;
+    }
+    let case = FAT_CASES[0];
+    let workspace = Workspace::new(FORMAT, "mtools-case-only-rename-").unwrap();
+    let image = workspace.path.join("mtools.img");
+    mtools::format(&image, case).unwrap();
+    let mut adapter = MtoolsFatAdapter::new(image, &workspace.path).unwrap();
+    adapter
+        .apply(&Operation::CreateFile {
+            path: "/lower.txt".into(),
+            data: b"contents".to_vec(),
+        })
+        .unwrap();
+    let before = adapter.snapshot().unwrap();
+    assert!(
+        adapter
+            .apply(&Operation::Rename {
+                from: "/lower.txt".into(),
+                to: "/LOWER.TXT".into(),
+            })
+            .is_err()
+    );
+    let after = adapter.snapshot().unwrap();
+    compare_snapshot("mtools rejected case-only rename", &before, &after).unwrap();
+
+    adapter
+        .apply(&Operation::CreateDir {
+            path: "/Long Directory Name".into(),
+        })
+        .unwrap();
+    let before = adapter.snapshot().unwrap();
+    assert!(
+        adapter
+            .apply(&Operation::CreateDir {
+                path: "/long directory name".into(),
+            })
+            .is_err()
+    );
+    let after = adapter.snapshot().unwrap();
+    compare_snapshot("mtools rejected duplicate directory", &before, &after).unwrap();
+
+    adapter
+        .apply(&Operation::CreateFile {
+            path: "/README.TXT".into(),
+            data: b"original".to_vec(),
+        })
+        .unwrap();
+    let before = adapter.snapshot().unwrap();
+    assert!(
+        adapter
+            .apply(&Operation::CreateFile {
+                path: "/readme.txt".into(),
+                data: b"replacement".to_vec(),
+            })
+            .is_err()
+    );
+    let after = adapter.snapshot().unwrap();
+    compare_snapshot("mtools rejected duplicate file", &before, &after).unwrap();
+}
+
+#[test]
 #[ignore = "manual mtools and dosfstools accuracy suite"]
 fn mtools_accuracy_report() {
     assert!(mtools::require_tools());

--- a/tests/suite/fat/spec.rs
+++ b/tests/suite/fat/spec.rs
@@ -27,7 +27,6 @@ pub fn run_spec_matrix(operations: &[Operation]) -> Result<(), String> {
 }
 
 #[test]
-#[ignore = "manual FAT specification conformance suite"]
 fn fat_spec_conformance() {
     report_failures(specification_scenarios());
 }

--- a/tests/suite/iso/boot.rs
+++ b/tests/suite/iso/boot.rs
@@ -371,6 +371,7 @@ fn test_compare_boot_catalogs() {
 }
 
 #[test]
+#[ignore = "requires QEMU system emulation"]
 fn test_qemu_boot_xorriso_iso() {
     if !xorriso::require() {
         return;
@@ -404,6 +405,7 @@ fn test_qemu_boot_xorriso_iso() {
 }
 
 #[test]
+#[ignore = "requires QEMU system emulation"]
 fn test_qemu_boot_hadris_iso() {
     if !qemu::available() {
         eprintln!("skipping: {} is not available", qemu::PROGRAM);

--- a/tests/suite/iso/peers.rs
+++ b/tests/suite/iso/peers.rs
@@ -6,7 +6,40 @@ use hadris_tests::iso::xorriso::{self, Xorriso};
 use hadris_tests::iso::{FORMAT, IsoProducer, conformance_scenarios, measure};
 
 #[test]
-#[ignore = "manual xorriso and mkisofs accuracy suite; run through nix develop"]
+fn external_tools_interoperate_with_hadris() -> Result<(), String> {
+    if !xorriso::require() {
+        return Ok(());
+    }
+    let mut scorecard = measure::scorecard(xorriso::NAME);
+    let scenarios = conformance_scenarios();
+    let expected_attempts = scenarios.len();
+    for (scenario, expected) in scenarios {
+        let workspace = Workspace::new(FORMAT, &format!("{scenario}-xorriso-strict-"))?;
+        measure::producer(
+            &mut scorecard,
+            scenario,
+            &expected,
+            &Xorriso,
+            &workspace.path,
+        )?;
+        measure::consumer(
+            &mut scorecard,
+            scenario,
+            &expected,
+            &Xorriso,
+            &workspace.path,
+        )?;
+    }
+    let labels = measure::labels(xorriso::NAME);
+    scorecard.require_all(&[
+        (&labels.reads, expected_attempts),
+        (&labels.writes, expected_attempts),
+        (&labels.hadris_reads, expected_attempts),
+    ])
+}
+
+#[test]
+#[ignore = "manual xorriso and mkisofs accuracy suite"]
 fn external_iso_tool_accuracy_report() -> Result<(), String> {
     assert!(xorriso::available(), "xorriso is required");
     let mkisofs = Mkisofs::detect().expect("mkisofs or genisoimage is required");

--- a/website/docs/concepts/features.md
+++ b/website/docs/concepts/features.md
@@ -34,7 +34,7 @@ The `sync` and `async` features select parallel API namespaces backed by
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["alloc", "read", "sync", "async", "lfn"]
 }
@@ -70,7 +70,7 @@ directory trees, or image construction may still require `alloc`.
 
 ```toml
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["read", "sync"]
 }
@@ -80,7 +80,7 @@ hadris-fat = {
 
 ```toml
 hadris-iso = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["alloc", "read", "async", "joliet"]
 }
@@ -90,7 +90,7 @@ hadris-iso = {
 
 ```toml
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   features = ["cache", "tool"]
 }
 ```
@@ -99,7 +99,7 @@ hadris-fat = {
 
 ```toml
 hadris-cpio = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["alloc", "read", "write", "sync"]
 }

--- a/website/docs/crates.md
+++ b/website/docs/crates.md
@@ -36,7 +36,7 @@ Examples include `hadris-fat`, `hadris-part`, `hadris-iso`, `hadris-udf`, and
 
 ```toml
 [dependencies]
-hadris-fat = "2.2.0"
+hadris-fat = "2.3.0"
 ```
 
 ## Category facades
@@ -58,7 +58,7 @@ single dependency declaration.
 ```toml
 [dependencies]
 hadris = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["std", "sync", "read", "block", "optical"]
 }

--- a/website/docs/creation/fat.md
+++ b/website/docs/creation/fat.md
@@ -12,7 +12,7 @@ and other targets implementing the selected Hadris I/O mode.
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.2.0", features = ["write", "sync", "lfn"] }
+hadris-fat = { version = "2.3.0", features = ["write", "sync", "lfn"] }
 ```
 
 ## Format an image file

--- a/website/docs/creation/iso.md
+++ b/website/docs/creation/iso.md
@@ -13,7 +13,7 @@ synchronous API and requires a target implementing `Read + Write + Seek`.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.2.0", features = ["write", "sync", "joliet"] }
+hadris-iso = { version = "2.3.0", features = ["write", "sync", "joliet"] }
 ```
 
 ## Create a basic image

--- a/website/docs/creation/udf.md
+++ b/website/docs/creation/udf.md
@@ -12,7 +12,7 @@ should be used when authoring a shared ISO/UDF bridge image.
 
 ```toml
 [dependencies]
-hadris-udf = { version = "2.2.0", features = ["write", "sync"] }
+hadris-udf = { version = "2.3.0", features = ["write", "sync"] }
 ```
 
 ## Create a directory tree

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -9,13 +9,13 @@ Choose the narrowest crate that covers your application:
 ```toml
 [dependencies]
 # A single filesystem:
-hadris-fat = "2.2.0"
+hadris-fat = "2.3.0"
 
 # Experimental read-only NTFS:
-hadris-ntfs = "2.2.0"
+hadris-ntfs = "2.3.0"
 
 # Or several storage categories:
-hadris = { version = "2.2.0", features = ["block", "optical"] }
+hadris = { version = "2.3.0", features = ["block", "optical"] }
 ```
 
 Hadris separates platform support, I/O mode, and capabilities. For a
@@ -24,7 +24,7 @@ freestanding read-only FAT consumer:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/async-io.md
+++ b/website/docs/guides/async-io.md
@@ -11,11 +11,11 @@ and drives the future with its chosen runtime.
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["alloc", "async", "read", "lfn"]
 }
-hadris-io = { version = "2.2.0", default-features = false, features = ["async"] }
+hadris-io = { version = "2.3.0", default-features = false, features = ["async"] }
 ```
 
 ```rust

--- a/website/docs/guides/build-initramfs.md
+++ b/website/docs/guides/build-initramfs.md
@@ -6,7 +6,7 @@ title: Build a CPIO initramfs
 
 ```toml
 [dependencies]
-hadris-cpio = "2.2.0"
+hadris-cpio = "2.3.0"
 ```
 
 ```rust

--- a/website/docs/guides/cpio-archives.md
+++ b/website/docs/guides/cpio-archives.md
@@ -9,7 +9,7 @@ used by Linux initramfs images.
 
 ```toml
 [dependencies]
-hadris-cpio = "2.2.0"
+hadris-cpio = "2.3.0"
 ```
 
 ## Stream archive entries

--- a/website/docs/guides/custom-io.md
+++ b/website/docs/guides/custom-io.md
@@ -12,11 +12,11 @@ Hosted `std::io` readers work directly. Embedded devices implementing
 [dependencies]
 embedded-io = "0.7"
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["read", "sync"]
 }
-hadris-io = { version = "2.2.0", default-features = false, features = ["sync"] }
+hadris-io = { version = "2.3.0", default-features = false, features = ["sync"] }
 ```
 
 ```rust,ignore

--- a/website/docs/guides/detect-open-images.md
+++ b/website/docs/guides/detect-open-images.md
@@ -12,7 +12,7 @@ metadata. Opening performs the format's full validation.
 
 ```toml
 [dependencies]
-hadris-block = "2.2.0"
+hadris-block = "2.3.0"
 ```
 
 ```rust,no_run
@@ -47,7 +47,7 @@ and create a bounded view before opening its filesystem.
 
 ```toml
 [dependencies]
-hadris-optical = "2.2.0"
+hadris-optical = "2.3.0"
 ```
 
 ```rust,no_run

--- a/website/docs/guides/modify-fat.md
+++ b/website/docs/guides/modify-fat.md
@@ -10,7 +10,7 @@ backing device is removed.
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.2.0", features = ["cache", "dirty-file-panic"] }
+hadris-fat = { version = "2.3.0", features = ["cache", "dirty-file-panic"] }
 ```
 
 ```rust,no_run

--- a/website/docs/guides/no-std.md
+++ b/website/docs/guides/no-std.md
@@ -10,7 +10,7 @@ that the target needs:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.2.0",
+  version = "2.3.0",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/open-partitioned-fat.md
+++ b/website/docs/guides/open-partitioned-fat.md
@@ -11,7 +11,7 @@ byte range.
 ```toml
 [dependencies]
 anyhow = "1"
-hadris-block = "2.2.0"
+hadris-block = "2.3.0"
 ```
 
 ```rust,no_run

--- a/website/docs/guides/read-fat-image.md
+++ b/website/docs/guides/read-fat-image.md
@@ -10,7 +10,7 @@ filesystem.
 ```toml
 [dependencies]
 anyhow = "1"
-hadris-fat = "2.2.0"
+hadris-fat = "2.3.0"
 ```
 
 ```rust,no_run

--- a/website/docs/guides/read-partition-table.md
+++ b/website/docs/guides/read-partition-table.md
@@ -6,7 +6,7 @@ title: Read a partition table
 
 ```toml
 [dependencies]
-hadris-part = "2.2.0"
+hadris-part = "2.3.0"
 ```
 
 ```rust

--- a/website/docs/guides/read-udf.md
+++ b/website/docs/guides/read-udf.md
@@ -6,7 +6,7 @@ title: Read and extract UDF
 
 ```toml
 [dependencies]
-hadris-udf = "2.2.0"
+hadris-udf = "2.3.0"
 ```
 
 The UDF reader exposes owned directory metadata and reads a selected file into

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -21,7 +21,7 @@ directly to the [use-case guides](./guides/index.md).
 
 :::note Stability
 
-`2.2.0` is the current stable V2 release under Semantic Versioning. The
+`2.3.0` is the current stable V2 release under Semantic Versioning. The
 `unstable-exfat` feature and experimental `hadris-ntfs` crate remain outside
 that stability promise.
 

--- a/website/docs/stability.md
+++ b/website/docs/stability.md
@@ -4,14 +4,14 @@ title: Stability and compatibility
 
 # Stability and compatibility
 
-Hadris 2.2.0 is the current stable release of the V2 API, first stabilized in
+Hadris 2.3.0 is the current stable release of the V2 API, first stabilized in
 2.0.0. The public surface frozen during the release-candidate series follows
 Semantic Versioning: within the `2.x` series, breaking changes require a new
 major version, minor releases add backward-compatible functionality, and patch
 releases carry correctness fixes, interoperability qualification, and
 documentation.
 
-Read the [2.2.0 changelog](https://github.com/hxyulin/hadris/blob/main/CHANGELOG.md#210---2026-08-18)
+Read the [2.3.0 changelog](https://github.com/hxyulin/hadris/blob/main/CHANGELOG.md#230---2026-09-01)
 or the [V2 upgrade notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-release-notes.md),
 and report real-world compatibility findings through
 [GitHub Issues](https://github.com/hxyulin/hadris/issues).

--- a/website/docs/stability.md
+++ b/website/docs/stability.md
@@ -11,7 +11,7 @@ major version, minor releases add backward-compatible functionality, and patch
 releases carry correctness fixes, interoperability qualification, and
 documentation.
 
-Read the [2.3.0 changelog](https://github.com/hxyulin/hadris/blob/main/CHANGELOG.md#230---2026-09-01)
+Read the [2.3.0 changelog](https://github.com/hxyulin/hadris/blob/main/CHANGELOG.md#230---2026-09-02)
 or the [V2 upgrade notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-release-notes.md),
 and report real-world compatibility findings through
 [GitHub Issues](https://github.com/hxyulin/hadris/issues).

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hadris-docs",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hadris-docs",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@docusaurus/core": "3.10.2",
         "@docusaurus/preset-classic": "3.10.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hadris-docs",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",


### PR DESCRIPTION
# Summary

Prepares the v2.3.0 release.

- Bump every crate to 2.3.0 and refresh the README version references.
- Update the changelog format and finish the 2.3.0 entries.
- Normalize the FAT and ISO strict conformance suites: scorecard support in
  the harness, peer-suite adjustments, CI workflow and `CONTRIBUTING.md`
  updates, and `tests/README.md` docs.
- Stop `mtools` from prompting on name collisions in the FAT peer suite by
  passing the skip option when attributes are not preserved.
- Add `qemu` and `python3` to the Nix flake so the ISO boot tests run in the
  dev shell.
- Rename the MBR partition helper argument from `end_block` to `sector_count`
  to match what it actually receives.
- Add `.envrc` for direnv users.

# Notes

- `hadris-iso` on this branch still carries the unreleased
  `WrittenFile::additional_extents` field. #104 removes it and should merge
  before 2.3.0 is tagged.
