### PR TITLE
ci: separate Rust toolchain selection from action updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
 
       - name: Validate release metadata
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,14 +55,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       # cargo-public-api generates rustdoc JSON through nightly rustdoc even
       # though the project itself remains pinned to the stable MSRV above.
       # Pin the nightly: rustdoc's rendering of blanket impls (e.g.
       # `std::io::Read` vs `alloc::io::read::Read`) drifts between nightlies, so
       # an unpinned toolchain makes the snapshot diff nondeterministic. Bump
       # this date deliberately alongside a snapshot refresh.
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
           toolchain: nightly-2026-07-15
       - uses: Swatinem/rust-cache@v2
@@ -85,7 +87,9 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Check workspace (default features)
         run: cargo check --workspace
@@ -349,7 +353,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Check ${{ matrix.crate }} with features "${{ matrix.features }}"
         run: cargo check -p ${{ matrix.crate }} --no-default-features --features "${{ matrix.features }}"
@@ -363,7 +369,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Run all-feature tests
         if: runner.os != 'Windows'
@@ -394,7 +402,9 @@ jobs:
       HADRIS_REQUIRE_EXTERNAL_TOOLS: "1"
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install exfatprogs
         run: |
@@ -412,7 +422,9 @@ jobs:
       HADRIS_REQUIRE_EXTERNAL_TOOLS: "1"
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install FAT image tools
         run: |
@@ -428,7 +440,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install optical image tools
         run: |
@@ -454,7 +468,9 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: cargo doc --workspace
         run: cargo doc --workspace --no-deps
@@ -468,8 +484,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
+          toolchain: 1.88.0
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -481,8 +498,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
+          toolchain: 1.88.0
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
       # this date deliberately alongside a snapshot refresh.
       - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
-          toolchain: nightly-2026-07-15
+          toolchain: nightly-2026-09-04
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-public-api
         run: cargo install cargo-public-api --version 0.52.0 --locked
@@ -75,7 +75,7 @@ jobs:
         # RUSTUP_TOOLCHAIN when it names a nightly, so this drives rustdoc with
         # the pinned dated nightly installed above.
         env:
-          RUSTUP_TOOLCHAIN: nightly-2026-07-15
+          RUSTUP_TOOLCHAIN: nightly-2026-09-04
         run: scripts/check-public-api.sh
 
   check:

--- a/api-snapshots/hadris-io.txt
+++ b/api-snapshots/hadris-io.txt
@@ -178,6 +178,10 @@ impl hadris_io::Read for hadris_io::Cursor<'_>
 pub type hadris_io::Cursor<'_>::Error = hadris_io::ErrorKind
 pub fn hadris_io::Cursor<'_>::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
 pub fn hadris_io::Cursor<'_>::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
+impl<T: alloc::io::read::Read + ?core::marker::Sized> hadris_io::Read for T
+pub type T::Error = core::io::error::Error
+pub fn T::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
+pub fn T::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
 impl<T: embedded_io::Read> hadris_io::Read for hadris_io::FromEmbedded<T>
 pub type hadris_io::FromEmbedded<T>::Error = <T as embedded_io::ErrorType>::Error
 pub fn hadris_io::FromEmbedded<T>::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
@@ -186,10 +190,6 @@ impl<T: hadris_io::Read + ?core::marker::Sized> hadris_io::Read for hadris_io::B
 pub type hadris_io::Borrowed<'_, T>::Error = <T as hadris_io::Read>::Error
 pub fn hadris_io::Borrowed<'_, T>::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
 pub fn hadris_io::Borrowed<'_, T>::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
-impl<T: std::io::Read + ?core::marker::Sized> hadris_io::Read for T
-pub type T::Error = core::io::error::Error
-pub fn T::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
-pub fn T::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
 pub trait hadris_io::sync::ReadExt: hadris_io::Read
 pub fn hadris_io::sync::ReadExt::parse<T: hadris_io::Parsable>(&mut self) -> hadris_io::Result<T> where Self: core::marker::Sized
 pub fn hadris_io::sync::ReadExt::read_struct<T: bytemuck::zeroable::Zeroable + bytemuck::no_uninit::NoUninit + bytemuck::anybitpattern::AnyBitPattern>(&mut self) -> hadris_io::Result<T>
@@ -394,6 +394,10 @@ impl hadris_io::Read for hadris_io::Cursor<'_>
 pub type hadris_io::Cursor<'_>::Error = hadris_io::ErrorKind
 pub fn hadris_io::Cursor<'_>::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
 pub fn hadris_io::Cursor<'_>::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
+impl<T: alloc::io::read::Read + ?core::marker::Sized> hadris_io::Read for T
+pub type T::Error = core::io::error::Error
+pub fn T::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
+pub fn T::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
 impl<T: embedded_io::Read> hadris_io::Read for hadris_io::FromEmbedded<T>
 pub type hadris_io::FromEmbedded<T>::Error = <T as embedded_io::ErrorType>::Error
 pub fn hadris_io::FromEmbedded<T>::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
@@ -402,10 +406,6 @@ impl<T: hadris_io::Read + ?core::marker::Sized> hadris_io::Read for hadris_io::B
 pub type hadris_io::Borrowed<'_, T>::Error = <T as hadris_io::Read>::Error
 pub fn hadris_io::Borrowed<'_, T>::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
 pub fn hadris_io::Borrowed<'_, T>::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
-impl<T: std::io::Read + ?core::marker::Sized> hadris_io::Read for T
-pub type T::Error = core::io::error::Error
-pub fn T::read(&mut self, &mut [u8]) -> hadris_io::Result<usize, Self::Error>
-pub fn T::read_exact(&mut self, &mut [u8]) -> hadris_io::Result<()>
 pub trait hadris_io::ReadExt: hadris_io::Read
 pub fn hadris_io::ReadExt::parse<T: hadris_io::Parsable>(&mut self) -> hadris_io::Result<T> where Self: core::marker::Sized
 pub fn hadris_io::ReadExt::read_struct<T: bytemuck::zeroable::Zeroable + bytemuck::no_uninit::NoUninit + bytemuck::anybitpattern::AnyBitPattern>(&mut self) -> hadris_io::Result<T>


### PR DESCRIPTION
## Summary

- Pin `dtolnay/rust-toolchain` to a full commit SHA.
- Select Rust 1.88.0 explicitly through the action's `toolchain` input.
- Update the public API job to `nightly-2026-09-04`.
- Regenerate the affected `hadris-io` API snapshot.

This lets Dependabot update the action independently from the Rust compiler version. It supersedes #112, which accidentally selects the nonexistent Rust 1.120.0 toolchain.

The snapshot change only reflects rustdoc's new internal path for `std::io::Read`, now shown as `alloc::io::read::Read`. It does not change Hadris's public API.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --workspace`
- `cargo test --workspace --tests`
- `RUSTUP_TOOLCHAIN=nightly-2026-09-04 scripts/check-public-api.sh`