### PR TITLE
fix(iso): reject images too large for an MBR or GPT partition entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **hadris-iso:** Images too large for an MBR or GPT partition entry now fail
+  with `InvalidInput` instead of writing a truncated sector count.
+  ([#105](https://github.com/hxyulin/hadris/issues/105))
+
 ## [2.3.0] - 2026-09-02
 
 ### Added

--- a/crates/optical/hadris-iso/src/write/mod.rs
+++ b/crates/optical/hadris-iso/src/write/mod.rs
@@ -309,7 +309,7 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
     ) -> io::Result<()> {
         let catalog_ptr = self.write_boot_catalog().await?;
         let end_sector = self.pad_and_get_end_sector().await?;
-        let volume_space = self.volume_space_sectors(end_sector);
+        let volume_space = self.volume_space_sectors(end_sector)?;
 
         self.patch_volume_descriptors(&root_dirs, catalog_ptr, volume_space).await?;
 
@@ -1045,7 +1045,10 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
 
     /// Writes an MBR partition table for BIOS USB boot (isohybrid-style).
     async fn write_mbr_boot(&mut self, end_sector: LogicalSector) -> io::Result<()> {
-        let sector_count = (end_sector.0 * (self.data.sector_size / 512)) as u32;
+        let sector_count = checked_sector_count(
+            end_sector.0 as u64 * (self.data.sector_size as u64 / 512),
+            "image exceeds the 2 TiB limit of an MBR partition entry",
+        )?;
 
         let hybrid_opts = self.ops.features.hybrid_boot.as_ref();
         let bootable = hybrid_opts.map(|h| h.bootable).unwrap_or(true);
@@ -1124,8 +1127,8 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
     /// The `volume_space_size` to declare: for GPT/Hybrid images it covers the
     /// whole image including the appended backup-GPT region, so tools that
     /// copy `volume_space_size` logical sectors preserve the backup GPT.
-    fn volume_space_sectors(&self, end_sector: LogicalSector) -> u32 {
-        match self
+    fn volume_space_sectors(&self, end_sector: LogicalSector) -> io::Result<u32> {
+        let sectors = match self
             .ops
             .features
             .hybrid_boot
@@ -1134,10 +1137,14 @@ impl<DATA: Read + Write + Seek> IsoImageWriter<DATA> {
         {
             Some(PartitionScheme::Gpt) | Some(PartitionScheme::Hybrid) => {
                 let blocks_per_sector = (self.ops.sector_size / 512) as u64;
-                (self.gpt_total_512(end_sector) / blocks_per_sector) as u32
+                self.gpt_total_512(end_sector) / blocks_per_sector
             }
-            _ => end_sector.0 as u32,
-        }
+            _ => end_sector.0 as u64,
+        };
+        checked_sector_count(
+            sectors,
+            "image exceeds the 32-bit volume space size of ISO 9660",
+        )
     }
 
     fn build_gpt_disk(
@@ -1540,6 +1547,16 @@ mod tests {
 
     const DIR_NAME_DOT: &[u8] = b"\x00";
     const DIR_NAME_DOTDOT: &[u8] = b"\x01";
+
+    #[test]
+    fn should_reject_sector_counts_that_do_not_fit_a_partition_entry() {
+        assert_eq!(
+            checked_sector_count(u64::from(u32::MAX), "too large").unwrap(),
+            u32::MAX
+        );
+        let error = checked_sector_count(u64::from(u32::MAX) + 1, "too large").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
 
     #[test]
     fn should_create_empty_iso_no_boot() {

--- a/crates/optical/hadris-iso/src/write/options.rs
+++ b/crates/optical/hadris-iso/src/write/options.rs
@@ -78,6 +78,10 @@ impl HybridBootOptions {
 }
 
 /// The partition scheme to use for hybrid boot.
+///
+/// MBR partition entries and the ISO 9660 volume space size are 32-bit sector
+/// counts, so `Mbr` and `Hybrid` layouts are limited to 2 TiB of 512-byte
+/// sectors; a larger image fails to write with `InvalidInput`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PartitionScheme {
     /// No partition table (CD/DVD only, not USB bootable).

--- a/crates/optical/hadris-iso/src/write/utils.rs
+++ b/crates/optical/hadris-iso/src/write/utils.rs
@@ -534,6 +534,12 @@ pub const fn alignment_requires_materialization(
     aligned_position > current_position
 }
 
+/// Converts a sector count to the 32-bit field of an MBR partition entry or the
+/// ISO 9660 volume space size, failing with `InvalidInput` instead of truncating.
+pub fn checked_sector_count(sectors: u64, message: &'static str) -> io::Result<u32> {
+    u32::try_from(sectors).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, message))
+}
+
 pub fn part_io_error(err: hadris_part::Error) -> io::Error {
     match err {
         hadris_part::Error::Io(err) => err,


### PR DESCRIPTION
## Summary

The ISO writer filled two 32-bit fields with a plain `as u32` cast: the MBR partition entry's sector count in `write_mbr_boot`, and the ISO 9660 `volume_space_size` in `volume_space_sectors` (which the GPT and hybrid layouts also size from). An image over 2 TiB of 512-byte sectors got a truncated partition entry that did not cover the image, silently.

Both call sites now go through one crate-private `checked_sector_count` helper that returns an `InvalidInput` error with a clear message when the count does not fit.

- Unit test asserts the boundary (`u32::MAX` passes, `u32::MAX + 1` fails with `InvalidInput`) without writing a large file.
- `PartitionScheme` docs note that MBR and hybrid layouts are limited to 2 TiB of 512-byte sectors.
- CHANGELOG entry under Unreleased.

Closes #105

## Verification

- `cargo fmt --all -- --check`: pass
- `RUSTFLAGS="-D warnings" cargo check -p hadris-iso --all-features`: pass
- `RUSTFLAGS="-D warnings" cargo check -p hadris-iso --no-default-features --features std,sync,read,write,joliet`: pass
- `cargo clippy -p hadris-iso --all-targets --all-features -- -D warnings`: pass
- `cargo test -p hadris-iso --all-features --lib`: 217 passed; `--tests`: 219 passed
- Public API snapshot for hadris-iso: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)