### PR TITLE
fix: address review findings from the streaming and iteration merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,17 @@ Each published package owns its version and may be released independently.
   error instead of returning the same error on every call.
   ([@zone117x](https://github.com/zone117x),
   [#113](https://github.com/hxyulin/hadris/pull/113))
-- **hadris-iso:** Images too large for an MBR or GPT partition entry now fail
-  with `InvalidInput` instead of writing a truncated sector count.
+- **hadris-iso:** Images too large for an MBR partition entry or for the
+  32-bit ISO 9660 volume space size now fail with `InvalidInput` instead of
+  writing a truncated sector count.
   ([#105](https://github.com/hxyulin/hadris/issues/105))
+- **hadris-iso:** Path table iteration now stops after an I/O or parse error
+  instead of returning the same error on every call.
+- **hadris-udf:** Files of 1 GiB or more are now recorded with several short
+  allocation descriptors. The single descriptor written before overflowed its
+  30-bit extent length, so such files read back empty or truncated.
+- **hadris-udf (`unstable-streaming`):** An interrupted read from a
+  `FileSource` is retried instead of failing the image.
 
 ## [2.3.0] - 2026-09-02
 

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -114,10 +114,11 @@ it adds the `Source` variant to `InputEntryKind`, so exhaustive matches on that
 enum must account for it.
 
 ```rust,ignore
+use std::sync::Arc;
 use hadris_iso::write::{FileSource, InputEntry, InputEntryKind, InputMetadata};
 
 let entry = InputEntry {
-    name: "movie.mkv".into(),
+    name: Arc::new("movie.mkv".to_string()),
     kind: InputEntryKind::Source(FileSource::from_path("movie.mkv")?),
     metadata: InputMetadata::default(),
 };

--- a/crates/optical/hadris-iso/src/path.rs
+++ b/crates/optical/hadris-iso/src/path.rs
@@ -185,17 +185,27 @@ pub struct PathTableEntryIter<'a, DATA: Read + Seek> {
 impl<DATA: Read + Seek> Iterator for PathTableEntryIter<'_, DATA> {
     type Item = io::Result<PathTableEntry>;
 
-    /// Undefined if continued reading after IO error
+    /// An error ends the iteration: later calls return `None`.
     fn next(&mut self) -> Option<Self::Item> {
-        use super::io::try_io_result_option as try_io;
+        macro_rules! try_or_end {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(val) => val,
+                    Err(err) => {
+                        self.current = self.end;
+                        return Some(Err(err));
+                    }
+                }
+            };
+        }
         if self.current >= self.end {
             return None;
         }
         let mut data = self.data.lock();
-        try_io!(data
+        try_or_end!(data
             .seek(SeekFrom::Start(self.current))
             .map_err(Error::erase));
-        let entry = try_io!(PathTableEntry::parse(
+        let entry = try_or_end!(PathTableEntry::parse(
             data.deref_mut(),
             EndianType::NativeEndian,
         ));

--- a/crates/optical/hadris-iso/src/write/options.rs
+++ b/crates/optical/hadris-iso/src/write/options.rs
@@ -79,9 +79,10 @@ impl HybridBootOptions {
 
 /// The partition scheme to use for hybrid boot.
 ///
-/// MBR partition entries and the ISO 9660 volume space size are 32-bit sector
-/// counts, so `Mbr` and `Hybrid` layouts are limited to 2 TiB of 512-byte
-/// sectors; a larger image fails to write with `InvalidInput`.
+/// MBR partition entries hold 32-bit counts of 512-byte sectors, so `Mbr` and
+/// `Hybrid` layouts are limited to 2 TiB. The ISO 9660 volume space size is a
+/// 32-bit count of logical sectors, so every scheme is limited to 2^32 logical
+/// sectors. A larger image fails to write with `InvalidInput`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PartitionScheme {
     /// No partition table (CD/DVD only, not USB bootable).

--- a/crates/optical/hadris-iso/src/write/types.rs
+++ b/crates/optical/hadris-iso/src/write/types.rs
@@ -254,6 +254,22 @@ impl FileSource {
     ///
     /// The file is opened when the image is written; its length must not change
     /// in between.
+    ///
+    /// ```
+    /// # #[cfg(feature = "unstable-streaming")] {
+    /// use hadris_iso::write::FileSource;
+    ///
+    /// let path = std::env::temp_dir().join("hadris-iso-file-source-doc.bin");
+    /// std::fs::write(&path, b"streamed")?;
+    /// let source = FileSource::from_path(&path)?;
+    /// assert_eq!(source.len(), 8);
+    /// let mut contents = Vec::new();
+    /// source.open()?.read_to_end(&mut contents)?;
+    /// assert_eq!(contents, b"streamed");
+    /// # std::fs::remove_file(&path)?;
+    /// # }
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn from_path(path: impl Into<PathBuf>) -> std::io::Result<Self> {
         let path = path.into();
         let len = std::fs::metadata(&path)?.len();

--- a/crates/optical/hadris-udf/src/write/mod.rs
+++ b/crates/optical/hadris-udf/src/write/mod.rs
@@ -605,7 +605,8 @@ impl<W: Write + Seek> UdfFormatter<W> {
             let file_len = file.len();
             let data_block = if file_len > 0 {
                 let block = self.allocate_block();
-                let data_sectors = file_len.div_ceil(SECTOR_SIZE as u64) as u32;
+                let data_sectors = u32::try_from(file_len.div_ceil(SECTOR_SIZE as u64))
+                    .map_err(|_| crate::error::Error::TooManyAllocationDescriptors)?;
                 for _ in 1..data_sectors {
                     self.allocate_block();
                 }
@@ -694,14 +695,7 @@ impl<W: Write + Seek> UdfFormatter<W> {
 
         // Write file File Entries and data
         for file in &dir.files {
-            let file_alloc = if file.data_length > 0 {
-                vec![ShortAllocationDescriptor {
-                    extent_length: file.data_length as u32,
-                    extent_position: file.data_block,
-                }]
-            } else {
-                vec![]
-            };
+            let file_alloc = short_allocation_descriptors(file.data_block, file.data_length);
 
             self.writer.write_file_entry(
                 file.icb_block,
@@ -763,19 +757,46 @@ impl<W: Write + Seek> UdfFormatter<W> {
         let mut remaining = len;
         let mut buffer = vec![0u8; 256 * 1024];
         while remaining > 0 {
-            let want = buffer.len().min(remaining as usize);
-            let got = std::io::Read::read(&mut reader, &mut buffer[..want]).map_err(io_error)?;
-            if got == 0 {
-                return Err(crate::error::Error::Io(hadris_io::Error::Context {
-                    kind: hadris_io::ErrorKind::UnexpectedEof,
-                    message: Some("file source ended before its declared length"),
-                }));
-            }
+            let want = usize::try_from(remaining.min(buffer.len() as u64)).unwrap_or(buffer.len());
+            let got = match std::io::Read::read(&mut reader, &mut buffer[..want]) {
+                Ok(0) => {
+                    return Err(crate::error::Error::Io(hadris_io::Error::Context {
+                        kind: hadris_io::ErrorKind::UnexpectedEof,
+                        message: Some("file source ended before its declared length"),
+                    }));
+                }
+                Ok(got) => got,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(io_error(error)),
+            };
             self.writer.writer.write_all(&buffer[..got])?;
             remaining -= got as u64;
         }
         Ok(())
     }
+}
+
+/// The largest extent a short allocation descriptor can describe: its length
+/// field is 30 bits and the top two bits carry the extent type, rounded down to
+/// a whole number of sectors so every extent but the last stays sector-aligned.
+const MAX_SHORT_AD_LENGTH: u64 = (1 << 30) - SECTOR_SIZE as u64;
+
+/// Describes `len` contiguous bytes starting at `data_block` with as many
+/// short allocation descriptors as the 30-bit extent length requires.
+fn short_allocation_descriptors(data_block: u32, len: u64) -> Vec<ShortAllocationDescriptor> {
+    let mut descriptors = Vec::new();
+    let mut position = data_block;
+    let mut remaining = len;
+    while remaining > 0 {
+        let extent = remaining.min(MAX_SHORT_AD_LENGTH);
+        descriptors.push(ShortAllocationDescriptor {
+            extent_length: extent as u32,
+            extent_position: position,
+        });
+        position += (MAX_SHORT_AD_LENGTH / SECTOR_SIZE as u64) as u32;
+        remaining -= extent;
+    }
+    descriptors
 }
 
 // =============================================================================
@@ -1784,6 +1805,74 @@ mod tests {
         ));
         let mut buffer = vec![0u8; 2 * 1024 * 1024];
         assert!(UdfWriter::create(Cursor::new(&mut buffer[..]), &root, UdfWriteOptions::default()).is_err());
+    }
+
+    #[test]
+    fn large_files_are_split_across_short_allocation_descriptors() {
+        assert!(short_allocation_descriptors(7, 0).is_empty());
+
+        let single = short_allocation_descriptors(7, MAX_SHORT_AD_LENGTH);
+        assert_eq!(single.len(), 1);
+        assert_eq!(single[0].length() as u64, MAX_SHORT_AD_LENGTH);
+        assert_eq!(single[0].extent_position, 7);
+
+        let split = short_allocation_descriptors(7, MAX_SHORT_AD_LENGTH + 1);
+        assert_eq!(split.len(), 2);
+        assert_eq!(split[0].length() as u64, MAX_SHORT_AD_LENGTH);
+        assert_eq!(split[1].length(), 1);
+        assert_eq!(
+            split[1].extent_position as u64,
+            7 + MAX_SHORT_AD_LENGTH / SECTOR_SIZE as u64
+        );
+
+        let three_gib = short_allocation_descriptors(0, 3 << 30);
+        assert_eq!(three_gib.len(), 4);
+        assert_eq!(
+            three_gib.iter().map(|ad| ad.length() as u64).sum::<u64>(),
+            3 << 30
+        );
+        for ad in &three_gib {
+            assert_eq!(ad.extent_length >> 30, 0, "extent type bits must stay clear");
+        }
+    }
+
+    #[cfg(feature = "unstable-streaming")]
+    #[test]
+    fn an_interrupted_read_is_retried() {
+        struct Flaky {
+            inner: Cursor<Vec<u8>>,
+            interruptions: usize,
+        }
+
+        impl std::io::Read for Flaky {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if self.interruptions > 0 {
+                    self.interruptions -= 1;
+                    return Err(std::io::Error::from(std::io::ErrorKind::Interrupted));
+                }
+                self.inner.read(buf)
+            }
+        }
+
+        let payload = vec![0xA5u8; 5000];
+        let mut root = SimpleDir::root();
+        let data = payload.clone();
+        root.add_file(SimpleFile::from_source(
+            "flaky.bin",
+            FileSource::new(payload.len() as u64, move || {
+                Ok(Box::new(Flaky {
+                    inner: Cursor::new(data.clone()),
+                    interruptions: 2,
+                }) as Box<dyn std::io::Read + Send>)
+            }),
+        ));
+
+        let mut buffer = vec![0u8; 2 * 1024 * 1024];
+        UdfWriter::create(Cursor::new(&mut buffer[..]), &root, UdfWriteOptions::default()).unwrap();
+        let udf = crate::UdfVolume::open(Cursor::new(&buffer[..])).unwrap();
+        let dir = udf.root_dir().unwrap();
+        let entry = dir.find("flaky.bin").unwrap();
+        assert_eq!(udf.read_file(entry).unwrap(), payload);
     }
 
     #[test]

--- a/tests/src/fat/mtools.rs
+++ b/tests/src/fat/mtools.rs
@@ -36,10 +36,22 @@ impl ClashPolicy {
     }
 }
 
+/// Settings the generated `mtoolsrc` pins, so a global `/etc/mtools.conf`
+/// cannot change how names are listed or how the image is checked. The file
+/// is read after the global one and overrides it.
+const MTOOLSRC_DEFAULTS: &str = "MTOOLS_LOWER_CASE=0
+MTOOLS_SKIP_CHECK=0
+MTOOLS_NO_VFAT=0
+MTOOLS_FAT_COMPATIBILITY=0
+MTOOLS_DOTTED_DIR=0
+MTOOLS_NAME_NUMERIC_TAIL=1
+";
+
 /// GNU mtools driven through its command-line programs. mtools reads
-/// `/etc/mtools.conf`, `$HOME/.mtoolsrc`, and `$MTOOLSRC` cumulatively, so the
-/// run points `MTOOLSRC` at an empty file and `HOME` at an empty directory to
-/// keep the host's user configuration out of it.
+/// `/etc/mtools.conf`, `$HOME/.mtoolsrc`, `$MTOOLSRC`, and `MTOOLS_*`
+/// environment variables cumulatively, so the run points `MTOOLSRC` at a file
+/// with fixed settings, `HOME` at an empty directory, and drops every
+/// inherited `MTOOLS_*` variable to keep the host's configuration out of it.
 pub struct MtoolsFatAdapter {
     image: PathBuf,
     config: PathBuf,
@@ -51,7 +63,7 @@ pub struct MtoolsFatAdapter {
 impl MtoolsFatAdapter {
     pub fn new(image: PathBuf, workspace: &Path) -> Result<Self, String> {
         let config = workspace.join("mtoolsrc");
-        std::fs::write(&config, []).map_err(|error| error.to_string())?;
+        std::fs::write(&config, MTOOLSRC_DEFAULTS).map_err(|error| error.to_string())?;
         let home = workspace.join("mtools-home");
         std::fs::create_dir_all(&home).map_err(|error| error.to_string())?;
         let scratch = workspace.join("mtools-inputs");
@@ -73,6 +85,7 @@ impl MtoolsFatAdapter {
                 ("MTOOLSRC", self.config.as_os_str()),
                 ("HOME", self.home.as_os_str()),
             ],
+            &["MTOOLS_"],
         )
     }
 

--- a/tests/src/harness/command.rs
+++ b/tests/src/harness/command.rs
@@ -26,7 +26,10 @@ pub fn run_command_with_env(
     command.args(&args).env("LC_ALL", "C.UTF-8");
     for (key, _) in std::env::vars_os() {
         let name = key.to_string_lossy();
-        if remove_prefixes.iter().any(|prefix| name.starts_with(prefix)) {
+        if remove_prefixes
+            .iter()
+            .any(|prefix| name.starts_with(prefix))
+        {
             command.env_remove(&key);
         }
     }

--- a/tests/src/harness/command.rs
+++ b/tests/src/harness/command.rs
@@ -6,13 +6,16 @@ use std::process::{Command, Output};
 pub const REQUIRE_TOOLS_ENV: &str = "HADRIS_REQUIRE_EXTERNAL_TOOLS";
 
 pub fn run_command(program: &str, args: Vec<OsString>) -> Result<Output, String> {
-    run_command_with_env(program, args, &[])
+    run_command_with_env(program, args, &[], &[])
 }
 
+/// Runs `program` with `env` added and every inherited variable whose name
+/// starts with one of `remove_prefixes` dropped.
 pub fn run_command_with_env(
     program: &str,
     args: Vec<OsString>,
     env: &[(&str, &OsStr)],
+    remove_prefixes: &[&str],
 ) -> Result<Output, String> {
     let printable = args
         .iter()
@@ -21,6 +24,12 @@ pub fn run_command_with_env(
         .join(" ");
     let mut command = Command::new(program);
     command.args(&args).env("LC_ALL", "C.UTF-8");
+    for (key, _) in std::env::vars_os() {
+        let name = key.to_string_lossy();
+        if remove_prefixes.iter().any(|prefix| name.starts_with(prefix)) {
+            command.env_remove(&key);
+        }
+    }
     for (key, value) in env {
         command.env(key, value);
     }

--- a/tests/src/harness/qemu.rs
+++ b/tests/src/harness/qemu.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -17,8 +18,9 @@ pub fn require() -> bool {
 }
 
 /// Boots `iso` headlessly with the serial console on stdout and returns what
-/// the guest printed before it halted or the timeout expired.
-pub fn boot_serial_output(iso: &Path, timeout: Duration) -> Option<String> {
+/// the guest printed. Returns as soon as the output contains `marker`, or when
+/// QEMU exits or `timeout` expires; QEMU is killed and reaped either way.
+pub fn boot_serial_output(iso: &Path, marker: &str, timeout: Duration) -> Option<String> {
     let mut child = Command::new(PROGRAM)
         .args([
             "-cdrom",
@@ -40,22 +42,37 @@ pub fn boot_serial_output(iso: &Path, timeout: Duration) -> Option<String> {
         .spawn()
         .ok()?;
 
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let reader = {
+        let output = Arc::clone(&output);
+        let mut stdout = child.stdout.take()?;
+        thread::spawn(move || {
+            let mut chunk = [0u8; 4096];
+            while let Ok(read) = stdout.read(&mut chunk) {
+                if read == 0 {
+                    break;
+                }
+                output.lock().unwrap().extend_from_slice(&chunk[..read]);
+            }
+        })
+    };
+
     let start = Instant::now();
     loop {
+        if String::from_utf8_lossy(&output.lock().unwrap()).contains(marker) {
+            break;
+        }
         match child.try_wait() {
             Ok(Some(_)) => break,
-            Ok(None) if start.elapsed() > timeout => {
-                let _ = child.kill();
-                break;
-            }
-            Ok(None) => thread::sleep(Duration::from_millis(100)),
+            Ok(None) if start.elapsed() > timeout => break,
+            Ok(None) => thread::sleep(Duration::from_millis(50)),
             Err(_) => break,
         }
     }
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
 
-    let mut stdout = String::new();
-    if let Some(mut out) = child.stdout.take() {
-        let _ = out.read_to_string(&mut stdout);
-    }
-    Some(stdout)
+    let output = output.lock().unwrap();
+    Some(String::from_utf8_lossy(&output).into_owned())
 }

--- a/tests/suite/iso/boot.rs
+++ b/tests/suite/iso/boot.rs
@@ -17,10 +17,27 @@ use tempfile::TempDir;
 
 use super::{find_boot_catalog, validation_checksum};
 
-/// x86 code that writes "OK\n" to COM1 and halts.
-const SERIAL_OK_BOOT_CODE: [u8; 15] = [
-    0xB0, 0x4F, // mov al, 'O'
+/// The line the boot code prints, chosen so firmware chatter cannot match it.
+const BOOT_MARKER: &str = "HADRIS-OK";
+
+/// x86 code that writes the boot marker and a newline to COM1 and halts.
+const SERIAL_OK_BOOT_CODE: [u8; 36] = [
     0xBA, 0xF8, 0x03, // mov dx, 0x3F8
+    0xB0, 0x48, // mov al, 'H'
+    0xEE, // out dx, al
+    0xB0, 0x41, // mov al, 'A'
+    0xEE, // out dx, al
+    0xB0, 0x44, // mov al, 'D'
+    0xEE, // out dx, al
+    0xB0, 0x52, // mov al, 'R'
+    0xEE, // out dx, al
+    0xB0, 0x49, // mov al, 'I'
+    0xEE, // out dx, al
+    0xB0, 0x53, // mov al, 'S'
+    0xEE, // out dx, al
+    0xB0, 0x2D, // mov al, '-'
+    0xEE, // out dx, al
+    0xB0, 0x4F, // mov al, 'O'
     0xEE, // out dx, al
     0xB0, 0x4B, // mov al, 'K'
     0xEE, // out dx, al
@@ -387,10 +404,10 @@ fn test_qemu_boot_xorriso_iso() {
     .unwrap();
     xorriso::create_bootable(&content_dir, &iso_path, "boot.bin").unwrap();
 
-    let stdout = qemu::boot_serial_output(&iso_path, Duration::from_secs(5))
+    let stdout = qemu::boot_serial_output(&iso_path, BOOT_MARKER, Duration::from_secs(30))
         .expect("QEMU command failed to run");
     assert!(
-        stdout.contains("OK"),
+        stdout.contains(BOOT_MARKER),
         "xorriso ISO did not print the boot marker in QEMU; serial output: {stdout:?}"
     );
 }
@@ -406,9 +423,9 @@ fn test_qemu_boot_hadris_iso() {
     let iso_data = hadris_bootable_image(padded_boot_image(&SERIAL_OK_BOOT_CODE));
     fs::write(&iso_path, &iso_data).expect("Failed to write ISO file");
 
-    let stdout = qemu::boot_serial_output(&iso_path, Duration::from_secs(5))
+    let stdout = qemu::boot_serial_output(&iso_path, BOOT_MARKER, Duration::from_secs(30))
         .expect("QEMU command failed to run");
-    if !stdout.contains("OK") {
+    if !stdout.contains(BOOT_MARKER) {
         println!("QEMU stdout: {stdout}");
         if let Some((sector, catalog_lba)) = find_boot_catalog(&iso_data) {
             let catalog_offset = catalog_lba * 2048;

--- a/website/docs/concepts/features.md
+++ b/website/docs/concepts/features.md
@@ -55,7 +55,9 @@ the exFAT preview, and the hybrid ISO/UDF writer.
 | `hadris-fat` `unstable-exfat` | exFAT preview | Partial | Partial | Yes | No | `alloc` | Experimental |
 | `hadris-part` | MBR and GPT | Yes | Yes | Yes | Yes | Allocation-free | Stable |
 | `hadris-iso` | ISO 9660, Joliet, Rock Ridge | Yes | Yes | Yes | Yes | Allocation-free | Stable |
+| `hadris-iso` `unstable-streaming` | Streamed file input for the ISO writer | N/A | Yes | Yes | Yes | `std` | Experimental |
 | `hadris-udf` | UDF 1.02 | Yes | Yes | Yes | Yes | `alloc` for filesystem traversal | Stable |
+| `hadris-udf` `unstable-streaming` | Streamed file input for the UDF writer | N/A | Yes | Yes | No | `std` | Experimental |
 | `hadris-cpio` | CPIO newc and CRC | Yes | Yes | Yes | Yes | Allocation-free | Stable |
 | `hadris-ntfs` | NTFS | Yes | No | Yes | Yes | `alloc` | Experimental |
 | `hadris-cd` | Hybrid ISO/UDF images | N/A | Yes | Yes | No | `std` | Stable |
@@ -111,7 +113,8 @@ hadris-cpio = {
 - Select at least one I/O mode for APIs that access storage.
 - Add `alloc` only when the chosen API returns or stores owned data.
 - Prefer leaf crates when only one format is needed.
-- Treat `unstable-exfat` and `hadris-ntfs` as separately versioned experiments.
+- Treat `unstable-exfat`, `unstable-streaming`, and `hadris-ntfs` as separately
+  versioned experiments.
 
 The workspace CI checks representative allocation-free, `alloc`, `std`, sync,
 async, and combined-mode tiers for every stable format crate.

--- a/website/docs/stability.md
+++ b/website/docs/stability.md
@@ -16,8 +16,8 @@ or the [V2 upgrade notes](https://github.com/hxyulin/hadris/blob/main/docs/hadri
 and report real-world compatibility findings through
 [GitHub Issues](https://github.com/hxyulin/hadris/issues).
 
-The `unstable-exfat` preview and experimental `hadris-ntfs` reader are
-explicitly outside the V2 stability promise.
+The `unstable-exfat` and `unstable-streaming` previews and the experimental
+`hadris-ntfs` reader are explicitly outside the V2 stability promise.
 
 ## Compatibility policy
 


### PR DESCRIPTION
Follow-ups from a review of everything merged since v2.3.0 (#111, #113, #115, #117, #118, #119).

## Library

- **hadris-udf:** files of 1 GiB or more were recorded with a single short allocation descriptor whose 30-bit extent length overflowed, so they read back empty or truncated. Files now get as many descriptors as they need (`short_allocation_descriptors`), and a file whose sector count does not fit the 32-bit partition is rejected with `TooManyAllocationDescriptors` instead of being silently truncated.
- **hadris-udf (`unstable-streaming`):** `copy_from_source` retries `ErrorKind::Interrupted` like the ISO writer, and no longer truncates the remaining length on 32-bit targets.
- **hadris-iso:** `PathTableEntryIter` ends after an I/O or parse error instead of returning it on every call, matching the directory iterator fix from #113.
- **hadris-iso:** the README streaming example now compiles as written (`InputEntry::name` is `Arc<String>`), `FileSource::from_path` has a doctest, and the `PartitionScheme` docs and CHANGELOG describe the MBR and volume-space limits accurately (GPT is bounded by the 32-bit ISO volume space size, not its partition entry).

## Test harness

- mtools runs drop every inherited `MTOOLS_*` variable and the generated `mtoolsrc` pins the listing and checking options a global `/etc/mtools.conf` could otherwise change.
- The QEMU harness reads serial output on a thread and returns as soon as the guest prints the marker, then kills and reaps QEMU (it was left as a zombie before). The boot code prints `HADRIS-OK` so firmware chatter such as SeaBIOS' `Booting from DVD/CD..OK` cannot satisfy the assertion. Both boot tests now finish in well under a second.
- The website feature matrix and stability page list the `unstable-streaming` preview.

## Checks

`cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check --workspace --locked`, clippy with `--all-targets --all-features -D warnings` on hadris-iso, hadris-udf, and the tests crate, `cargo test -p hadris-iso -p hadris-udf --all-features`, `HADRIS_REQUIRE_EXTERNAL_TOOLS=1 cargo test --manifest-path tests/Cargo.toml`, the ignored QEMU boot tests, `cargo doc` with and without features, and the hadris-iso and hadris-udf feature tiers without default features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQRUPpgfwF24t4DJZ2hjL