### PR TITLE
tests: fail QEMU boot tests when the image does not boot

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -60,6 +60,7 @@ cargo test --manifest-path tests/Cargo.toml              # hosted suite
 cargo test --manifest-path tests/Cargo.toml fat::        # one format
 cargo test --manifest-path tests/Cargo.toml iso::boot::  # one topic
 cargo test --manifest-path tests/Cargo.toml -- --ignored # manual peer reports
+cargo test --manifest-path tests/Cargo.toml iso::boot::test_qemu_boot -- --ignored # QEMU boot checks
 
 # Require every command-line peer tool through the repository flake
 nix develop -c env HADRIS_REQUIRE_EXTERNAL_TOOLS=1 \
@@ -69,7 +70,10 @@ nix develop -c env HADRIS_REQUIRE_EXTERNAL_TOOLS=1 \
 FAT and ISO use the same three test tiers. Hosted oracle tests always run.
 External-tool interoperability tests skip when their tools are absent, while
 CI sets `HADRIS_REQUIRE_EXTERNAL_TOOLS=1` to make them mandatory. Accuracy
-reports, QEMU checks, and privileged native-mount checks are `#[ignore]`d.
+reports, QEMU checks, and privileged native-mount checks are `#[ignore]`d and
+run only with `-- --ignored`; the QEMU boot checks fail when the image does not
+boot, skip when QEMU is absent, and treat a missing QEMU as a failure under
+`HADRIS_REQUIRE_EXTERNAL_TOOLS=1`.
 The commands and environment variables are documented in the repository
 [`CONTRIBUTING.md`](../CONTRIBUTING.md#conformance-and-interoperability-suite).
 Reports are written to `tests/target/reports/<format>/`.

--- a/tests/src/harness/qemu.rs
+++ b/tests/src/harness/qemu.rs
@@ -10,6 +10,12 @@ pub fn available() -> bool {
     super::command::program_available(PROGRAM, "--version")
 }
 
+/// Skips the calling test when QEMU is absent, or panics when
+/// [`REQUIRE_TOOLS_ENV`](super::command::REQUIRE_TOOLS_ENV) is set.
+pub fn require() -> bool {
+    super::command::require_or_skip(PROGRAM, "--version")
+}
+
 /// Boots `iso` headlessly with the serial console on stdout and returns what
 /// the guest printed before it halted or the timeout expired.
 pub fn boot_serial_output(iso: &Path, timeout: Duration) -> Option<String> {
@@ -22,10 +28,13 @@ pub fn boot_serial_output(iso: &Path, timeout: Duration) -> Option<String> {
             "-nographic",
             "-serial",
             "stdio",
+            "-monitor",
+            "none",
             "-no-reboot",
             "-m",
             "16",
         ])
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()

--- a/tests/suite/iso/boot.rs
+++ b/tests/suite/iso/boot.rs
@@ -373,11 +373,7 @@ fn test_compare_boot_catalogs() {
 #[test]
 #[ignore = "requires QEMU system emulation"]
 fn test_qemu_boot_xorriso_iso() {
-    if !xorriso::require() {
-        return;
-    }
-    if !qemu::available() {
-        eprintln!("skipping: {} is not available", qemu::PROGRAM);
+    if !xorriso::require() || !qemu::require() {
         return;
     }
     let temp_dir = TempDir::new().unwrap();
@@ -391,24 +387,18 @@ fn test_qemu_boot_xorriso_iso() {
     .unwrap();
     xorriso::create_bootable(&content_dir, &iso_path, "boot.bin").unwrap();
 
-    match qemu::boot_serial_output(&iso_path, Duration::from_secs(5)) {
-        Some(stdout) => {
-            println!("QEMU stdout: {stdout}");
-            if stdout.contains("OK") {
-                println!("xorriso ISO boots successfully in QEMU");
-            } else {
-                println!("Note: boot code may not have executed as expected");
-            }
-        }
-        None => println!("QEMU command failed to run"),
-    }
+    let stdout = qemu::boot_serial_output(&iso_path, Duration::from_secs(5))
+        .expect("QEMU command failed to run");
+    assert!(
+        stdout.contains("OK"),
+        "xorriso ISO did not print the boot marker in QEMU; serial output: {stdout:?}"
+    );
 }
 
 #[test]
 #[ignore = "requires QEMU system emulation"]
 fn test_qemu_boot_hadris_iso() {
-    if !qemu::available() {
-        eprintln!("skipping: {} is not available", qemu::PROGRAM);
+    if !qemu::require() {
         return;
     }
     let temp_dir = TempDir::new().unwrap();
@@ -416,29 +406,23 @@ fn test_qemu_boot_hadris_iso() {
     let iso_data = hadris_bootable_image(padded_boot_image(&SERIAL_OK_BOOT_CODE));
     fs::write(&iso_path, &iso_data).expect("Failed to write ISO file");
 
-    match qemu::boot_serial_output(&iso_path, Duration::from_secs(5)) {
-        Some(stdout) => {
-            println!("QEMU stdout: {stdout}");
-            if stdout.contains("OK") {
-                println!("hadris-iso ISO boots successfully in QEMU");
-            } else {
-                println!("Note: boot code may not have executed as expected");
-                if let Some((sector, catalog_lba)) = find_boot_catalog(&iso_data) {
-                    let catalog_offset = catalog_lba * 2048;
-                    let default = &iso_data[catalog_offset + 32..catalog_offset + 64];
-                    let load_rba =
-                        u32::from_le_bytes([default[8], default[9], default[10], default[11]]);
-                    println!("boot record at sector {sector}, catalog LBA {catalog_lba}");
-                    println!("default entry boot indicator {:#04x}", default[0]);
-                    println!("default load RBA {load_rba}");
-                    let boot_offset = load_rba as usize * 2048;
-                    println!(
-                        "boot image first 16 bytes: {:02x?}",
-                        &iso_data[boot_offset..boot_offset + 16]
-                    );
-                }
-            }
+    let stdout = qemu::boot_serial_output(&iso_path, Duration::from_secs(5))
+        .expect("QEMU command failed to run");
+    if !stdout.contains("OK") {
+        println!("QEMU stdout: {stdout}");
+        if let Some((sector, catalog_lba)) = find_boot_catalog(&iso_data) {
+            let catalog_offset = catalog_lba * 2048;
+            let default = &iso_data[catalog_offset + 32..catalog_offset + 64];
+            let load_rba = u32::from_le_bytes([default[8], default[9], default[10], default[11]]);
+            println!("boot record at sector {sector}, catalog LBA {catalog_lba}");
+            println!("default entry boot indicator {:#04x}", default[0]);
+            println!("default load RBA {load_rba}");
+            let boot_offset = load_rba as usize * 2048;
+            println!(
+                "boot image first 16 bytes: {:02x?}",
+                &iso_data[boot_offset..boot_offset + 16]
+            );
         }
-        None => println!("QEMU command failed to run"),
+        panic!("hadris ISO did not print the boot marker in QEMU");
     }
 }


### PR DESCRIPTION
Closes #109

The two `test_qemu_boot_*` tests in `tests/suite/iso/boot.rs` only printed a note when the "OK" serial marker was missing, so an unbootable El Torito image passed both. They now assert on the marker and go through the suite's require-or-skip helper (new `qemu::require`), so they skip when QEMU is absent and fail under `HADRIS_REQUIRE_EXTERNAL_TOOLS=1`, matching the rule in `tests/README.md`.

While making them assert, the tests failed on this machine because QEMU exited immediately: with `-nographic -serial stdio` the monitor was multiplexed onto stdio and read EOF from the test's stdin, so the guest never booted and the serial output was the monitor banner. The harness now passes `-monitor none` and detaches stdin. Both images then print the marker.

The tests stay `#[ignore]`d since CI does not install QEMU; the README now documents the exact command that runs them.

Verified locally with QEMU 11.1.0:
- `cargo test --manifest-path tests/Cargo.toml iso::boot::test_qemu_boot -- --ignored`: 2 passed
- Same command with the boot code changed to halt before printing: `test_qemu_boot_hadris_iso` FAILED with "hadris ISO did not print the boot marker in QEMU"
- `cargo fmt --all -- --check` and `cargo clippy --manifest-path tests/Cargo.toml --all-targets -- -D warnings` clean

Follow-up, out of scope here: `flake.nix` pulls the all-targets `pkgs.qemu` (about 2.3 GB) into the default dev shell for a manual tier that CI never runs. A separate `devShells.boot` or a host-only QEMU variant would keep the default shell small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)