### PR TITLE
fix(iso): correct multi-extent directory planning and extent sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Each published package owns its version and may be released independently.
   8.3 aliases when long filenames share the same generated short name. Such
   entries previously appeared through their long names but were rejected as
   duplicate directory entries by `fsck.fat`.
+- **hadris-iso:** Non-final extents of multi-extent files are now sized as a
+  multiple of the configured logical block size instead of always 2048 bytes,
+  as required by ECMA-119 6.5.4.
 
 ## [2.2.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Each published package owns its version and may be released independently.
 
 ### Fixed
 
+- **hadris-iso:** Multi-extent directory planning now counts continuation
+  records before assigning file data, preventing creation failures when a
+  continuation crosses a directory-sector boundary. `WrittenFile` retains its
+  v2.2 field layout for source compatibility.
 - **hadris-fat:** FAT name handling is now case-insensitive for long names,
   rejects reserved characters, permits case-only renames, prevents moving a
   directory into its own subtree, and generates valid aliases for leading-dot

--- a/api-snapshots/hadris-iso.txt
+++ b/api-snapshots/hadris-iso.txt
@@ -4146,7 +4146,6 @@ impl hadris_iso::write::writer::WrittenDirectory
 pub fn hadris_iso::write::writer::WrittenDirectory::new(alloc::sync::Arc<alloc::string::String>) -> Self
 pub fn hadris_iso::write::writer::WrittenDirectory::push_dir(&mut self, alloc::sync::Arc<alloc::string::String>, hadris_iso::write::InputMetadata) -> usize
 pub struct hadris_iso::sync::write::writer::WrittenFile
-pub hadris_iso::sync::write::writer::WrittenFile::additional_extents: alloc::vec::Vec<hadris_iso::directory::DirectoryRef>
 pub hadris_iso::sync::write::writer::WrittenFile::entry: hadris_iso::directory::DirectoryRef
 pub hadris_iso::sync::write::writer::WrittenFile::kind: hadris_iso::write::InputEntryKind
 pub hadris_iso::sync::write::writer::WrittenFile::metadata: hadris_iso::write::InputMetadata
@@ -4640,7 +4639,6 @@ impl hadris_iso::write::writer::WrittenDirectory
 pub fn hadris_iso::write::writer::WrittenDirectory::new(alloc::sync::Arc<alloc::string::String>) -> Self
 pub fn hadris_iso::write::writer::WrittenDirectory::push_dir(&mut self, alloc::sync::Arc<alloc::string::String>, hadris_iso::write::InputMetadata) -> usize
 pub struct hadris_iso::write::writer::WrittenFile
-pub hadris_iso::write::writer::WrittenFile::additional_extents: alloc::vec::Vec<hadris_iso::directory::DirectoryRef>
 pub hadris_iso::write::writer::WrittenFile::entry: hadris_iso::directory::DirectoryRef
 pub hadris_iso::write::writer::WrittenFile::kind: hadris_iso::write::InputEntryKind
 pub hadris_iso::write::writer::WrittenFile::metadata: hadris_iso::write::InputMetadata

--- a/crates/optical/hadris-iso/src/write/mod.rs
+++ b/crates/optical/hadris-iso/src/write/mod.rs
@@ -764,6 +764,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                     rrip_options.as_ref(),
                     rrip_time,
                     default_refs,
+                    sector_size,
                 )?;
 
                 let (extent, size_sectors) = layout_directory_records(cursor, sector_size, &records);
@@ -800,20 +801,17 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 
             if len == 0 {
                 file.entry = DirectoryRef::default();
-                file.additional_extents.clear();
                 continue;
             }
 
-            let extents_iter = ExtentIter::new(len, cursor, sector_size);
-            let (mut extents_vec, new_cursor) = extents_iter.collect_with_cursor();
-
-            if !extents_vec.is_empty() {
-                let first = extents_vec.remove(0);
+            let mut extents = ExtentIter::new(len, cursor, sector_size);
+            if let Some((first, new_cursor)) = extents.next() {
                 file.entry = first;
-                file.additional_extents = extents_vec;
+                cursor = new_cursor;
             }
-
-            cursor = new_cursor;
+            for (_, new_cursor) in extents {
+                cursor = new_cursor;
+            }
         }
 
         Ok(cursor)
@@ -875,6 +873,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                     rrip_options.as_ref(),
                     rrip_time,
                     relocation_refs,
+                    sector_size,
                 )?;
                 Self::write_directory_records(&mut self.data, sector_size, expected, &mut records).await?;
             }
@@ -886,13 +885,16 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
         &mut self,
         file_order: &[FileOrder],
     ) -> io::Result<()> {
+        let sector_size = self.data.sector_size as u64;
 
         for (directory_id, index) in file_order {
             let dir = self.written_files.get(directory_id);
             let file = &dir.files[*index];
+            let len = file.kind.file_len().unwrap_or(0);
+            let cursor = file.entry.extent.0 as u64 * sector_size;
 
             let mut offset = 0_u64;
-            for extent in file.extents() {
+            for (extent, _) in ExtentIter::new(len, cursor, sector_size) {
                 let start = self.data.pad_align_sector().await?;
 
                 if start != extent.extent {
@@ -1532,7 +1534,7 @@ mod tests {
         read::PathSeparator,
         write::options::{CreationFeatures, HybridBootOptions},
     };
-    use alloc::{string::ToString, vec};
+    use alloc::{format, string::ToString, vec};
     use core::assert_eq;
     use std::io::Cursor;
 
@@ -1737,6 +1739,44 @@ mod tests {
         assert_eq!(extent.sector.0, expected_sector);
 
         assert!(file.rrip.is_none());
+    }
+
+    #[test]
+    fn should_plan_multi_extent_record_across_directory_sector_boundary() {
+        const SIZE: u64 = 4_294_967_296;
+
+        let mut entries = (0..44)
+            .map(|index| InputEntry {
+                name: Arc::new(format!("F{index:07}")),
+                kind: InputEntryKind::File(Vec::new()),
+                metadata: InputMetadata::default(),
+            })
+            .collect::<Vec<_>>();
+        entries.push(InputEntry {
+            name: Arc::new("MULTIEXT".into()),
+            kind: InputEntryKind::TestFile { size: SIZE },
+            metadata: InputMetadata::default(),
+        });
+
+        let input = InputTree {
+            path_separator: PathSeparator::ForwardSlash,
+            entries,
+        };
+        let options = IsoFormatOptions {
+            volume_name: "BOUNDARY".to_string(),
+            system_id: None,
+            volume_set_id: None,
+            publisher_id: None,
+            preparer_id: None,
+            application_id: None,
+            sector_size: 2048,
+            path_separator: PathSeparator::ForwardSlash,
+            features: CreationFeatures::default(),
+            strict_charset: false,
+        };
+
+        let output = tempfile::tempfile().unwrap();
+        IsoImageWriter::create(output, input, options).unwrap();
     }
 
     #[test]

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -597,6 +597,7 @@ impl PendingRecords {
     /// Identifier (ECMA-119 9.3). Sizes never depend on extent values, so
     /// the planning pass calls this with placeholder refs and the write pass
     /// rebuilds with the real ones.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ty: EntryType,
         dir: &WrittenDirectory,
@@ -780,6 +781,7 @@ impl PendingRecords {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_file_records(
         records: &mut Vec<PendingRecord>,
         files: &[WrittenFile],

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -605,6 +605,7 @@ impl PendingRecords {
         rrip_options: Option<&RripOptions>,
         fallback_time: &RripTime,
         relocation_refs: &BTreeMap<(usize, EntryType), DirectoryRef>,
+        sector_size: u64,
     ) -> io::Result<Self> {
         let rrip_options = rrip_options.filter(|options| options.enabled);
         let has_rrip = ty.supports_rrip() && rrip_options.is_some();
@@ -650,6 +651,7 @@ impl PendingRecords {
             &options,
             inode_counter,
             fallback_time,
+            sector_size,
         )?;
 
         Self::deduplicate_names(&mut records, ty);
@@ -786,6 +788,7 @@ impl PendingRecords {
         options: &RripOptions,
         inode_counter: &mut u32,
         fallback_time: &RripTime,
+        sector_size: u64,
     ) -> io::Result<()> {
         for file in files {
             let converted_name = ty.convert_name(&file.name);
@@ -805,7 +808,11 @@ impl PendingRecords {
                 SplitSu::empty()
             };
 
-            let first_flags = if file.additional_extents.is_empty() {
+            let len = file.kind.file_len().unwrap_or(file.entry.size as u64);
+            let cursor = file.entry.extent.0 as u64 * sector_size;
+            let mut additional_extents =
+                ExtentIter::new(len, cursor, sector_size).skip(1).peekable();
+            let first_flags = if additional_extents.peek().is_none() {
                 FileFlags::empty()
             } else {
                 FileFlags::NOT_FINAL
@@ -814,15 +821,11 @@ impl PendingRecords {
             let first = PendingRecord::new(&converted_name, split, file.entry, first_flags);
             records.push(first);
 
-            // Push additional extents (multi-extent files)
-            // ECMA-119 9.1.4: Each extent gets its own directory record
-            // with the same file identifier.
-            let len = file.additional_extents.len();
-            for (i, dir_ref) in file.additional_extents.iter().cloned().enumerate() {
-                let flags = if i == len - 1 {
-                    FileFlags::empty() // Last extent
+            while let Some((dir_ref, _)) = additional_extents.next() {
+                let flags = if additional_extents.peek().is_none() {
+                    FileFlags::empty()
                 } else {
-                    FileFlags::NOT_FINAL // Middle extents
+                    FileFlags::NOT_FINAL
                 };
 
                 let record = PendingRecord::new(&converted_name, SplitSu::empty(), dir_ref, flags);
@@ -1006,6 +1009,7 @@ impl ExtentIter {
     }
 
     /// Collects all extents into a `Vec<DirectoryRef>` and returns the final cursor.
+    #[cfg(test)]
     pub fn collect_with_cursor(self) -> (Vec<DirectoryRef>, u64) {
         let mut extents = Vec::new();
         let mut cursor = self.cursor;

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -991,10 +991,6 @@ pub struct ExtentIter {
 }
 
 impl ExtentIter {
-    // ECMA-119 6.5.4: Non-final extents must be multiples of the logical block size.
-    // Maximum extent size is floor(u32::MAX / 2048) * 2048 = 4,294,965,248.
-    const MAX_EXTENT_SIZE: u64 = (u32::MAX as u64 / 2048) * 2048;
-
     /// Creates a new extent iterator.
     pub fn new(len: u64, cursor: u64, sector_size: u64) -> Self {
         Self {
@@ -1002,6 +998,11 @@ impl ExtentIter {
             cursor,
             sector_size,
         }
+    }
+
+    // ECMA-119 6.5.4: Non-final extents must be multiples of the logical block size.
+    fn max_extent_size(&self) -> u64 {
+        (u32::MAX as u64 / self.sector_size) * self.sector_size
     }
 
     /// Collects all extents into a `Vec<DirectoryRef>` and returns the final cursor.
@@ -1026,11 +1027,7 @@ impl Iterator for ExtentIter {
             return None;
         }
 
-        let chunk = if self.remaining > Self::MAX_EXTENT_SIZE {
-            Self::MAX_EXTENT_SIZE
-        } else {
-            self.remaining
-        };
+        let chunk = self.remaining.min(self.max_extent_size());
 
         let aligned = (self.cursor + self.sector_size - 1) & !(self.sector_size - 1);
         let extent = DirectoryRef::new((aligned / self.sector_size) as usize, chunk as usize);
@@ -1064,6 +1061,20 @@ mod tests {
         let expected_sector: u64 = 4_294_965_248 / 2048;
         assert_eq!(extents[1].extent.0, expected_sector as usize);
 
+        assert_eq!(final_cursor, len);
+    }
+
+    #[test]
+    fn extent_iter_aligns_non_final_extents_to_sector_size() {
+        let sector_size = 4096;
+        let len = u32::MAX as u64 + 1;
+        let (extents, final_cursor) = ExtentIter::new(len, 0, sector_size).collect_with_cursor();
+
+        assert_eq!(extents.len(), 2);
+        assert_eq!(extents[0].size as u64, 4_294_963_200);
+        assert_eq!(extents[0].size as u64 % sector_size, 0);
+        assert_eq!(extents[1].size as u64, len - 4_294_963_200);
+        assert_eq!(extents[1].extent.0 as u64, 4_294_963_200 / sector_size);
         assert_eq!(final_cursor, len);
     }
 

--- a/crates/optical/hadris-iso/src/write/writer.rs
+++ b/crates/optical/hadris-iso/src/write/writer.rs
@@ -255,8 +255,7 @@ impl WrittenDirectory {
 
 /// A file that has been written to the ISO image.
 ///
-/// Contains the file's name, location on disk, and metadata.
-/// Large files (>4 GiB) may have multiple extents.
+/// Contains the file's name, first extent, contents, and metadata.
 #[derive(Debug)]
 pub struct WrittenFile {
     /// Original filename.
@@ -267,19 +266,6 @@ pub struct WrittenFile {
     /// For most files, this is the only extent.
     /// For multi-extent files (>4 GiB), this is the first chunk.
     pub entry: DirectoryRef,
-
-    /// Additional extents for files larger than 4 GiB.
-    ///
-    /// ISO 9660 limits each extent to 4 GiB (u32::MAX bytes).
-    /// Files exceeding this are split into multiple extents.
-    /// This vector contains all extents after the first.
-    ///
-    /// # Example
-    /// A 10 GiB file would have:
-    /// - `entry`: first 4 GiB
-    /// - `additional_extents[0]`: next 4 GiB
-    /// - `additional_extents[1]`: remaining 2 GiB
-    pub additional_extents: Vec<DirectoryRef>,
 
     /// File contents or directory children.
     pub kind: InputEntryKind,
@@ -296,7 +282,6 @@ impl WrittenFile {
         Self {
             name,
             entry: DirectoryRef::default(),
-            additional_extents: Vec::new(),
             kind,
             metadata,
         }
@@ -314,17 +299,9 @@ impl WrittenFile {
         Self {
             name,
             entry: extent,
-            additional_extents: Vec::new(),
             kind,
             metadata,
         }
-    }
-
-    /// Returns all extents for this file.
-    ///
-    /// The first extent is `entry`, followed by any additional extents.
-    pub(crate) fn extents(&self) -> impl Iterator<Item = &DirectoryRef> {
-        core::iter::once(&self.entry).chain(self.additional_extents.iter())
     }
 }
 


### PR DESCRIPTION
## Summary

Two fixes to multi-extent (>4 GiB) file handling in the `hadris-iso` writer.

- **Continuation records were not counted when sizing directories.** Directory
  extents are laid out before file extents are assigned, and the continuation
  records for multi-extent files were only known after file assignment. When
  such a record pushed a directory past a sector boundary, image creation
  failed. Extents are now derived from the file length wherever they are
  needed, so planning, record emission, and data writing all agree.
- **Non-final extents were always sized against a 2048-byte block.** ECMA-119
  6.5.4 requires non-final extents to be a multiple of the logical block size.
  `ExtentIter` now derives the limit from the configured sector size.

## API change

The `WrittenFile::additional_extents` field is removed. It was added after
v2.2.0 and has not shipped in any published release, so this is not a
breaking change against crates.io. The API snapshot is updated accordingly.

## Testing

- New regression test creates a directory where a continuation record crosses
  a sector boundary. It fails on the release branch and passes here.
- New `ExtentIter` test with a 4096-byte sector checks that the non-final
  extent is block-aligned.
- `cargo fmt --check`, `cargo check --workspace` with `-D warnings`,
  `hadris-iso` with `--no-default-features`, and the full `hadris-iso` suite
  all pass.

