### PR TITLE
fix(iso): end a directory listing at the first record that does not parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **hadris-iso:** Directory iteration now stops after a malformed record or I/O
+  error instead of returning the same error on every call.
+  ([@zone117x](https://github.com/zone117x),
+  [#113](https://github.com/hxyulin/hadris/pull/113))
+
 ## [2.3.0] - 2026-09-02
 
 ### Added

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -56,6 +56,10 @@ criterion.workspace = true
 name = "no_alloc_reader"
 required-features = ["std", "sync", "read"]
 
+[[test]]
+name = "dir_iter_error"
+required-features = ["std", "sync", "write"]
+
 [[bench]]
 name = "iso_benchmarks"
 harness = false

--- a/crates/optical/hadris-iso/src/read/directory.rs
+++ b/crates/optical/hadris-iso/src/read/directory.rs
@@ -523,24 +523,40 @@ impl<T: Read + Seek> IsoDirIter<'_, T> {
     }
 
     /// Read the next raw DirectoryRecord from the directory data.
+    ///
+    /// An error ends the directory: the offset is moved to its end so that the next
+    /// call returns `None`. Otherwise a record that does not parse (or a read that
+    /// fails) would be retried at the same offset and the iterator would yield the
+    /// same error forever.
     fn next_raw_record(&mut self) -> Option<io::Result<DirectoryRecord>> {
-        use super::super::io::try_io_result_option;
         let reader = &self.image.data;
         let mut reader = reader.lock();
 
         const SECTOR_SIZE: usize = 2048;
+
+        macro_rules! try_or_end {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(val) => val,
+                    Err(err) => {
+                        self.offset = self.directory.size;
+                        return Some(Err(err.erase()));
+                    }
+                }
+            };
+        }
 
         loop {
             if self.offset >= self.directory.size {
                 return None;
             }
 
-            try_io_result_option!(reader.seek(SeekFrom::Start(
+            try_or_end!(reader.seek(SeekFrom::Start(
                 (self.directory.extent.0 as u64) * SECTOR_SIZE as u64 + (self.offset as u64),
             )));
 
             let mut len_byte = [0u8; 1];
-            try_io_result_option!(reader.read_exact(&mut len_byte));
+            try_or_end!(reader.read_exact(&mut len_byte));
 
             if len_byte[0] == 0 {
                 let current_sector_offset = self.offset % SECTOR_SIZE;
@@ -552,11 +568,11 @@ impl<T: Read + Seek> IsoDirIter<'_, T> {
                 continue;
             }
 
-            try_io_result_option!(reader.seek(SeekFrom::Start(
+            try_or_end!(reader.seek(SeekFrom::Start(
                 (self.directory.extent.0 as u64) * SECTOR_SIZE as u64 + (self.offset as u64),
             )));
 
-            let record = try_io_result_option!(DirectoryRecord::parse(reader.deref_mut()));
+            let record = try_or_end!(DirectoryRecord::parse(reader.deref_mut()));
             self.offset += record.size();
 
             return Some(Ok(record));
@@ -657,23 +673,36 @@ impl<T: Read + Seek> RawDirIter<'_, T> {
 
 impl<T: Read + Seek> Iterator for RawDirIter<'_, T> {
     type Item = io::Result<DirectoryRecord>;
+    /// An error ends the directory (the offset moves to its end), as in
+    /// [`IsoDirIter`]: otherwise the same failing record would be reported forever.
     fn next(&mut self) -> Option<Self::Item> {
-        use super::super::io::try_io_result_option;
         let mut reader = self.reader.lock();
 
         const SECTOR_SIZE: usize = 2048;
+
+        macro_rules! try_or_end {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(val) => val,
+                    Err(err) => {
+                        self.offset = self.directory.size;
+                        return Some(Err(err.erase()));
+                    }
+                }
+            };
+        }
 
         loop {
             if self.offset >= self.directory.size {
                 return None;
             }
 
-            try_io_result_option!(reader.seek(SeekFrom::Start(
+            try_or_end!(reader.seek(SeekFrom::Start(
                 (self.directory.extent.0 as u64) * SECTOR_SIZE as u64 + (self.offset as u64),
             )));
 
             let mut len_byte = [0u8; 1];
-            try_io_result_option!(reader.read_exact(&mut len_byte));
+            try_or_end!(reader.read_exact(&mut len_byte));
 
             if len_byte[0] == 0 {
                 let current_sector_offset = self.offset % SECTOR_SIZE;
@@ -685,11 +714,11 @@ impl<T: Read + Seek> Iterator for RawDirIter<'_, T> {
                 continue;
             }
 
-            try_io_result_option!(reader.seek(SeekFrom::Start(
+            try_or_end!(reader.seek(SeekFrom::Start(
                 (self.directory.extent.0 as u64) * SECTOR_SIZE as u64 + (self.offset as u64),
             )));
 
-            let record = try_io_result_option!(DirectoryRecord::parse(reader.deref_mut()));
+            let record = try_or_end!(DirectoryRecord::parse(reader.deref_mut()));
             self.offset += record.size();
 
             return Some(Ok(record));

--- a/crates/optical/hadris-iso/tests/dir_iter_error.rs
+++ b/crates/optical/hadris-iso/tests/dir_iter_error.rs
@@ -1,0 +1,79 @@
+//! A directory record that does not parse ends the directory listing instead of
+//! being reported again and again: the iterator used to stay at the same offset after
+//! an error, so `entries()` yielded the same `Err` forever.
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use hadris_iso::read::{IsoImage, PathSeparator};
+use hadris_iso::write::options::{CreationFeatures, IsoFormatOptions};
+use hadris_iso::write::{File as IsoFile, InputFiles, IsoImageWriter};
+
+fn write_bytes(files: Vec<IsoFile>) -> Vec<u8> {
+    let options = IsoFormatOptions {
+        volume_name: "BROKEN".to_string(),
+        system_id: None,
+        volume_set_id: None,
+        publisher_id: None,
+        preparer_id: None,
+        application_id: None,
+        sector_size: 2048,
+        path_separator: PathSeparator::ForwardSlash,
+        features: CreationFeatures::default(),
+        strict_charset: false,
+    };
+    let input = InputFiles {
+        path_separator: PathSeparator::ForwardSlash,
+        files,
+    };
+    let mut buffer = Cursor::new(vec![0u8; 2 * 1024 * 1024]);
+    IsoImageWriter::create(&mut buffer, input, options).expect("write ISO");
+    buffer.into_inner()
+}
+
+fn file(name: &str) -> IsoFile {
+    IsoFile::File {
+        name: Arc::new(name.to_string()),
+        contents: name.as_bytes().to_vec(),
+    }
+}
+
+/// Byte offset of the `index`-th record of the root directory (0 and 1 are `.` and
+/// `..`).
+fn root_record_offset(image: &[u8], index: usize) -> usize {
+    let pvd = 16 * 2048;
+    let root = &image[pvd + 156..pvd + 190];
+    let extent = u32::from_le_bytes([root[2], root[3], root[4], root[5]]) as usize;
+    let mut offset = extent * 2048;
+    for _ in 0..index {
+        offset += image[offset] as usize;
+    }
+    offset
+}
+
+#[test]
+fn a_record_that_does_not_parse_ends_the_directory_instead_of_repeating() {
+    let mut bytes = write_bytes(vec![file("A.TXT"), file("B.TXT"), file("C.TXT")]);
+    // Make the first file's record inconsistent: its big-endian extent no longer
+    // matches the little-endian one, which the parser rejects.
+    let broken = root_record_offset(&bytes, 2);
+    bytes[broken + 6] ^= 0xFF;
+
+    let image = IsoImage::open(Cursor::new(bytes)).expect("open ISO");
+    let root = image.root_dir();
+    let results: Vec<_> = image.open_dir(root.dir_ref()).entries().take(64).collect();
+
+    assert!(
+        results.len() <= 3,
+        "the iterator kept going after the bad record: {} results",
+        results.len()
+    );
+    assert!(
+        results.last().is_some_and(|r| r.is_err()),
+        "the bad record was not reported"
+    );
+    assert!(
+        results[..results.len() - 1].iter().all(|r| r.is_ok()),
+        "the records before the bad one are fine"
+    );
+}


### PR DESCRIPTION
`IsoDirIter::next_raw_record` and `RawDirIter::next` return an error without moving `self.offset`, so a directory containing one malformed record (for example an inconsistent both-endian extent field) yields the same `Err` on every call, forever. I found it by fuzzing a reader built on the crate: the caller collected millions of identical errors before its own entry cap stopped it, hundreds of seconds per input.

This change moves the offset to the directory's end on any error (seek, read, or parse), so the error is reported once and the iterator then returns `None`, in both iterators.

A regression test (`tests/dir_iter_error.rs`, registered in `Cargo.toml` since `autotests = false`) writes an image with three files, corrupts the first file record's big-endian extent so the parser rejects it, and checks that `entries()` ends after that error.

Reproducer for the current behaviour: open the attached image and iterate the directory at block 21 with a `take(10_000)`: 9,998 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)