### PR TITLE
feat(iso): stream file contents from a reader while writing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -221,7 +221,7 @@ jobs:
             features: "alloc,sync,async,read,joliet"
           - crate: hadris-iso
             tier: all-capabilities
-            features: "std,alloc,sync,async,read,write,joliet"
+            features: "std,alloc,sync,async,read,write,joliet,unstable-streaming"
 
           # hadris-udf
           - crate: hadris-udf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+### Added
+
+- **hadris-iso:** `InputEntryKind::Source` streams a file's contents from a reader
+  that is opened while the image is written, so a large input no longer has to be
+  held in memory. `FileSource::from_path` streams a file on disk.
+
 ## [2.3.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ Each published package owns its version and may be released independently.
 
 ### Added
 
-- **hadris-iso:** `InputEntryKind::Source` streams a file's contents from a reader
-  that is opened while the image is written, so a large input no longer has to be
-  held in memory. `FileSource::from_path` streams a file on disk.
+- **hadris-iso (`unstable-streaming`):** `InputEntryKind::Source` streams a
+  file's contents from a reader that is opened while the image is written, so a
+  large input no longer has to be held in memory. `FileSource::from_path`
+  streams a file on disk. The feature is outside the V2 stability promise.
+  ([@zone117x](https://github.com/zone117x),
+  [#111](https://github.com/hxyulin/hadris/pull/111))
 
 ## [2.3.0] - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ breaking changes to the public API require a new major version; minor releases
 add backward-compatible functionality, and patch releases are limited to
 correctness fixes, interoperability qualification, and documentation.
 
-The `unstable-exfat` preview and experimental `hadris-ntfs` reader are
-explicitly outside this stability promise.
+The `unstable-exfat` and `unstable-streaming` previews and the experimental
+`hadris-ntfs` reader are explicitly outside this stability promise.
 Stable FAT12/16/32, partition, ISO 9660, UDF, CPIO, facade, and storage APIs are
 covered by the V2 public-API snapshots.
 

--- a/api-snapshots/hadris-iso.txt
+++ b/api-snapshots/hadris-iso.txt
@@ -4184,9 +4184,22 @@ pub hadris_iso::sync::write::InputEntryKind::CharacterDevice::major: u32
 pub hadris_iso::sync::write::InputEntryKind::CharacterDevice::minor: u32
 pub hadris_iso::sync::write::InputEntryKind::Directory(alloc::vec::Vec<hadris_iso::write::InputEntry>)
 pub hadris_iso::sync::write::InputEntryKind::File(alloc::vec::Vec<u8>)
+pub hadris_iso::sync::write::InputEntryKind::Source(hadris_iso::write::FileSource)
 pub hadris_iso::sync::write::InputEntryKind::Symlink(alloc::string::String)
 pub enum hadris_iso::sync::write::IsoCreationError
 pub hadris_iso::sync::write::IsoCreationError::Io(hadris_io::error::Error)
+pub struct hadris_iso::sync::write::FileSource
+impl hadris_iso::write::FileSource
+pub fn hadris_iso::write::FileSource::from_path(impl core::convert::Into<std::path::PathBuf>) -> core::io::error::Result<Self>
+pub const fn hadris_iso::write::FileSource::is_empty(&self) -> bool
+pub const fn hadris_iso::write::FileSource::len(&self) -> u64
+pub fn hadris_iso::write::FileSource::new<F>(u64, F) -> Self where F: core::ops::function::Fn() -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>> + core::marker::Send + core::marker::Sync + 'static
+pub fn hadris_iso::write::FileSource::open(&self) -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>>
+impl core::cmp::Eq for hadris_iso::write::FileSource
+impl core::cmp::PartialEq for hadris_iso::write::FileSource
+pub fn hadris_iso::write::FileSource::eq(&self, &Self) -> bool
+impl core::fmt::Debug for hadris_iso::write::FileSource
+pub fn hadris_iso::write::FileSource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_iso::sync::write::InputEntry
 pub hadris_iso::sync::write::InputEntry::kind: hadris_iso::write::InputEntryKind
 pub hadris_iso::sync::write::InputEntry::metadata: hadris_iso::write::InputMetadata
@@ -4677,9 +4690,22 @@ pub hadris_iso::write::InputEntryKind::CharacterDevice::major: u32
 pub hadris_iso::write::InputEntryKind::CharacterDevice::minor: u32
 pub hadris_iso::write::InputEntryKind::Directory(alloc::vec::Vec<hadris_iso::write::InputEntry>)
 pub hadris_iso::write::InputEntryKind::File(alloc::vec::Vec<u8>)
+pub hadris_iso::write::InputEntryKind::Source(hadris_iso::write::FileSource)
 pub hadris_iso::write::InputEntryKind::Symlink(alloc::string::String)
 pub enum hadris_iso::write::IsoCreationError
 pub hadris_iso::write::IsoCreationError::Io(hadris_io::error::Error)
+pub struct hadris_iso::write::FileSource
+impl hadris_iso::write::FileSource
+pub fn hadris_iso::write::FileSource::from_path(impl core::convert::Into<std::path::PathBuf>) -> core::io::error::Result<Self>
+pub const fn hadris_iso::write::FileSource::is_empty(&self) -> bool
+pub const fn hadris_iso::write::FileSource::len(&self) -> u64
+pub fn hadris_iso::write::FileSource::new<F>(u64, F) -> Self where F: core::ops::function::Fn() -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>> + core::marker::Send + core::marker::Sync + 'static
+pub fn hadris_iso::write::FileSource::open(&self) -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>>
+impl core::cmp::Eq for hadris_iso::write::FileSource
+impl core::cmp::PartialEq for hadris_iso::write::FileSource
+pub fn hadris_iso::write::FileSource::eq(&self, &Self) -> bool
+impl core::fmt::Debug for hadris_iso::write::FileSource
+pub fn hadris_iso::write::FileSource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_iso::write::InputEntry
 pub hadris_iso::write::InputEntry::kind: hadris_iso::write::InputEntryKind
 pub hadris_iso::write::InputEntry::metadata: hadris_iso::write::InputMetadata

--- a/api-snapshots/hadris-iso.txt
+++ b/api-snapshots/hadris-iso.txt
@@ -4184,22 +4184,9 @@ pub hadris_iso::sync::write::InputEntryKind::CharacterDevice::major: u32
 pub hadris_iso::sync::write::InputEntryKind::CharacterDevice::minor: u32
 pub hadris_iso::sync::write::InputEntryKind::Directory(alloc::vec::Vec<hadris_iso::write::InputEntry>)
 pub hadris_iso::sync::write::InputEntryKind::File(alloc::vec::Vec<u8>)
-pub hadris_iso::sync::write::InputEntryKind::Source(hadris_iso::write::FileSource)
 pub hadris_iso::sync::write::InputEntryKind::Symlink(alloc::string::String)
 pub enum hadris_iso::sync::write::IsoCreationError
 pub hadris_iso::sync::write::IsoCreationError::Io(hadris_io::error::Error)
-pub struct hadris_iso::sync::write::FileSource
-impl hadris_iso::write::FileSource
-pub fn hadris_iso::write::FileSource::from_path(impl core::convert::Into<std::path::PathBuf>) -> core::io::error::Result<Self>
-pub const fn hadris_iso::write::FileSource::is_empty(&self) -> bool
-pub const fn hadris_iso::write::FileSource::len(&self) -> u64
-pub fn hadris_iso::write::FileSource::new<F>(u64, F) -> Self where F: core::ops::function::Fn() -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>> + core::marker::Send + core::marker::Sync + 'static
-pub fn hadris_iso::write::FileSource::open(&self) -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>>
-impl core::cmp::Eq for hadris_iso::write::FileSource
-impl core::cmp::PartialEq for hadris_iso::write::FileSource
-pub fn hadris_iso::write::FileSource::eq(&self, &Self) -> bool
-impl core::fmt::Debug for hadris_iso::write::FileSource
-pub fn hadris_iso::write::FileSource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_iso::sync::write::InputEntry
 pub hadris_iso::sync::write::InputEntry::kind: hadris_iso::write::InputEntryKind
 pub hadris_iso::sync::write::InputEntry::metadata: hadris_iso::write::InputMetadata
@@ -4690,22 +4677,9 @@ pub hadris_iso::write::InputEntryKind::CharacterDevice::major: u32
 pub hadris_iso::write::InputEntryKind::CharacterDevice::minor: u32
 pub hadris_iso::write::InputEntryKind::Directory(alloc::vec::Vec<hadris_iso::write::InputEntry>)
 pub hadris_iso::write::InputEntryKind::File(alloc::vec::Vec<u8>)
-pub hadris_iso::write::InputEntryKind::Source(hadris_iso::write::FileSource)
 pub hadris_iso::write::InputEntryKind::Symlink(alloc::string::String)
 pub enum hadris_iso::write::IsoCreationError
 pub hadris_iso::write::IsoCreationError::Io(hadris_io::error::Error)
-pub struct hadris_iso::write::FileSource
-impl hadris_iso::write::FileSource
-pub fn hadris_iso::write::FileSource::from_path(impl core::convert::Into<std::path::PathBuf>) -> core::io::error::Result<Self>
-pub const fn hadris_iso::write::FileSource::is_empty(&self) -> bool
-pub const fn hadris_iso::write::FileSource::len(&self) -> u64
-pub fn hadris_iso::write::FileSource::new<F>(u64, F) -> Self where F: core::ops::function::Fn() -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>> + core::marker::Send + core::marker::Sync + 'static
-pub fn hadris_iso::write::FileSource::open(&self) -> core::io::error::Result<alloc::boxed::Box<(dyn std::io::Read + core::marker::Send)>>
-impl core::cmp::Eq for hadris_iso::write::FileSource
-impl core::cmp::PartialEq for hadris_iso::write::FileSource
-pub fn hadris_iso::write::FileSource::eq(&self, &Self) -> bool
-impl core::fmt::Debug for hadris_iso::write::FileSource
-pub fn hadris_iso::write::FileSource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct hadris_iso::write::InputEntry
 pub hadris_iso::write::InputEntry::kind: hadris_iso::write::InputEntryKind
 pub hadris_iso::write::InputEntry::metadata: hadris_iso::write::InputMetadata

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["filesystem", "embedded", "no-std"]
 exclude = ["/spec"]
 
 [package.metadata.docs.rs]
-features = ["std", "write", "joliet", "read", "alloc", "sync", "async"]
+features = ["std", "write", "joliet", "read", "alloc", "sync", "async", "unstable-streaming"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -31,6 +31,9 @@ async = ["hadris-io/async", "hadris-common/async", "hadris-part/async"]
 
 write = ["alloc", "std", "hadris-part/write", "hadris-part/crc"]
 joliet = ["alloc"]
+# Unstable streaming input for the writer (`InputEntryKind::Source`, `FileSource`).
+# Outside the V2 stability promise; enabling it adds a variant to `InputEntryKind`.
+unstable-streaming = ["write"]
 
 [dependencies]
 bitflags = { workspace = true, features = ["bytemuck"] }

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -8,7 +8,9 @@ embedded systems working with CD-ROM, DVD, and bootable optical-disc images.
 
 ## Features
 
-- **Read & Write Support** - Full-featured ISO creation and extraction
+- **Read & Write Support** - Full-featured ISO creation and extraction; file
+  contents can be streamed from a reader while the image is written, so large
+  inputs never have to be held in memory
 - **Zero-allocation Reader** - Navigate ISO 9660 and Joliet trees and stream
   multi-extent files entirely through caller-owned buffers
 - **No-std Compatible** - Use the sync or async reader in bootloaders, firmware,
@@ -101,6 +103,21 @@ let format_options = IsoFormatOptions {
 
 let mut buffer = Cursor::new(vec![0u8; 1024 * 1024]);
 IsoImageWriter::create(&mut buffer, files, format_options)?;
+```
+
+To add a file without loading it into memory, give the input tree an
+`InputEntryKind::Source` instead of a `File`. A `FileSource` carries the length
+and a way to open a reader; the writer opens it once, when the file's extents
+are written, and streams the contents in fixed-size chunks:
+
+```rust,ignore
+use hadris_iso::write::{FileSource, InputEntry, InputEntryKind, InputMetadata};
+
+let entry = InputEntry {
+    name: "movie.mkv".into(),
+    kind: InputEntryKind::Source(FileSource::from_path("movie.mkv")?),
+    metadata: InputMetadata::default(),
+};
 ```
 
 ## Feature Flags

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -105,10 +105,13 @@ let mut buffer = Cursor::new(vec![0u8; 1024 * 1024]);
 IsoImageWriter::create(&mut buffer, files, format_options)?;
 ```
 
-To add a file without loading it into memory, give the input tree an
-`InputEntryKind::Source` instead of a `File`. A `FileSource` carries the length
-and a way to open a reader; the writer opens it once, when the file's extents
-are written, and streams the contents in fixed-size chunks:
+With the `unstable-streaming` feature, a file can be added without loading it
+into memory: give the input tree an `InputEntryKind::Source` instead of a
+`File`. A `FileSource` carries the length and a way to open a reader; the writer
+opens it once, when the file's extents are written, and streams the contents in
+fixed-size chunks. The feature is outside the V2 stability promise, and enabling
+it adds the `Source` variant to `InputEntryKind`, so exhaustive matches on that
+enum must account for it.
 
 ```rust,ignore
 use hadris_iso::write::{FileSource, InputEntry, InputEntryKind, InputMetadata};
@@ -131,6 +134,7 @@ let entry = InputEntry {
 | `async` | Asynchronous read API under `hadris_iso::r#async` | — |
 | `write` | Synchronous ISO creation/formatting | `std`, `alloc` |
 | `joliet` | Allocating Joliet encode/write helpers; allocation-free Joliet reading is part of `read` | `alloc` |
+| `unstable-streaming` | Unstable: stream file contents from a reader while writing (`InputEntryKind::Source`) | `write` |
 
 `std` selects platform integration but does not select an I/O mode. The default
 configuration enables `sync`; custom configurations should select `sync`,

--- a/crates/optical/hadris-iso/src/write/estimator.rs
+++ b/crates/optical/hadris-iso/src/write/estimator.rs
@@ -163,6 +163,13 @@ fn walk_entries_stats(
                     stats.total_file_bytes += align_to_sector(len, sector_size) * sector_size;
                 }
             }
+            InputEntryKind::Source(source) => {
+                stats.file_count += 1;
+                let len = source.len();
+                if len > 0 {
+                    stats.total_file_bytes += align_to_sector(len, sector_size) * sector_size;
+                }
+            }
             #[cfg(test)]
             InputEntryKind::TestFile { size } => {
                 stats.file_count += 1;

--- a/crates/optical/hadris-iso/src/write/estimator.rs
+++ b/crates/optical/hadris-iso/src/write/estimator.rs
@@ -163,6 +163,7 @@ fn walk_entries_stats(
                     stats.total_file_bytes += align_to_sector(len, sector_size) * sector_size;
                 }
             }
+            #[cfg(feature = "unstable-streaming")]
             InputEntryKind::Source(source) => {
                 stats.file_count += 1;
                 let len = source.len();

--- a/crates/optical/hadris-iso/src/write/mod.rs
+++ b/crates/optical/hadris-iso/src/write/mod.rs
@@ -39,7 +39,9 @@ use writer::{DirectoryRelocation, PathTableWriter, WrittenDirectory, WrittenFile
 use alloc::{string::String, vec, vec::Vec};
 
 use types::*;
-pub use types::{File, InputEntry, InputEntryKind, InputFiles, InputMetadata, InputTree};
+pub use types::{
+    File, FileSource, InputEntry, InputEntryKind, InputFiles, InputMetadata, InputTree,
+};
 
 /// APIs for options.
 pub mod options;
@@ -892,6 +894,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             let file = &dir.files[*index];
             let len = file.kind.file_len().unwrap_or(0);
             let cursor = file.entry.extent.0 as u64 * sector_size;
+            let mut reader = match &file.kind {
+                InputEntryKind::Source(source) => Some(source.open().map_err(source_error)?),
+                _ => None,
+            };
 
             let mut offset = 0_u64;
             for (extent, _) in ExtentIter::new(len, cursor, sector_size) {
@@ -917,6 +923,13 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                     continue;
                 }
 
+                if let Some(reader) = reader.as_mut() {
+                    Self::copy_from_reader(&mut self.data, reader.as_mut(), extent.size as u64)
+                        .await?;
+                    offset += extent.size as u64;
+                    continue;
+                }
+
                 if let InputEntryKind::File(contents) = &file.kind {
                     let chunk_end = (offset + extent.size as u64).min(contents.len() as u64);
                     let range = usize::try_from(offset)
@@ -935,6 +948,34 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Copies exactly `len` bytes from `reader` to the image at the current position.
+    async fn copy_from_reader(
+        data: &mut IsoCursor<DATA>,
+        reader: &mut (dyn std::io::Read + Send),
+        len: u64,
+    ) -> io::Result<()> {
+        const CHUNK: usize = 64 * 1024;
+        let mut buffer = vec![0_u8; CHUNK];
+        let mut remaining = len;
+        while remaining > 0 {
+            let want = usize::try_from(remaining.min(CHUNK as u64)).unwrap_or(CHUNK);
+            let read = match reader.read(&mut buffer[..want]) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "file source ended before its declared length",
+                    ));
+                }
+                Ok(read) => read,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(source_error(error)),
+            };
+            data.write_all(&buffer[..read]).await?;
+            remaining -= read as u64;
+        }
         Ok(())
     }
 
@@ -1526,6 +1567,11 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 }
 } // io_transform!
 
+/// A failure of a [`FileSource`] reader, as an image error.
+fn source_error(error: std::io::Error) -> io::Error {
+    io::Error::<std::io::Error>::from(error).erase()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1739,6 +1785,138 @@ mod tests {
         assert_eq!(extent.sector.0, expected_sector);
 
         assert!(file.rrip.is_none());
+    }
+
+    /// A deterministic byte pattern of a given length, produced without holding it.
+    struct PatternReader {
+        position: u64,
+        len: u64,
+    }
+
+    impl PatternReader {
+        fn byte_at(position: u64) -> u8 {
+            (position % 251) as u8
+        }
+    }
+
+    impl std::io::Read for PatternReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let remaining = usize::try_from(self.len - self.position).unwrap_or(usize::MAX);
+            // Short reads exercise the writer's refill loop.
+            let count = buf.len().min(remaining).min(1000);
+            for (index, byte) in buf[..count].iter_mut().enumerate() {
+                *byte = Self::byte_at(self.position + index as u64);
+            }
+            self.position += count as u64;
+            Ok(count)
+        }
+    }
+
+    fn single_file_tree(name: &str, kind: InputEntryKind) -> InputTree {
+        InputTree {
+            path_separator: PathSeparator::ForwardSlash,
+            entries: vec![InputEntry {
+                name: Arc::new(name.into()),
+                kind,
+                metadata: InputMetadata::default(),
+            }],
+        }
+    }
+
+    fn plain_options(volume_name: &str) -> IsoFormatOptions {
+        IsoFormatOptions {
+            volume_name: volume_name.to_string(),
+            system_id: None,
+            volume_set_id: None,
+            publisher_id: None,
+            preparer_id: None,
+            application_id: None,
+            sector_size: 2048,
+            path_separator: PathSeparator::ForwardSlash,
+            features: CreationFeatures::default(),
+            strict_charset: false,
+        }
+    }
+
+    #[test]
+    fn should_stream_file_source_contents_opened_once() {
+        const LEN: u64 = 3 * 1024 * 1024 + 1;
+        let opens = Arc::new(core::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&opens);
+        let source = FileSource::new(LEN, move || {
+            counter.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+            Ok(Box::new(PatternReader {
+                position: 0,
+                len: LEN,
+            }))
+        });
+        assert_eq!(source.len(), LEN);
+        assert!(!source.is_empty());
+        let input = single_file_tree("STREAMED", InputEntryKind::Source(source));
+
+        let output = tempfile::tempfile().unwrap();
+        let mut output = IsoImageWriter::create(output, input, plain_options("STREAM")).unwrap();
+        assert_eq!(opens.load(core::sync::atomic::Ordering::SeqCst), 1);
+
+        output.seek(SeekFrom::Start(0)).unwrap();
+        let image = IsoImage::open(output).expect("Failed to parse ISO image");
+        let root_dir = image.root_dir();
+        let iso_dir = root_dir.iter(&image);
+        let file = iso_dir
+            .entries()
+            .nth(2)
+            .unwrap()
+            .expect("Failed to parse iso file");
+        assert_eq!(file.display_name(), "STREAMED;1");
+        assert_eq!(file.total_size(), LEN);
+
+        let contents = image
+            .read_file(&file)
+            .expect("Failed to read streamed file");
+        assert_eq!(contents.len() as u64, LEN);
+        assert!(
+            contents
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| *byte == PatternReader::byte_at(index as u64))
+        );
+    }
+
+    #[test]
+    fn should_fail_when_file_source_ends_early() {
+        let source = FileSource::new(5000, || Ok(Box::new(Cursor::new(vec![7_u8; 100]))));
+        let input = single_file_tree("SHORT", InputEntryKind::Source(source));
+
+        let output = tempfile::tempfile().unwrap();
+        let error = IsoImageWriter::create(output, input, plain_options("SHORT"))
+            .expect_err("a short source must fail the write");
+        assert!(
+            matches!(error, IsoCreationError::Io(ref io) if io.kind() == io::ErrorKind::UnexpectedEof),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn should_stream_file_source_from_path() {
+        let contents: Vec<u8> = (0..70_000_u32).map(|value| (value % 199) as u8).collect();
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), &contents).unwrap();
+        let source = FileSource::from_path(file.path()).unwrap();
+        assert_eq!(source.len(), contents.len() as u64);
+        let input = single_file_tree("ONDISK", InputEntryKind::Source(source));
+
+        let output = tempfile::tempfile().unwrap();
+        let mut output = IsoImageWriter::create(output, input, plain_options("ONDISK")).unwrap();
+        output.seek(SeekFrom::Start(0)).unwrap();
+        let image = IsoImage::open(output).expect("Failed to parse ISO image");
+        let root_dir = image.root_dir();
+        let iso_dir = root_dir.iter(&image);
+        let entry = iso_dir
+            .entries()
+            .nth(2)
+            .unwrap()
+            .expect("Failed to parse iso file");
+        assert_eq!(image.read_file(&entry).unwrap(), contents);
     }
 
     #[test]

--- a/crates/optical/hadris-iso/src/write/mod.rs
+++ b/crates/optical/hadris-iso/src/write/mod.rs
@@ -38,10 +38,10 @@ use writer::{DirectoryRelocation, PathTableWriter, WrittenDirectory, WrittenFile
 
 use alloc::{string::String, vec, vec::Vec};
 
+#[cfg(feature = "unstable-streaming")]
+pub use types::FileSource;
 use types::*;
-pub use types::{
-    File, FileSource, InputEntry, InputEntryKind, InputFiles, InputMetadata, InputTree,
-};
+pub use types::{File, InputEntry, InputEntryKind, InputFiles, InputMetadata, InputTree};
 
 /// APIs for options.
 pub mod options;
@@ -894,6 +894,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
             let file = &dir.files[*index];
             let len = file.kind.file_len().unwrap_or(0);
             let cursor = file.entry.extent.0 as u64 * sector_size;
+            #[cfg(feature = "unstable-streaming")]
             let mut reader = match &file.kind {
                 InputEntryKind::Source(source) => Some(source.open().map_err(source_error)?),
                 _ => None,
@@ -923,6 +924,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
                     continue;
                 }
 
+                #[cfg(feature = "unstable-streaming")]
                 if let Some(reader) = reader.as_mut() {
                     Self::copy_from_reader(&mut self.data, reader.as_mut(), extent.size as u64)
                         .await?;
@@ -952,6 +954,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
     }
 
     /// Copies exactly `len` bytes from `reader` to the image at the current position.
+    #[cfg(feature = "unstable-streaming")]
     async fn copy_from_reader(
         data: &mut IsoCursor<DATA>,
         reader: &mut (dyn std::io::Read + Send),
@@ -1568,6 +1571,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 } // io_transform!
 
 /// A failure of a [`FileSource`] reader, as an image error.
+#[cfg(feature = "unstable-streaming")]
 fn source_error(error: std::io::Error) -> io::Error {
     io::Error::<std::io::Error>::from(error).erase()
 }
@@ -1787,136 +1791,143 @@ mod tests {
         assert!(file.rrip.is_none());
     }
 
-    /// A deterministic byte pattern of a given length, produced without holding it.
-    struct PatternReader {
-        position: u64,
-        len: u64,
-    }
+    #[cfg(feature = "unstable-streaming")]
+    mod streaming {
+        use super::*;
 
-    impl PatternReader {
-        fn byte_at(position: u64) -> u8 {
-            (position % 251) as u8
+        /// A deterministic byte pattern of a given length, produced without holding it.
+        struct PatternReader {
+            position: u64,
+            len: u64,
         }
-    }
 
-    impl std::io::Read for PatternReader {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            let remaining = usize::try_from(self.len - self.position).unwrap_or(usize::MAX);
-            // Short reads exercise the writer's refill loop.
-            let count = buf.len().min(remaining).min(1000);
-            for (index, byte) in buf[..count].iter_mut().enumerate() {
-                *byte = Self::byte_at(self.position + index as u64);
+        impl PatternReader {
+            fn byte_at(position: u64) -> u8 {
+                (position % 251) as u8
             }
-            self.position += count as u64;
-            Ok(count)
         }
-    }
 
-    fn single_file_tree(name: &str, kind: InputEntryKind) -> InputTree {
-        InputTree {
-            path_separator: PathSeparator::ForwardSlash,
-            entries: vec![InputEntry {
-                name: Arc::new(name.into()),
-                kind,
-                metadata: InputMetadata::default(),
-            }],
+        impl std::io::Read for PatternReader {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                let remaining = usize::try_from(self.len - self.position).unwrap_or(usize::MAX);
+                // Short reads exercise the writer's refill loop.
+                let count = buf.len().min(remaining).min(1000);
+                for (index, byte) in buf[..count].iter_mut().enumerate() {
+                    *byte = Self::byte_at(self.position + index as u64);
+                }
+                self.position += count as u64;
+                Ok(count)
+            }
         }
-    }
 
-    fn plain_options(volume_name: &str) -> IsoFormatOptions {
-        IsoFormatOptions {
-            volume_name: volume_name.to_string(),
-            system_id: None,
-            volume_set_id: None,
-            publisher_id: None,
-            preparer_id: None,
-            application_id: None,
-            sector_size: 2048,
-            path_separator: PathSeparator::ForwardSlash,
-            features: CreationFeatures::default(),
-            strict_charset: false,
+        fn single_file_tree(name: &str, kind: InputEntryKind) -> InputTree {
+            InputTree {
+                path_separator: PathSeparator::ForwardSlash,
+                entries: vec![InputEntry {
+                    name: Arc::new(name.into()),
+                    kind,
+                    metadata: InputMetadata::default(),
+                }],
+            }
         }
-    }
 
-    #[test]
-    fn should_stream_file_source_contents_opened_once() {
-        const LEN: u64 = 3 * 1024 * 1024 + 1;
-        let opens = Arc::new(core::sync::atomic::AtomicUsize::new(0));
-        let counter = Arc::clone(&opens);
-        let source = FileSource::new(LEN, move || {
-            counter.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
-            Ok(Box::new(PatternReader {
-                position: 0,
-                len: LEN,
-            }))
-        });
-        assert_eq!(source.len(), LEN);
-        assert!(!source.is_empty());
-        let input = single_file_tree("STREAMED", InputEntryKind::Source(source));
+        fn plain_options(volume_name: &str) -> IsoFormatOptions {
+            IsoFormatOptions {
+                volume_name: volume_name.to_string(),
+                system_id: None,
+                volume_set_id: None,
+                publisher_id: None,
+                preparer_id: None,
+                application_id: None,
+                sector_size: 2048,
+                path_separator: PathSeparator::ForwardSlash,
+                features: CreationFeatures::default(),
+                strict_charset: false,
+            }
+        }
 
-        let output = tempfile::tempfile().unwrap();
-        let mut output = IsoImageWriter::create(output, input, plain_options("STREAM")).unwrap();
-        assert_eq!(opens.load(core::sync::atomic::Ordering::SeqCst), 1);
+        #[test]
+        fn should_stream_file_source_contents_opened_once() {
+            const LEN: u64 = 3 * 1024 * 1024 + 1;
+            let opens = Arc::new(core::sync::atomic::AtomicUsize::new(0));
+            let counter = Arc::clone(&opens);
+            let source = FileSource::new(LEN, move || {
+                counter.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+                Ok(Box::new(PatternReader {
+                    position: 0,
+                    len: LEN,
+                }))
+            });
+            assert_eq!(source.len(), LEN);
+            assert!(!source.is_empty());
+            let input = single_file_tree("STREAMED", InputEntryKind::Source(source));
 
-        output.seek(SeekFrom::Start(0)).unwrap();
-        let image = IsoImage::open(output).expect("Failed to parse ISO image");
-        let root_dir = image.root_dir();
-        let iso_dir = root_dir.iter(&image);
-        let file = iso_dir
-            .entries()
-            .nth(2)
-            .unwrap()
-            .expect("Failed to parse iso file");
-        assert_eq!(file.display_name(), "STREAMED;1");
-        assert_eq!(file.total_size(), LEN);
+            let output = tempfile::tempfile().unwrap();
+            let mut output =
+                IsoImageWriter::create(output, input, plain_options("STREAM")).unwrap();
+            assert_eq!(opens.load(core::sync::atomic::Ordering::SeqCst), 1);
 
-        let contents = image
-            .read_file(&file)
-            .expect("Failed to read streamed file");
-        assert_eq!(contents.len() as u64, LEN);
-        assert!(
-            contents
-                .iter()
-                .enumerate()
-                .all(|(index, byte)| *byte == PatternReader::byte_at(index as u64))
-        );
-    }
+            output.seek(SeekFrom::Start(0)).unwrap();
+            let image = IsoImage::open(output).expect("Failed to parse ISO image");
+            let root_dir = image.root_dir();
+            let iso_dir = root_dir.iter(&image);
+            let file = iso_dir
+                .entries()
+                .nth(2)
+                .unwrap()
+                .expect("Failed to parse iso file");
+            assert_eq!(file.display_name(), "STREAMED;1");
+            assert_eq!(file.total_size(), LEN);
 
-    #[test]
-    fn should_fail_when_file_source_ends_early() {
-        let source = FileSource::new(5000, || Ok(Box::new(Cursor::new(vec![7_u8; 100]))));
-        let input = single_file_tree("SHORT", InputEntryKind::Source(source));
+            let contents = image
+                .read_file(&file)
+                .expect("Failed to read streamed file");
+            assert_eq!(contents.len() as u64, LEN);
+            assert!(
+                contents
+                    .iter()
+                    .enumerate()
+                    .all(|(index, byte)| *byte == PatternReader::byte_at(index as u64))
+            );
+        }
 
-        let output = tempfile::tempfile().unwrap();
-        let error = IsoImageWriter::create(output, input, plain_options("SHORT"))
-            .expect_err("a short source must fail the write");
-        assert!(
-            matches!(error, IsoCreationError::Io(ref io) if io.kind() == io::ErrorKind::UnexpectedEof),
-            "{error:?}"
-        );
-    }
+        #[test]
+        fn should_fail_when_file_source_ends_early() {
+            let source = FileSource::new(5000, || Ok(Box::new(Cursor::new(vec![7_u8; 100]))));
+            let input = single_file_tree("SHORT", InputEntryKind::Source(source));
 
-    #[test]
-    fn should_stream_file_source_from_path() {
-        let contents: Vec<u8> = (0..70_000_u32).map(|value| (value % 199) as u8).collect();
-        let file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(file.path(), &contents).unwrap();
-        let source = FileSource::from_path(file.path()).unwrap();
-        assert_eq!(source.len(), contents.len() as u64);
-        let input = single_file_tree("ONDISK", InputEntryKind::Source(source));
+            let output = tempfile::tempfile().unwrap();
+            let error = IsoImageWriter::create(output, input, plain_options("SHORT"))
+                .expect_err("a short source must fail the write");
+            assert!(
+                matches!(error, IsoCreationError::Io(ref io) if io.kind() == io::ErrorKind::UnexpectedEof),
+                "{error:?}"
+            );
+        }
 
-        let output = tempfile::tempfile().unwrap();
-        let mut output = IsoImageWriter::create(output, input, plain_options("ONDISK")).unwrap();
-        output.seek(SeekFrom::Start(0)).unwrap();
-        let image = IsoImage::open(output).expect("Failed to parse ISO image");
-        let root_dir = image.root_dir();
-        let iso_dir = root_dir.iter(&image);
-        let entry = iso_dir
-            .entries()
-            .nth(2)
-            .unwrap()
-            .expect("Failed to parse iso file");
-        assert_eq!(image.read_file(&entry).unwrap(), contents);
+        #[test]
+        fn should_stream_file_source_from_path() {
+            let contents: Vec<u8> = (0..70_000_u32).map(|value| (value % 199) as u8).collect();
+            let file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(file.path(), &contents).unwrap();
+            let source = FileSource::from_path(file.path()).unwrap();
+            assert_eq!(source.len(), contents.len() as u64);
+            let input = single_file_tree("ONDISK", InputEntryKind::Source(source));
+
+            let output = tempfile::tempfile().unwrap();
+            let mut output =
+                IsoImageWriter::create(output, input, plain_options("ONDISK")).unwrap();
+            output.seek(SeekFrom::Start(0)).unwrap();
+            let image = IsoImage::open(output).expect("Failed to parse ISO image");
+            let root_dir = image.root_dir();
+            let iso_dir = root_dir.iter(&image);
+            let entry = iso_dir
+                .entries()
+                .nth(2)
+                .unwrap()
+                .expect("Failed to parse iso file");
+            assert_eq!(image.read_file(&entry).unwrap(), contents);
+        }
     }
 
     #[test]

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::{fmt, ops::Deref};
 use std::{fs::FileType, path::PathBuf};
 
@@ -159,6 +160,7 @@ impl InputTree {
                     //     ));
                     // }
                 }
+                InputEntryKind::Source(_) => {}
                 #[cfg(test)]
                 InputEntryKind::TestFile { .. } => {}
             }
@@ -207,11 +209,90 @@ impl InputMetadata {
     }
 }
 
+/// File contents that are read from a reader while the image is written.
+///
+/// An [`InputEntryKind::File`] holds its contents in memory. A `FileSource` holds
+/// only the length and a way to open a reader, so a large file is streamed into the
+/// image in fixed-size chunks and never has to fit in memory. The writer opens the
+/// reader once per file, in image order, and reads exactly `len` bytes from it: a
+/// reader that ends early fails the write with [`ErrorKind::UnexpectedEof`], and
+/// bytes beyond `len` are never read.
+///
+/// The reader is a blocking [`std::io::Read`] in both the sync and the async writer;
+/// the async writer awaits only its output.
+///
+/// [`ErrorKind::UnexpectedEof`]: crate::io::ErrorKind::UnexpectedEof
+#[derive(Clone)]
+pub struct FileSource {
+    len: u64,
+    open:
+        alloc::sync::Arc<dyn Fn() -> std::io::Result<Box<dyn std::io::Read + Send>> + Send + Sync>,
+}
+
+impl FileSource {
+    /// A source of `len` bytes that `open` produces a reader for.
+    pub fn new<F>(len: u64, open: F) -> Self
+    where
+        F: Fn() -> std::io::Result<Box<dyn std::io::Read + Send>> + Send + Sync + 'static,
+    {
+        Self {
+            len,
+            open: alloc::sync::Arc::new(open),
+        }
+    }
+
+    /// A source that streams the file at `path`, whose length is taken now.
+    ///
+    /// The file is opened when the image is written; its length must not change
+    /// in between.
+    pub fn from_path(path: impl Into<PathBuf>) -> std::io::Result<Self> {
+        let path = path.into();
+        let len = std::fs::metadata(&path)?.len();
+        Ok(Self::new(len, move || {
+            std::fs::File::open(&path).map(|file| Box::new(file) as Box<dyn std::io::Read + Send>)
+        }))
+    }
+
+    /// The number of bytes the source provides.
+    pub const fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Whether the source provides no bytes.
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Opens a fresh reader positioned at the start of the contents.
+    pub fn open(&self) -> std::io::Result<Box<dyn std::io::Read + Send>> {
+        (self.open)()
+    }
+}
+
+impl fmt::Debug for FileSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileSource")
+            .field("len", &self.len)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for FileSource {
+    /// Two sources are equal when they share the same opener and length.
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && alloc::sync::Arc::ptr_eq(&self.open, &other.open)
+    }
+}
+
+impl Eq for FileSource {}
+
 /// The data represented by an [`InputEntry`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InputEntryKind {
     /// The `File` variant.
     File(Vec<u8>),
+    /// A file whose contents are streamed from a reader while the image is written.
+    Source(FileSource),
     /// A virtual sparse file used by large-file regression tests.
     #[cfg(test)]
     TestFile {
@@ -242,6 +323,7 @@ impl InputEntryKind {
     pub(crate) fn file_len(&self) -> Option<u64> {
         match self {
             Self::File(contents) => Some(contents.len() as u64),
+            Self::Source(source) => Some(source.len()),
             #[cfg(test)]
             Self::TestFile { size } => Some(*size),
             _ => None,

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "unstable-streaming")]
 use alloc::boxed::Box;
 use core::{fmt, ops::Deref};
 use std::{fs::FileType, path::PathBuf};
@@ -160,6 +161,7 @@ impl InputTree {
                     //     ));
                     // }
                 }
+                #[cfg(feature = "unstable-streaming")]
                 InputEntryKind::Source(_) => {}
                 #[cfg(test)]
                 InputEntryKind::TestFile { .. } => {}
@@ -221,7 +223,13 @@ impl InputMetadata {
 /// The reader is a blocking [`std::io::Read`] in both the sync and the async writer;
 /// the async writer awaits only its output.
 ///
+/// Requires the `unstable-streaming` feature, which is outside the V2 API
+/// stability promise: this type and [`InputEntryKind::Source`] may change in any
+/// release.
+///
 /// [`ErrorKind::UnexpectedEof`]: crate::io::ErrorKind::UnexpectedEof
+#[cfg(feature = "unstable-streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-streaming")))]
 #[derive(Clone)]
 pub struct FileSource {
     len: u64,
@@ -229,6 +237,7 @@ pub struct FileSource {
         alloc::sync::Arc<dyn Fn() -> std::io::Result<Box<dyn std::io::Read + Send>> + Send + Sync>,
 }
 
+#[cfg(feature = "unstable-streaming")]
 impl FileSource {
     /// A source of `len` bytes that `open` produces a reader for.
     pub fn new<F>(len: u64, open: F) -> Self
@@ -269,6 +278,7 @@ impl FileSource {
     }
 }
 
+#[cfg(feature = "unstable-streaming")]
 impl fmt::Debug for FileSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FileSource")
@@ -277,6 +287,7 @@ impl fmt::Debug for FileSource {
     }
 }
 
+#[cfg(feature = "unstable-streaming")]
 impl PartialEq for FileSource {
     /// Two sources are equal when they share the same opener and length.
     fn eq(&self, other: &Self) -> bool {
@@ -284,14 +295,24 @@ impl PartialEq for FileSource {
     }
 }
 
+#[cfg(feature = "unstable-streaming")]
 impl Eq for FileSource {}
 
 /// The data represented by an [`InputEntry`].
+///
+/// With the `unstable-streaming` feature enabled this enum gains the
+/// [`Source`](Self::Source) variant, so exhaustive matches on it must account for
+/// that variant when the feature is on.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InputEntryKind {
     /// The `File` variant.
     File(Vec<u8>),
     /// A file whose contents are streamed from a reader while the image is written.
+    ///
+    /// Requires the `unstable-streaming` feature and is outside the V2 API
+    /// stability promise.
+    #[cfg(feature = "unstable-streaming")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-streaming")))]
     Source(FileSource),
     /// A virtual sparse file used by large-file regression tests.
     #[cfg(test)]
@@ -323,6 +344,7 @@ impl InputEntryKind {
     pub(crate) fn file_len(&self) -> Option<u64> {
         match self {
             Self::File(contents) => Some(contents.len() as u64),
+            #[cfg(feature = "unstable-streaming")]
             Self::Source(source) => Some(source.len()),
             #[cfg(test)]
             Self::TestFile { size } => Some(*size),

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -301,7 +301,7 @@ impl Eq for FileSource {}
 /// The data represented by an [`InputEntry`].
 ///
 /// With the `unstable-streaming` feature enabled this enum gains the
-/// [`Source`](Self::Source) variant, so exhaustive matches on it must account for
+/// `Source` variant, so exhaustive matches on it must account for
 /// that variant when the feature is on.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InputEntryKind {

--- a/crates/optical/hadris-iso/src/write/utils.rs
+++ b/crates/optical/hadris-iso/src/write/utils.rs
@@ -382,7 +382,7 @@ pub fn build_rrip_entries(
             kind,
         } => {
             let (type_mode, default_permissions) = match kind {
-                InputEntryKind::File(_) => (0o100000, 0o644),
+                InputEntryKind::File(_) | InputEntryKind::Source(_) => (0o100000, 0o644),
                 #[cfg(test)]
                 InputEntryKind::TestFile { .. } => (0o100000, 0o644),
                 InputEntryKind::Symlink(_) => (0o120000, 0o777),

--- a/crates/optical/hadris-iso/src/write/utils.rs
+++ b/crates/optical/hadris-iso/src/write/utils.rs
@@ -382,7 +382,9 @@ pub fn build_rrip_entries(
             kind,
         } => {
             let (type_mode, default_permissions) = match kind {
-                InputEntryKind::File(_) | InputEntryKind::Source(_) => (0o100000, 0o644),
+                InputEntryKind::File(_) => (0o100000, 0o644),
+                #[cfg(feature = "unstable-streaming")]
+                InputEntryKind::Source(_) => (0o100000, 0o644),
                 #[cfg(test)]
                 InputEntryKind::TestFile { .. } => (0o100000, 0o644),
                 InputEntryKind::Symlink(_) => (0o120000, 0o777),

--- a/scripts/check-public-api.sh
+++ b/scripts/check-public-api.sh
@@ -46,6 +46,12 @@ for crate in "${crates[@]}"; do
       --no-default-features \
       --features "std,sync,async,read,write,lfn,cache,tool,defmt,dirty-file-panic" \
       -sss --color never >"$generated"
+  elif [[ "$crate" == "hadris-iso" ]]; then
+    # The unstable streaming input is outside the V2 API stability promise.
+    cargo public-api -p "$crate" \
+      --no-default-features \
+      --features "std,alloc,sync,async,read,write,joliet" \
+      -sss --color never >"$generated"
   else
     cargo public-api -p "$crate" --all-features -sss --color never >"$generated"
   fi


### PR DESCRIPTION
## Summary

`InputEntryKind::File` holds a file's whole contents in memory, so creating an image from large inputs (a few GiB of media, an OS install tree) needs as much memory as the inputs. This adds `InputEntryKind::Source(FileSource)`: the length plus a way to open a reader. The writer opens the reader once per file, in image order, and copies exactly the declared length into the file's extents in 64 KiB chunks, so peak memory no longer depends on input size.

- `FileSource::new(len, || Ok(Box::new(reader)))` for any `std::io::Read`; `FileSource::from_path(path)` streams a file on disk (length taken when constructed).
- A reader that ends before `len` fails the write with `ErrorKind::UnexpectedEof`; bytes beyond `len` are never read, and `Interrupted` reads are retried.
- The size estimator and the RRIP mode defaults treat a `Source` like a `File`, so extent prediction, multi-extent planning, and the estimator's layout stay unchanged.
- `FileSource` is `Clone` (shared opener) and compares equal only to itself, so `InputTree`/`InputEntry`/`InputEntryKind` keep their derives.

### Design notes

The reader is a blocking `std::io::Read` in both the sync and the async writer: the async `Read` trait uses `async fn` and is not object safe, so a boxed async reader cannot live in the (mode-independent) input tree. The async writer still awaits its output; the docs on `FileSource` say so. `write` already implies `std`, so the variant needs no new feature gate, and every feature tier still compiles.

`InputTree::from_fs` is unchanged (it still reads files into memory); switching it, or a threshold-based mix, could be a follow-up if you want it.

## Tests

- `should_stream_file_source_contents_opened_once`: a 3 MiB + 1 byte patterned source that returns short reads; verifies the opener runs once, the record's `total_size`, and every byte read back through `IsoImage::read_file`.
- `should_fail_when_file_source_ends_early`: a source that declares 5000 bytes but yields 100 fails with `UnexpectedEof`.
- `should_stream_file_source_from_path`: round trip through `FileSource::from_path`.
- `cargo test --workspace --tests` (776 passed), `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTFLAGS="-D warnings" cargo check --workspace`, the `read,sync` / `alloc,sync` / `std,sync` / `std,write,async` / all-feature tiers for `hadris-iso`, `cargo test -p hadris-iso --all-features --doc`, and the hosted `iso::` conformance suite. The public API snapshot was refreshed with `scripts/check-public-api.sh update` on `nightly-2026-07-15`.

## Motivation

I'm using `hadris-iso` as the ISO backend of an archive manager, where the inputs are streamed from arbitrary sources and can be much larger than memory; this is the one blocker for creating large images with the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
