### PR TITLE
chore: prepare v2.4.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: Version without the v prefix
         required: true
-        default: 2.3.0
+        default: 2.4.0
         type: string
       mode:
         description: Validate packages or publish the release
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Version must be a stable semantic version such as 2.3.0" >&2
+            echo "Version must be a stable semantic version such as 2.4.0" >&2
             exit 1
           fi
           if [[ $(grep -Fc "## [$VERSION] - " CHANGELOG.md) -ne 1 ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Version must be a stable semantic version such as 2.4.0" >&2
+            echo "Version must be a stable semantic version such as 1.2.3" >&2
             exit 1
           fi
           if [[ $(grep -Fc "## [$VERSION] - " CHANGELOG.md) -ne 1 ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Each published package owns its version and may be released independently.
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-09-08
+
 ### Added
 
 - **hadris-iso (`unstable-streaming`):** `InputEntryKind::Source` streams a
@@ -732,7 +734,8 @@ under Semantic Versioning.
 - **Build:** Disabled `thiserror` default features so the workspace builds as
   `no_std`. ([@aruiz](https://github.com/aruiz))
 
-[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/hxyulin/hadris/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/hxyulin/hadris/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/hxyulin/hadris/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/hxyulin/hadris/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/hxyulin/hadris/compare/v2.0.0...v2.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "hadris"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "hadris-archive",
  "hadris-block",
@@ -465,14 +465,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-archive"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "hadris-cpio",
 ]
 
 [[package]]
 name = "hadris-block"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "hadris-fat",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "hadris-io",
  "hadris-iso",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cd-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "hadris-cd",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "hadris-common",
  "hadris-io",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-cpio-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -607,14 +607,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "hadris-io"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "hadris-iso",
@@ -657,14 +657,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-ntfs"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-optical"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "hadris-cd",
  "hadris-io",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-part"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "crc",
@@ -700,11 +700,11 @@ dependencies = [
 
 [[package]]
 name = "hadris-path"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "hadris-storage"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "embedded-io",
  "hadris-io",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-udf-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "hadris-udf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,19 +44,19 @@ anyhow = "1.0"
 libc = "0.2"
 
 # Internal crates
-hadris-macros = { version = "2.3.0", path = "crates/core/hadris-macros" }
-hadris-io = { version = "2.3.0", path = "crates/core/hadris-io", default-features = false }
-hadris-fixed = { version = "2.3.0", path = "crates/core/hadris-fixed", default-features = false }
-hadris-path = { version = "2.3.0", path = "crates/core/hadris-path", default-features = false }
-hadris-common = { version = "2.3.0", path = "crates/core/hadris-common", default-features = false }
-hadris-storage = { version = "2.3.0", path = "crates/core/hadris-storage", default-features = false }
-hadris-block = { version = "2.3.0", path = "crates/block/hadris-block", default-features = false }
-hadris-fat = { version = "2.3.0", path = "crates/block/hadris-fat", default-features = false }
-hadris-part = { version = "2.3.0", path = "crates/block/hadris-part", default-features = false }
-hadris-optical = { version = "2.3.0", path = "crates/optical/hadris-optical", default-features = false }
-hadris-iso = { version = "2.3.0", path = "crates/optical/hadris-iso", default-features = false }
-hadris-udf = { version = "2.3.0", path = "crates/optical/hadris-udf", default-features = false }
-hadris-cd = { version = "2.3.0", path = "crates/optical/hadris-cd", default-features = false }
-hadris-archive = { version = "2.3.0", path = "crates/archive/hadris-archive", default-features = false }
-hadris-cpio = { version = "2.3.0", path = "crates/archive/hadris-cpio", default-features = false }
-hadris-ntfs = { version = "2.3.0", path = "crates/block/hadris-ntfs", default-features = false }
+hadris-macros = { version = "2.4.0", path = "crates/core/hadris-macros" }
+hadris-io = { version = "2.4.0", path = "crates/core/hadris-io", default-features = false }
+hadris-fixed = { version = "2.4.0", path = "crates/core/hadris-fixed", default-features = false }
+hadris-path = { version = "2.4.0", path = "crates/core/hadris-path", default-features = false }
+hadris-common = { version = "2.4.0", path = "crates/core/hadris-common", default-features = false }
+hadris-storage = { version = "2.4.0", path = "crates/core/hadris-storage", default-features = false }
+hadris-block = { version = "2.4.0", path = "crates/block/hadris-block", default-features = false }
+hadris-fat = { version = "2.4.0", path = "crates/block/hadris-fat", default-features = false }
+hadris-part = { version = "2.4.0", path = "crates/block/hadris-part", default-features = false }
+hadris-optical = { version = "2.4.0", path = "crates/optical/hadris-optical", default-features = false }
+hadris-iso = { version = "2.4.0", path = "crates/optical/hadris-iso", default-features = false }
+hadris-udf = { version = "2.4.0", path = "crates/optical/hadris-udf", default-features = false }
+hadris-cd = { version = "2.4.0", path = "crates/optical/hadris-cd", default-features = false }
+hadris-archive = { version = "2.4.0", path = "crates/archive/hadris-archive", default-features = false }
+hadris-cpio = { version = "2.4.0", path = "crates/archive/hadris-cpio", default-features = false }
+hadris-ntfs = { version = "2.4.0", path = "crates/block/hadris-ntfs", default-features = false }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ layers coherent without hiding format-specific capabilities.
 
 Hadris follows [Semantic Versioning](https://semver.org/). The
 release-candidate series completed the V2 feature and public-API freeze, and
-`2.3.0` is the current stable release of that API. Within the `2.x` series,
+`2.4.0` is the current stable release of that API. Within the `2.x` series,
 breaking changes to the public API require a new major version; minor releases
 add backward-compatible functionality, and patch releases are limited to
 correctness fixes, interoperability qualification, and documentation.
@@ -135,7 +135,7 @@ Hadris-generated images are checked against an independent raw-image oracle
 and common FAT implementations. These results cover the same filesystem
 operations on every listed FAT variant. The oracle row counts the 18 peer
 scenarios and the three geometry-sized limit exercises, all of which pass in
-the 2.3.0 hosted suite.
+the 2.4.0 hosted suite.
 
 | Consumer | FAT12 | FAT16 | FAT32 |
 |----------|-------|-------|-------|
@@ -175,10 +175,10 @@ Choose the narrowest entry point that fits the application:
 ```toml
 [dependencies]
 # One filesystem:
-hadris-fat = "2.3.0"
+hadris-fat = "2.4.0"
 
 # Or the unified storage ecosystem:
-hadris = { version = "2.3.0", features = ["block", "optical"] }
+hadris = { version = "2.4.0", features = ["block", "optical"] }
 ```
 
 The umbrella crate re-exports the same underlying format crates through
@@ -186,15 +186,15 @@ The umbrella crate re-exports the same underlying format crates through
 grow into partition detection or additional disk-image formats without
 replacing their filesystem implementation.
 
-Each package now owns its version; all current packages target **2.3.0**:
+Each package now owns its version; all current packages target **2.4.0**:
 
 ```toml
 [dependencies]
-hadris-iso = "2.3.0"
-hadris-fat = "2.3.0"
-hadris-part = { version = "2.3.0", features = ["read"] }
-hadris-fixed = "2.3.0"
-hadris-path = "2.3.0"
+hadris-iso = "2.4.0"
+hadris-fat = "2.4.0"
+hadris-part = { version = "2.4.0", features = ["read"] }
+hadris-fixed = "2.4.0"
+hadris-path = "2.4.0"
 ```
 
 For allocation-free `no_std` ISO reading:
@@ -202,8 +202,8 @@ For allocation-free `no_std` ISO reading:
 ```toml
 [dependencies]
 # No heap allocator: ISO 9660/Joliet lookup and streamed file reads.
-hadris-iso = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
-hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
 ```
 
 Add the `alloc` feature to `hadris-iso` when owned collections, convenience
@@ -223,7 +223,7 @@ cargo build -p hadris-fat --no-default-features --features "read,sync"
 ```
 
 See [CLAUDE.md](CLAUDE.md) for detailed build instructions and architecture notes, and [CONTRIBUTING.md](CONTRIBUTING.md) for PR workflow.
-See the [`2.3.0` changelog](CHANGELOG.md#230---2026-09-02) for the current
+See the [`2.4.0` changelog](CHANGELOG.md#240---2026-09-08) for the current
 release summary and the [`2.0.0` release notes](docs/hadris-2.0.0-release-notes.md)
 for the V2 upgrade guide.
 The Docusaurus source for the task-oriented documentation site lives in

--- a/crates/archive/hadris-archive/Cargo.toml
+++ b/crates/archive/hadris-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-archive"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-archive/README.md
+++ b/crates/archive/hadris-archive/README.md
@@ -13,7 +13,7 @@ The current facade exposes:
 
 ```toml
 [dependencies]
-hadris-archive = "2.3.0"
+hadris-archive = "2.4.0"
 ```
 
 ```rust
@@ -40,7 +40,7 @@ needs:
 
 ```toml
 [dependencies]
-hadris-archive = { version = "2.3.0", default-features = false, features = ["cpio", "read", "sync"] }
+hadris-archive = { version = "2.4.0", default-features = false, features = ["cpio", "read", "sync"] }
 ```
 
 For format-specific examples and limitations, see the

--- a/crates/archive/hadris-cpio/Cargo.toml
+++ b/crates/archive/hadris-cpio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/archive/hadris-cpio/README.md
+++ b/crates/archive/hadris-cpio/README.md
@@ -76,21 +76,21 @@ configurations should enable `sync`, `async`, or both explicitly.
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+hadris-cpio = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Kernels with Heap (no-std + alloc)
 
 ```toml
 [dependencies]
-hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-cpio = { version = "2.4.0", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-cpio = "2.3.0"  # Uses default features
+hadris-cpio = "2.4.0"  # Uses default features
 ```
 
 ## Archive Format

--- a/crates/archive/hadris-cpio/src/lib.rs
+++ b/crates/archive/hadris-cpio/src/lib.rs
@@ -62,21 +62,21 @@
 //!
 //! ```toml
 //! [dependencies]
-//! hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+//! hadris-cpio = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
 //! ```
 //!
 //! ### For Kernels with Heap (no-std + alloc)
 //!
 //! ```toml
 //! [dependencies]
-//! hadris-cpio = { version = "2.3.0", default-features = false, features = ["read", "alloc", "sync"] }
+//! hadris-cpio = { version = "2.4.0", default-features = false, features = ["read", "alloc", "sync"] }
 //! ```
 //!
 //! ### For Desktop Applications (full features)
 //!
 //! ```toml
 //! [dependencies]
-//! hadris-cpio = "2.3.0"
+//! hadris-cpio = "2.4.0"
 //! ```
 //!
 //! ## Archive Format

--- a/crates/block/hadris-block/Cargo.toml
+++ b/crates/block/hadris-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-block"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-block/README.md
+++ b/crates/block/hadris-block/README.md
@@ -11,7 +11,7 @@ needed.
 
 ```toml
 [dependencies]
-hadris-block = "2.3.0"
+hadris-block = "2.4.0"
 ```
 
 ```rust

--- a/crates/block/hadris-fat/Cargo.toml
+++ b/crates/block/hadris-fat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-fat"
 autotests = false
-version = "2.3.0"
+version = "2.4.0"
 description = "Rust FAT12/FAT16/FAT32 filesystem library for disk images, embedded devices, and no-std"
 readme = "README.md"
 keywords = ["fat", "fat32", "vfat", "filesystem", "no-std"]

--- a/crates/block/hadris-fat/README.md
+++ b/crates/block/hadris-fat/README.md
@@ -191,21 +191,21 @@ Automatic FAT type selection follows Microsoft recommendations:
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+hadris-fat = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Embedded Systems with Heap
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
+hadris-fat = { version = "2.4.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-fat = "2.3.0"  # Uses default features
+hadris-fat = "2.4.0"  # Uses default features
 ```
 
 ## FAT Variant Support
@@ -242,7 +242,7 @@ application needs:
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.3.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync", "cache"] }
+hadris-fat = { version = "2.4.0", default-features = false, features = ["read", "write", "alloc", "lfn", "sync", "cache"] }
 ```
 
 Install it while opening the volume:

--- a/crates/block/hadris-ntfs/Cargo.toml
+++ b/crates/block/hadris-ntfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-ntfs"
 autotests = false
-version = "2.3.0"
+version = "2.4.0"
 description = "A library for reading NTFS filesystems"
 readme = "README.md"
 keywords = ["ntfs", "filesystem", "no-std"]

--- a/crates/block/hadris-part/Cargo.toml
+++ b/crates/block/hadris-part/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-part"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/block/hadris-part/README.md
+++ b/crates/block/hadris-part/README.md
@@ -114,16 +114,16 @@ for (idx, entry) in gpt.partitions() {
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+hadris-part = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
 ```
 
 ### For Desktop Applications
 
 ```toml
 [dependencies]
-hadris-part = { version = "2.3.0", features = ["write"] }  # read is already default
+hadris-part = { version = "2.4.0", features = ["write"] }  # read is already default
 # Optional GPT CRC verification:
-# hadris-part = { version = "2.3.0", features = ["write", "crc"] }
+# hadris-part = { version = "2.4.0", features = ["write", "crc"] }
 ```
 
 ## Partition Types

--- a/crates/core/hadris-common/Cargo.toml
+++ b/crates/core/hadris-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-common"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-common/README.md
+++ b/crates/core/hadris-common/README.md
@@ -58,14 +58,14 @@ assert_eq!(hadris_common::BOOT_SECTOR_BIN[511], 0xAA);
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.3.0", default-features = false, features = ["alloc", "bytemuck"] }
+hadris-common = { version = "2.4.0", default-features = false, features = ["alloc", "bytemuck"] }
 ```
 
 ### Minimal (No Heap)
 
 ```toml
 [dependencies]
-hadris-common = { version = "2.3.0", default-features = false, features = ["bytemuck"] }
+hadris-common = { version = "2.4.0", default-features = false, features = ["bytemuck"] }
 ```
 
 ## Documentation

--- a/crates/core/hadris-common/boot_sector/Cargo.lock
+++ b/crates/core/hadris-common/boot_sector/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "boot_sector"
-version = "2.3.0"
+version = "2.4.0"

--- a/crates/core/hadris-common/boot_sector/Cargo.toml
+++ b/crates/core/hadris-common/boot_sector/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "boot_sector"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/hadris-fixed/Cargo.toml
+++ b/crates/core/hadris-fixed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fixed"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/Cargo.toml
+++ b/crates/core/hadris-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-io"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-io/README.md
+++ b/crates/core/hadris-io/README.md
@@ -35,14 +35,14 @@ while custom configurations may select `sync`, `async`, or both.
 
 ```toml
 [dependencies]
-hadris-io = "2.3.0"
+hadris-io = "2.4.0"
 ```
 
 ### No-std
 
 ```toml
 [dependencies]
-hadris-io = { version = "2.3.0", default-features = false, features = ["sync"] }
+hadris-io = { version = "2.4.0", default-features = false, features = ["sync"] }
 ```
 
 ## Quick Start

--- a/crates/core/hadris-macros/Cargo.toml
+++ b/crates/core/hadris-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-macros"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-path/Cargo.toml
+++ b/crates/core/hadris-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-path"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris-storage/Cargo.toml
+++ b/crates/core/hadris-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-storage"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/hadris/Cargo.toml
+++ b/crates/core/hadris/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-cd/Cargo.toml
+++ b/crates/optical/hadris-cd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/Cargo.toml
+++ b/crates/optical/hadris-iso/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-iso"
 autotests = false
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-iso/README.md
+++ b/crates/optical/hadris-iso/README.md
@@ -146,7 +146,7 @@ only under `sync`.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.3.0", default-features = false, features = ["read", "sync"] }
+hadris-iso = { version = "2.4.0", default-features = false, features = ["read", "sync"] }
 ```
 
 The `read` feature exposes `IsoReader`, which opens and navigates ISO 9660 and
@@ -176,14 +176,14 @@ the allocation-free reader exposes raw system-use bytes for custom handling.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.3.0", default-features = false, features = ["read", "alloc", "sync"] }
+hadris-iso = { version = "2.4.0", default-features = false, features = ["read", "alloc", "sync"] }
 ```
 
 ### For Desktop Applications (full features)
 
 ```toml
 [dependencies]
-hadris-iso = "2.3.0"  # Uses default features
+hadris-iso = "2.4.0"  # Uses default features
 ```
 
 ## Extension Support

--- a/crates/optical/hadris-optical/Cargo.toml
+++ b/crates/optical/hadris-optical/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-optical"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-optical/README.md
+++ b/crates/optical/hadris-optical/README.md
@@ -10,7 +10,7 @@ validly contain both filesystems.
 
 ```toml
 [dependencies]
-hadris-optical = "2.3.0"
+hadris-optical = "2.4.0"
 ```
 
 ```rust,no_run

--- a/crates/optical/hadris-udf/Cargo.toml
+++ b/crates/optical/hadris-udf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hadris-udf"
 autotests = false
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/optical/hadris-udf/README.md
+++ b/crates/optical/hadris-udf/README.md
@@ -17,7 +17,7 @@ UDF (ECMA-167) is the filesystem used for DVD-ROM, DVD-Video, DVD-RAM, Blu-ray d
 
 ```toml
 [dependencies]
-hadris-udf = "2.3.0"
+hadris-udf = "2.4.0"
 ```
 
 ```rust,no_run
@@ -43,7 +43,7 @@ Enable the writer explicitly:
 
 ```toml
 [dependencies]
-hadris-udf = { version = "2.3.0", features = ["write"] }
+hadris-udf = { version = "2.4.0", features = ["write"] }
 ```
 
 ```rust,no_run

--- a/crates/tools/hadris-cd-cli/Cargo.toml
+++ b/crates/tools/hadris-cd-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cd-cli"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-cpio-cli/Cargo.toml
+++ b/crates/tools/hadris-cpio-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-cpio-cli"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-fat-cli/Cargo.toml
+++ b/crates/tools/hadris-fat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-fat-cli"
-version = "2.3.0"
+version = "2.4.0"
 description = "CLI utility for FAT filesystem analysis and management"
 readme = "README.md"
 keywords = ["fat", "fat32", "filesystem", "cli", "disk"]

--- a/crates/tools/hadris-iso-cli/Cargo.toml
+++ b/crates/tools/hadris-iso-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-iso-cli"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tools/hadris-udf-cli/Cargo.toml
+++ b/crates/tools/hadris-udf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hadris-udf-cli"
-version = "2.3.0"
+version = "2.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_version="${1:-2.3.0}"
+expected_version="${1:-2.4.0}"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "release check failed: working tree is not clean" >&2

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -251,14 +251,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "hadris-io"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-iso"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -286,14 +286,14 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-part"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bytemuck",
  "crc",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "hadris-path"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "hadris-tests"

--- a/website/docs/concepts/features.md
+++ b/website/docs/concepts/features.md
@@ -34,7 +34,7 @@ The `sync` and `async` features select parallel API namespaces backed by
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["alloc", "read", "sync", "async", "lfn"]
 }
@@ -72,7 +72,7 @@ directory trees, or image construction may still require `alloc`.
 
 ```toml
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["read", "sync"]
 }
@@ -82,7 +82,7 @@ hadris-fat = {
 
 ```toml
 hadris-iso = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["alloc", "read", "async", "joliet"]
 }
@@ -92,7 +92,7 @@ hadris-iso = {
 
 ```toml
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   features = ["cache", "tool"]
 }
 ```
@@ -101,7 +101,7 @@ hadris-fat = {
 
 ```toml
 hadris-cpio = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["alloc", "read", "write", "sync"]
 }

--- a/website/docs/crates.md
+++ b/website/docs/crates.md
@@ -36,7 +36,7 @@ Examples include `hadris-fat`, `hadris-part`, `hadris-iso`, `hadris-udf`, and
 
 ```toml
 [dependencies]
-hadris-fat = "2.3.0"
+hadris-fat = "2.4.0"
 ```
 
 ## Category facades
@@ -58,7 +58,7 @@ single dependency declaration.
 ```toml
 [dependencies]
 hadris = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["std", "sync", "read", "block", "optical"]
 }

--- a/website/docs/creation/fat.md
+++ b/website/docs/creation/fat.md
@@ -12,7 +12,7 @@ and other targets implementing the selected Hadris I/O mode.
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.3.0", features = ["write", "sync", "lfn"] }
+hadris-fat = { version = "2.4.0", features = ["write", "sync", "lfn"] }
 ```
 
 ## Format an image file

--- a/website/docs/creation/iso.md
+++ b/website/docs/creation/iso.md
@@ -13,7 +13,7 @@ synchronous API and requires a target implementing `Read + Write + Seek`.
 
 ```toml
 [dependencies]
-hadris-iso = { version = "2.3.0", features = ["write", "sync", "joliet"] }
+hadris-iso = { version = "2.4.0", features = ["write", "sync", "joliet"] }
 ```
 
 ## Create a basic image

--- a/website/docs/creation/udf.md
+++ b/website/docs/creation/udf.md
@@ -12,7 +12,7 @@ should be used when authoring a shared ISO/UDF bridge image.
 
 ```toml
 [dependencies]
-hadris-udf = { version = "2.3.0", features = ["write", "sync"] }
+hadris-udf = { version = "2.4.0", features = ["write", "sync"] }
 ```
 
 ## Create a directory tree

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -9,13 +9,13 @@ Choose the narrowest crate that covers your application:
 ```toml
 [dependencies]
 # A single filesystem:
-hadris-fat = "2.3.0"
+hadris-fat = "2.4.0"
 
 # Experimental read-only NTFS:
-hadris-ntfs = "2.3.0"
+hadris-ntfs = "2.4.0"
 
 # Or several storage categories:
-hadris = { version = "2.3.0", features = ["block", "optical"] }
+hadris = { version = "2.4.0", features = ["block", "optical"] }
 ```
 
 Hadris separates platform support, I/O mode, and capabilities. For a
@@ -24,7 +24,7 @@ freestanding read-only FAT consumer:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/async-io.md
+++ b/website/docs/guides/async-io.md
@@ -11,11 +11,11 @@ and drives the future with its chosen runtime.
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["alloc", "async", "read", "lfn"]
 }
-hadris-io = { version = "2.3.0", default-features = false, features = ["async"] }
+hadris-io = { version = "2.4.0", default-features = false, features = ["async"] }
 ```
 
 ```rust

--- a/website/docs/guides/build-initramfs.md
+++ b/website/docs/guides/build-initramfs.md
@@ -6,7 +6,7 @@ title: Build a CPIO initramfs
 
 ```toml
 [dependencies]
-hadris-cpio = "2.3.0"
+hadris-cpio = "2.4.0"
 ```
 
 ```rust

--- a/website/docs/guides/cpio-archives.md
+++ b/website/docs/guides/cpio-archives.md
@@ -9,7 +9,7 @@ used by Linux initramfs images.
 
 ```toml
 [dependencies]
-hadris-cpio = "2.3.0"
+hadris-cpio = "2.4.0"
 ```
 
 ## Stream archive entries

--- a/website/docs/guides/custom-io.md
+++ b/website/docs/guides/custom-io.md
@@ -12,11 +12,11 @@ Hosted `std::io` readers work directly. Embedded devices implementing
 [dependencies]
 embedded-io = "0.7"
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["read", "sync"]
 }
-hadris-io = { version = "2.3.0", default-features = false, features = ["sync"] }
+hadris-io = { version = "2.4.0", default-features = false, features = ["sync"] }
 ```
 
 ```rust,ignore

--- a/website/docs/guides/detect-open-images.md
+++ b/website/docs/guides/detect-open-images.md
@@ -12,7 +12,7 @@ metadata. Opening performs the format's full validation.
 
 ```toml
 [dependencies]
-hadris-block = "2.3.0"
+hadris-block = "2.4.0"
 ```
 
 ```rust,no_run
@@ -47,7 +47,7 @@ and create a bounded view before opening its filesystem.
 
 ```toml
 [dependencies]
-hadris-optical = "2.3.0"
+hadris-optical = "2.4.0"
 ```
 
 ```rust,no_run

--- a/website/docs/guides/modify-fat.md
+++ b/website/docs/guides/modify-fat.md
@@ -10,7 +10,7 @@ backing device is removed.
 
 ```toml
 [dependencies]
-hadris-fat = { version = "2.3.0", features = ["cache", "dirty-file-panic"] }
+hadris-fat = { version = "2.4.0", features = ["cache", "dirty-file-panic"] }
 ```
 
 ```rust,no_run

--- a/website/docs/guides/no-std.md
+++ b/website/docs/guides/no-std.md
@@ -10,7 +10,7 @@ that the target needs:
 ```toml
 [dependencies]
 hadris-fat = {
-  version = "2.3.0",
+  version = "2.4.0",
   default-features = false,
   features = ["read", "sync"]
 }

--- a/website/docs/guides/open-partitioned-fat.md
+++ b/website/docs/guides/open-partitioned-fat.md
@@ -11,7 +11,7 @@ byte range.
 ```toml
 [dependencies]
 anyhow = "1"
-hadris-block = "2.3.0"
+hadris-block = "2.4.0"
 ```
 
 ```rust,no_run

--- a/website/docs/guides/read-fat-image.md
+++ b/website/docs/guides/read-fat-image.md
@@ -10,7 +10,7 @@ filesystem.
 ```toml
 [dependencies]
 anyhow = "1"
-hadris-fat = "2.3.0"
+hadris-fat = "2.4.0"
 ```
 
 ```rust,no_run

--- a/website/docs/guides/read-partition-table.md
+++ b/website/docs/guides/read-partition-table.md
@@ -6,7 +6,7 @@ title: Read a partition table
 
 ```toml
 [dependencies]
-hadris-part = "2.3.0"
+hadris-part = "2.4.0"
 ```
 
 ```rust

--- a/website/docs/guides/read-udf.md
+++ b/website/docs/guides/read-udf.md
@@ -6,7 +6,7 @@ title: Read and extract UDF
 
 ```toml
 [dependencies]
-hadris-udf = "2.3.0"
+hadris-udf = "2.4.0"
 ```
 
 The UDF reader exposes owned directory metadata and reads a selected file into

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -21,7 +21,7 @@ directly to the [use-case guides](./guides/index.md).
 
 :::note Stability
 
-`2.3.0` is the current stable V2 release under Semantic Versioning. The
+`2.4.0` is the current stable V2 release under Semantic Versioning. The
 `unstable-exfat` feature and experimental `hadris-ntfs` crate remain outside
 that stability promise.
 

--- a/website/docs/stability.md
+++ b/website/docs/stability.md
@@ -4,14 +4,14 @@ title: Stability and compatibility
 
 # Stability and compatibility
 
-Hadris 2.3.0 is the current stable release of the V2 API, first stabilized in
+Hadris 2.4.0 is the current stable release of the V2 API, first stabilized in
 2.0.0. The public surface frozen during the release-candidate series follows
 Semantic Versioning: within the `2.x` series, breaking changes require a new
 major version, minor releases add backward-compatible functionality, and patch
 releases carry correctness fixes, interoperability qualification, and
 documentation.
 
-Read the [2.3.0 changelog](https://github.com/hxyulin/hadris/blob/main/CHANGELOG.md#230---2026-09-02)
+Read the [2.4.0 changelog](https://github.com/hxyulin/hadris/blob/main/CHANGELOG.md#240---2026-09-08)
 or the [V2 upgrade notes](https://github.com/hxyulin/hadris/blob/main/docs/hadris-2.0.0-release-notes.md),
 and report real-world compatibility findings through
 [GitHub Issues](https://github.com/hxyulin/hadris/issues).


### PR DESCRIPTION
Prepares the 2.4.0 release, following the 2.3.0 prep commit.

- Every publishable crate, the workspace dependency table, the nested `boot_sector` package, and the tests lockfile move to 2.4.0.
- The dated `[2.4.0] - 2026-09-08` section in CHANGELOG.md takes the Unreleased entries: the `unstable-streaming` previews for hadris-iso and hadris-udf, the exFAT DataLength fix, the ISO directory and path table iteration fixes, the partition size check, and the UDF allocation descriptor fix.
- README, crate READMEs, crate-level rustdoc, website pages, the release workflow default, and `scripts/release-check.sh` quote the new version.

## Checks

- `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check --workspace --locked`, `cargo test --workspace --locked`: pass
- The release workflow's metadata validation (one dated changelog section, every publishable package at 2.4.0, non-empty release notes): pass
- `scripts/release-check.sh 2.4.0`: pass
- `cargo +stable semver-checks --workspace`: no semver update required for any crate
- `scripts/check-public-api.sh`: snapshots match

After merging, run the Release workflow from main in dry-run mode, then in publish mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQRUPpgfwF24t4DJZ2hjL