### PR TITLE
fix(fat): an exFAT file's DataLength is its size, not its allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ Each published package owns its version and may be released independently.
 
 ### Fixed
 
+- **hadris-fat (`unstable-exfat`):** The exFAT writer now records a file's size
+  as the stream extension's `DataLength` instead of its cluster-rounded
+  allocation, and an empty file keeps `AllocationPossible` set with
+  `NoFatChain` clear so both `fsck_exfat` and `fsck.exfat` accept it.
+  ([@zone117x](https://github.com/zone117x),
+  [#116](https://github.com/hxyulin/hadris/pull/116))
 - **hadris-iso:** Directory iteration now stops after a malformed record or I/O
   error instead of returning the same error on every call.
   ([@zone117x](https://github.com/zone117x),

--- a/crates/block/hadris-fat/Cargo.toml
+++ b/crates/block/hadris-fat/Cargo.toml
@@ -76,3 +76,7 @@ tempfile = "3"
 [[test]]
 name = "exfat_upcase_dos"
 required-features = ["unstable-exfat"]
+
+[[test]]
+name = "exfat_roundtrip"
+required-features = ["unstable-exfat", "write"]

--- a/crates/block/hadris-fat/src/exfat/entry.rs
+++ b/crates/block/hadris-fat/src/exfat/entry.rs
@@ -126,7 +126,7 @@ pub struct RawStreamExtensionEntry {
     pub reserved3: U32<LittleEndian>,
     /// First cluster of file data
     pub first_cluster: U32<LittleEndian>,
-    /// Data length (allocated size, may be larger than valid_data_length)
+    /// Data length (the file size; valid_data_length is the initialised prefix)
     pub data_length: U64<LittleEndian>,
 }
 
@@ -255,7 +255,7 @@ pub struct ExFatFileEntry {
     pub attributes: FileAttributes,
     /// First cluster of file data
     pub first_cluster: u32,
-    /// Total data length (allocated size)
+    /// Data length (the file size, not its cluster allocation)
     pub data_length: u64,
     /// Valid data length (actual content size)
     pub valid_data_length: u64,

--- a/crates/block/hadris-fat/src/exfat/entry_writer.rs
+++ b/crates/block/hadris-fat/src/exfat/entry_writer.rs
@@ -170,14 +170,14 @@ impl EntrySetBuilder {
 
     fn build_stream_entry(&self, name_length: u8, name_hash: u16) -> RawStreamExtensionEntry {
         // General secondary flags:
-        // Bit 0: AllocationPossible (1 if a cluster allocation exists)
-        // Bit 1: NoFatChain (1 if contiguous; requires AllocationPossible=1)
-        // Per exFAT spec, both bits must be 0 when the file has no clusters.
+        // Bit 0: AllocationPossible, always 1 on a stream extension (exFAT 7.6.2)
+        // Bit 1: NoFatChain (1 if contiguous, or if there are no clusters at all,
+        //        as Windows writes empty files)
         let has_allocation = self.data_length > 0 || self.first_cluster != 0;
-        let flags = if has_allocation {
-            0x01 | if self.is_contiguous { 0x02 } else { 0x00 }
+        let flags = if !has_allocation || self.is_contiguous {
+            0x03
         } else {
-            0
+            0x01
         };
 
         RawStreamExtensionEntry {

--- a/crates/block/hadris-fat/src/exfat/entry_writer.rs
+++ b/crates/block/hadris-fat/src/exfat/entry_writer.rs
@@ -171,10 +171,11 @@ impl EntrySetBuilder {
     fn build_stream_entry(&self, name_length: u8, name_hash: u16) -> RawStreamExtensionEntry {
         // General secondary flags:
         // Bit 0: AllocationPossible, always 1 on a stream extension (exFAT 7.6.2)
-        // Bit 1: NoFatChain (1 if contiguous, or if there are no clusters at all,
-        //        as Windows writes empty files)
+        // Bit 1: NoFatChain, 1 only for a contiguous file that has clusters. An
+        //        empty file keeps it clear so both fsck_exfat and exfatprogs
+        //        accept the entry.
         let has_allocation = self.data_length > 0 || self.first_cluster != 0;
-        let flags = if !has_allocation || self.is_contiguous {
+        let flags = if has_allocation && self.is_contiguous {
             0x03
         } else {
             0x01

--- a/crates/block/hadris-fat/src/exfat/file.rs
+++ b/crates/block/hadris-fat/src/exfat/file.rs
@@ -315,10 +315,13 @@ impl<'a, DATA: Read + Write + Seek> ExFatFileWriter<'a, DATA> {
     /// This must be called after writing to update the file's metadata
     /// (size, data length, first cluster) and recalculate the entry set checksum.
     pub fn finish(self) -> Result<()> {
+        // DataLength is the file's size (exFAT 7.6.7); the allocation is implied by
+        // the clusters. Writing the allocated length there makes other
+        // implementations read a cluster's worth of zeros past the file's end.
         self.fs.update_entry_size(
             &self.entry,
             self.new_length,
-            self.allocated_length,
+            self.new_length,
             self.first_cluster,
             self.is_contiguous,
         )?;

--- a/crates/block/hadris-fat/src/exfat/fs.rs
+++ b/crates/block/hadris-fat/src/exfat/fs.rs
@@ -692,14 +692,15 @@ where
         // Update the stream extension entry (second entry, index 1)
         if entry_count >= 2 {
             let stream = unsafe { &mut entries[1].stream };
-            // Keep general_secondary_flags consistent with the new allocation
-            // state: AllocationPossible (bit 0) must be 0 when there are no
-            // clusters, and NoFatChain (bit 1) requires AllocationPossible=1.
+            // A stream extension's AllocationPossible (bit 0) is always 1 (exFAT
+            // 7.6.2); a file with no clusters has FirstCluster 0 and, as Windows
+            // writes it, NoFatChain (bit 1) set. fsck_exfat rejects an entry with
+            // AllocationPossible clear as "no stream allocation".
             let has_allocation = new_data_length > 0 || new_first_cluster != 0;
-            stream.general_secondary_flags = if has_allocation {
-                0x01 | if no_fat_chain { 0x02 } else { 0x00 }
+            stream.general_secondary_flags = if !has_allocation || no_fat_chain {
+                0x03
             } else {
-                0
+                0x01
             };
             stream.valid_data_length = U64::<LittleEndian>::new(new_valid_data_length);
             stream.data_length = U64::<LittleEndian>::new(new_data_length);

--- a/crates/block/hadris-fat/src/exfat/fs.rs
+++ b/crates/block/hadris-fat/src/exfat/fs.rs
@@ -744,9 +744,10 @@ where
             }
             self.update_entry_size(entry, 0, 0, 0, false)?;
         } else {
-            // Calculate clusters to keep
+            // Calculate clusters to keep; the entry's data length is the file's size,
+            // the allocation being implied by the clusters (exFAT 7.6.7).
             let clusters_to_keep = new_size.div_ceil(cluster_size);
-            let new_data_length = clusters_to_keep * cluster_size;
+            let new_data_length = new_size;
 
             if entry.no_fat_chain {
                 // For contiguous files, just free the excess clusters

--- a/crates/block/hadris-fat/src/exfat/fs.rs
+++ b/crates/block/hadris-fat/src/exfat/fs.rs
@@ -693,11 +693,11 @@ where
         if entry_count >= 2 {
             let stream = unsafe { &mut entries[1].stream };
             // A stream extension's AllocationPossible (bit 0) is always 1 (exFAT
-            // 7.6.2); a file with no clusters has FirstCluster 0 and, as Windows
-            // writes it, NoFatChain (bit 1) set. fsck_exfat rejects an entry with
-            // AllocationPossible clear as "no stream allocation".
+            // 7.6.2); fsck_exfat rejects an entry with it clear as "no stream
+            // allocation". NoFatChain (bit 1) is set only for a contiguous file
+            // that has clusters: exfatprogs rejects an empty file with it set.
             let has_allocation = new_data_length > 0 || new_first_cluster != 0;
-            stream.general_secondary_flags = if !has_allocation || no_fat_chain {
+            stream.general_secondary_flags = if has_allocation && no_fat_chain {
                 0x03
             } else {
                 0x01

--- a/crates/block/hadris-fat/tests/exfat_roundtrip.rs
+++ b/crates/block/hadris-fat/tests/exfat_roundtrip.rs
@@ -211,3 +211,34 @@ fn roundtrip_multiple_files() {
         assert_eq!(&got, payload, "mismatch for {name}");
     }
 }
+
+/// The stream extension's DataLength is the file's size, not the clusters
+/// allocated for it: other implementations take DataLength as the size, and a
+/// cluster-rounded one shows a small file with a tail of zeros.
+#[test]
+fn data_length_is_the_file_size_not_the_allocation() {
+    let dir = TempDir::new().expect("tempdir");
+    let image_path = dir.path().join("length.img");
+    make_image(&image_path, "LENGTH");
+    write_root_file(&image_path, "small.txt", b"Hello, exFAT!");
+
+    let fs = ExFatVolume::open(open_image(&image_path)).expect("open exFAT");
+    let entry = fs
+        .root_dir()
+        .find("small.txt")
+        .expect("find")
+        .expect("small.txt exists");
+    assert_eq!(entry.valid_data_length, 13);
+    assert_eq!(entry.data_length, 13, "DataLength must be the file's size");
+
+    // Truncating keeps the rule.
+    fs.truncate(&entry, 5).expect("truncate");
+    let entry = fs
+        .root_dir()
+        .find("small.txt")
+        .expect("find")
+        .expect("small.txt exists");
+    assert_eq!(entry.valid_data_length, 5);
+    assert_eq!(entry.data_length, 5);
+}
+

--- a/crates/block/hadris-fat/tests/exfat_roundtrip.rs
+++ b/crates/block/hadris-fat/tests/exfat_roundtrip.rs
@@ -242,3 +242,24 @@ fn data_length_is_the_file_size_not_the_allocation() {
     assert_eq!(entry.data_length, 5);
 }
 
+/// An empty file still has a stream extension that allows allocation (exFAT
+/// 7.6.2), with no FAT chain and no first cluster; fsck_exfat reports "no stream
+/// allocation" otherwise.
+#[test]
+fn an_empty_file_keeps_allocation_possible() {
+    let dir = TempDir::new().expect("tempdir");
+    let image_path = dir.path().join("empty.img");
+    make_image(&image_path, "EMPTY");
+    write_root_file(&image_path, "empty.txt", b"");
+
+    let fs = ExFatVolume::open(open_image(&image_path)).expect("open exFAT");
+    let entry = fs
+        .root_dir()
+        .find("empty.txt")
+        .expect("find")
+        .expect("empty.txt exists");
+    assert_eq!(entry.data_length, 0);
+    assert_eq!(entry.first_cluster, 0);
+    assert!(entry.no_fat_chain, "an empty file carries NoFatChain, as Windows writes it");
+}
+

--- a/crates/block/hadris-fat/tests/exfat_roundtrip.rs
+++ b/crates/block/hadris-fat/tests/exfat_roundtrip.rs
@@ -243,8 +243,9 @@ fn data_length_is_the_file_size_not_the_allocation() {
 }
 
 /// An empty file still has a stream extension that allows allocation (exFAT
-/// 7.6.2), with no FAT chain and no first cluster; fsck_exfat reports "no stream
-/// allocation" otherwise.
+/// 7.6.2) with no first cluster; fsck_exfat reports "no stream allocation"
+/// otherwise. NoFatChain stays clear: exfatprogs rejects an empty file that
+/// claims a contiguous allocation ("empty, but has no Fat chain").
 #[test]
 fn an_empty_file_keeps_allocation_possible() {
     let dir = TempDir::new().expect("tempdir");
@@ -260,6 +261,33 @@ fn an_empty_file_keeps_allocation_possible() {
         .expect("empty.txt exists");
     assert_eq!(entry.data_length, 0);
     assert_eq!(entry.first_cluster, 0);
-    assert!(entry.no_fat_chain, "an empty file carries NoFatChain, as Windows writes it");
+    assert!(
+        !entry.no_fat_chain,
+        "an empty file must not claim a contiguous allocation"
+    );
+
+    let flags = root_stream_flags(&image_path, fs.info().root_cluster, |stream| {
+        u64::from_le_bytes(stream[24..32].try_into().unwrap()) == 0
+            && u32::from_le_bytes(stream[20..24].try_into().unwrap()) == 0
+    });
+    assert_eq!(flags & 0x01, 0x01, "AllocationPossible must be set");
+    assert_eq!(flags & 0x02, 0x00, "NoFatChain must be clear");
+    assert_eq!(flags, 0x01);
 }
 
+/// GeneralSecondaryFlags of the first stream extension in the root directory
+/// cluster that `matches` the raw 32-byte entry.
+fn root_stream_flags(image_path: &Path, root_cluster: u32, matches: impl Fn(&[u8]) -> bool) -> u8 {
+    let fs = ExFatVolume::open(open_image(image_path)).expect("open exFAT");
+    let info = fs.info();
+    let offset = info.cluster_to_offset(root_cluster);
+    let mut cluster = vec![0u8; info.bytes_per_cluster];
+    let mut file = open_image(image_path);
+    file.seek(std::io::SeekFrom::Start(offset)).unwrap();
+    std::io::Read::read_exact(&mut file, &mut cluster).expect("read root cluster");
+    cluster
+        .chunks_exact(32)
+        .find(|raw| raw[0] == 0xC0 && matches(raw))
+        .map(|raw| raw[1])
+        .expect("stream extension entry")
+}


### PR DESCRIPTION
The exFAT writer recorded the allocated length (whole clusters) as the stream extension's DataLength. Implementations that take DataLength as the file's size (macOS among them) then read a small file followed by a cluster's worth of zeros. Per exFAT 7.6.7 DataLength is the file's size and the allocation is implied by the clusters, so `finish()` and `truncate()` now record the size.

Also registers `tests/exfat_roundtrip.rs`, which `autotests = false` had left out of the build, and adds a case for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)