### PR TITLE
tests: isolate mtools from the host home and gate its write direction

### DIFF
--- a/tests/src/fat/mtools.rs
+++ b/tests/src/fat/mtools.rs
@@ -19,11 +19,31 @@ pub const PROGRAMS: [&str; 11] = [
     "mlabel",
 ];
 
-/// GNU mtools driven through its command-line programs with an isolated
-/// `MTOOLSRC` so host configuration cannot leak into the run.
+/// How mtools handles a name clash on a write. It reads the answer from
+/// `/dev/tty` rather than stdin, so every write command must pass one.
+#[derive(Clone, Copy)]
+enum ClashPolicy {
+    Skip,
+    Overwrite,
+}
+
+impl ClashPolicy {
+    fn flag(self) -> &'static str {
+        match self {
+            Self::Skip => "s",
+            Self::Overwrite => "o",
+        }
+    }
+}
+
+/// GNU mtools driven through its command-line programs. mtools reads
+/// `/etc/mtools.conf`, `$HOME/.mtoolsrc`, and `$MTOOLSRC` cumulatively, so the
+/// run points `MTOOLSRC` at an empty file and `HOME` at an empty directory to
+/// keep the host's user configuration out of it.
 pub struct MtoolsFatAdapter {
     image: PathBuf,
     config: PathBuf,
+    home: PathBuf,
     scratch: PathBuf,
     next_file: usize,
 }
@@ -32,18 +52,45 @@ impl MtoolsFatAdapter {
     pub fn new(image: PathBuf, workspace: &Path) -> Result<Self, String> {
         let config = workspace.join("mtoolsrc");
         std::fs::write(&config, []).map_err(|error| error.to_string())?;
+        let home = workspace.join("mtools-home");
+        std::fs::create_dir_all(&home).map_err(|error| error.to_string())?;
         let scratch = workspace.join("mtools-inputs");
         std::fs::create_dir_all(&scratch).map_err(|error| error.to_string())?;
         Ok(Self {
             image,
             config,
+            home,
             scratch,
             next_file: 0,
         })
     }
 
     fn run(&self, program: &str, args: Vec<OsString>) -> Result<Output, String> {
-        run_command_with_env(program, args, &[("MTOOLSRC", self.config.as_os_str())])
+        run_command_with_env(
+            program,
+            args,
+            &[
+                ("MTOOLSRC", self.config.as_os_str()),
+                ("HOME", self.home.as_os_str()),
+            ],
+        )
+    }
+
+    /// Runs a command that writes to the image, with the clash policy set.
+    fn run_write(
+        &self,
+        program: &str,
+        clash: ClashPolicy,
+        args: impl IntoIterator<Item = OsString>,
+    ) -> Result<Output, String> {
+        let mut full_args: Vec<OsString> = vec![
+            "-i".into(),
+            self.image.as_os_str().into(),
+            "-D".into(),
+            clash.flag().into(),
+        ];
+        full_args.extend(args);
+        self.run(program, full_args)
     }
 
     fn write_host_file(&mut self, contents: &[u8]) -> Result<PathBuf, String> {
@@ -55,28 +102,20 @@ impl MtoolsFatAdapter {
         Ok(path)
     }
 
-    fn put_file(
-        &mut self,
-        path: &str,
-        contents: &[u8],
-        preserve_attrs: bool,
-    ) -> Result<(), String> {
-        let attrs = if preserve_attrs {
-            self.read_attrs(&[path.to_string()])?.get(path).copied()
+    /// Copies `contents` to `path`. Overwriting replaces an existing file, whose
+    /// attributes mcopy would otherwise reset, so they are read first and put back.
+    fn put_file(&mut self, path: &str, contents: &[u8], overwrite: bool) -> Result<(), String> {
+        let (clash, attrs) = if overwrite {
+            let attrs = self.read_attrs(&[path.to_string()])?.get(path).copied();
+            (ClashPolicy::Overwrite, attrs)
         } else {
-            None
+            (ClashPolicy::Skip, None)
         };
         let source = self.write_host_file(contents)?;
-        self.run(
+        self.run_write(
             "mcopy",
-            vec![
-                "-i".into(),
-                self.image.as_os_str().into(),
-                "-D".into(),
-                if preserve_attrs { "o" } else { "s" }.into(),
-                source.as_os_str().into(),
-                mtools_path(path).into(),
-            ],
+            clash,
+            [source.as_os_str().into(), mtools_path(path).into()],
         )?;
         if let Some(attrs) = attrs {
             self.set_attrs(path, attrs)?;
@@ -200,16 +239,7 @@ impl FatAdapter for MtoolsFatAdapter {
     fn apply(&mut self, operation: &Operation) -> Result<(), String> {
         match operation {
             Operation::CreateDir { path } => {
-                self.run(
-                    "mmd",
-                    vec![
-                        "-i".into(),
-                        self.image.as_os_str().into(),
-                        "-D".into(),
-                        "s".into(),
-                        mtools_path(path).into(),
-                    ],
-                )?;
+                self.run_write("mmd", ClashPolicy::Skip, [mtools_path(path).into()])?;
                 Ok(())
             }
             Operation::CreateFile { path, data } => self.put_file(path, data, false),
@@ -225,16 +255,10 @@ impl FatAdapter for MtoolsFatAdapter {
                 self.put_file(path, &contents, true)
             }
             Operation::Rename { from, to } => {
-                self.run(
+                self.run_write(
                     "mren",
-                    vec![
-                        "-i".into(),
-                        self.image.as_os_str().into(),
-                        "-D".into(),
-                        "s".into(),
-                        mtools_path(from).into(),
-                        mtools_path(to).into(),
-                    ],
+                    ClashPolicy::Skip,
+                    [mtools_path(from).into(), mtools_path(to).into()],
                 )?;
                 Ok(())
             }

--- a/tests/suite/fat/peers.rs
+++ b/tests/suite/fat/peers.rs
@@ -17,6 +17,7 @@ use hadris_tests::fat::{
     apply_operations_without_attrs, apply_rejection, clear_mutable_attrs, compare_snapshot,
     format_trace, spec, summarize_operation,
 };
+use hadris_tests::harness::command::REQUIRE_TOOLS_ENV;
 use hadris_tests::harness::{Scorecard, Workspace, catch_panic, write_report};
 
 const FATFS_READS: &str = "rust-fatfs reading Hadris";
@@ -409,72 +410,52 @@ fn external_tools_interoperate_with_hadris() {
     scorecard
         .require_all(&[
             (MTOOLS_READS, FAT_CASES.len()),
+            (MTOOLS_WRITES, FAT_CASES.len()),
             (FSCK_HADRIS, FAT_CASES.len()),
         ])
         .unwrap();
+    if std::env::var_os(REQUIRE_TOOLS_ENV).is_some() {
+        assert_eq!(
+            scorecard.command_failures,
+            0,
+            "external tool commands failed:\n{}",
+            scorecard.report()
+        );
+    }
 }
 
+/// mtools must refuse a clash instead of prompting, and leave the image
+/// spec-valid, for the shared duplicate-name scenarios and a case-only rename.
 #[test]
 fn mtools_collisions_are_noninteractive() {
     if !mtools::require_tools() {
         return;
     }
     let case = FAT_CASES[0];
-    let workspace = Workspace::new(FORMAT, "mtools-case-only-rename-").unwrap();
-    let image = workspace.path.join("mtools.img");
-    mtools::format(&image, case).unwrap();
-    let mut adapter = MtoolsFatAdapter::new(image, &workspace.path).unwrap();
-    adapter
-        .apply(&Operation::CreateFile {
+    let shared = ["duplicate-short-name-case", "duplicate-long-directory-case"];
+    let mut scenarios = rejection_scenarios()
+        .into_iter()
+        .filter(|scenario| shared.contains(&scenario.name.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(scenarios.len(), shared.len());
+    scenarios.push(RejectionScenario {
+        name: "case-only-rename".into(),
+        setup: vec![Operation::CreateFile {
             path: "/lower.txt".into(),
             data: b"contents".to_vec(),
-        })
+        }],
+        rejected: Operation::Rename {
+            from: "/lower.txt".into(),
+            to: "/LOWER.TXT".into(),
+        },
+    });
+    let mut scorecard = mtools_scorecard();
+    for scenario in &scenarios {
+        measure_mtools_rejection(case, scenario, &mut scorecard).unwrap();
+    }
+    scorecard
+        .require_all(&[(MTOOLS_REJECTS, scenarios.len())])
         .unwrap();
-    let before = adapter.snapshot().unwrap();
-    assert!(
-        adapter
-            .apply(&Operation::Rename {
-                from: "/lower.txt".into(),
-                to: "/LOWER.TXT".into(),
-            })
-            .is_err()
-    );
-    let after = adapter.snapshot().unwrap();
-    compare_snapshot("mtools rejected case-only rename", &before, &after).unwrap();
-
-    adapter
-        .apply(&Operation::CreateDir {
-            path: "/Long Directory Name".into(),
-        })
-        .unwrap();
-    let before = adapter.snapshot().unwrap();
-    assert!(
-        adapter
-            .apply(&Operation::CreateDir {
-                path: "/long directory name".into(),
-            })
-            .is_err()
-    );
-    let after = adapter.snapshot().unwrap();
-    compare_snapshot("mtools rejected duplicate directory", &before, &after).unwrap();
-
-    adapter
-        .apply(&Operation::CreateFile {
-            path: "/README.TXT".into(),
-            data: b"original".to_vec(),
-        })
-        .unwrap();
-    let before = adapter.snapshot().unwrap();
-    assert!(
-        adapter
-            .apply(&Operation::CreateFile {
-                path: "/readme.txt".into(),
-                data: b"replacement".to_vec(),
-            })
-            .is_err()
-    );
-    let after = adapter.snapshot().unwrap();
-    compare_snapshot("mtools rejected duplicate file", &before, &after).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Three cleanups in the FAT peer tests, found while reviewing #103.

- **#108:** the mtools adapter now points `HOME` at an empty directory inside the workspace. mtools reads `~/.mtoolsrc` regardless of `MTOOLSRC`, so a developer with `mtools_no_vfat=1` or `mtools_skip_check` got spurious results. The struct comment now says what is and is not isolated (`/etc/mtools.conf` still applies).
- **#110:** write commands go through one `run_write` prefix that always carries `-i <image> -D <policy>`, with an explicit `ClashPolicy` instead of deriving it from `preserve_attrs`. `put_file` takes an `overwrite` flag, which is what `ReplaceFile`, `AppendFile`, and `TruncateFile` actually rely on. The collision test runs the shared `duplicate-short-name-case` and `duplicate-long-directory-case` scenarios plus a local case-only rename through `measure_mtools_rejection`, so mtools is checked against the spec oracle and fsck rather than against itself.
- **#107:** `external_tools_interoperate_with_hadris` now requires `MTOOLS_WRITES` for every FAT case, and asserts zero external command failures when `HADRIS_REQUIRE_EXTERNAL_TOOLS` is set.

Verified locally with mtools 4.0.49 and dosfstools 4.2: `HADRIS_REQUIRE_EXTERNAL_TOOLS=1 cargo test --manifest-path tests/Cargo.toml fat::peers::` passes (3 passed, 2 ignored), plus `cargo fmt` and `cargo clippy --manifest-path tests/Cargo.toml --all-targets -- -D warnings`.

Closes #107, closes #108, closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)